### PR TITLE
Allow out of tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ bin_PROGRAMS = watchman
 doc_DATA = README.markdown
 docdir = ${prefix}/share/doc/watchman-$(VERSION)
 
-THIRDPARTY_CPPFLAGS = -Ithirdparty/jansson
+THIRDPARTY_CPPFLAGS = -I$(top_srcdir)/thirdparty/jansson -I$(top_builddir)/thirdparty/jansson
 JSON_LIB = -L. -lwmanjson
 
 watchman_CPPFLAGS = $(THIRDPARTY_CPPFLAGS) @IRONMANCFLAGS@


### PR DESCRIPTION
This changeset fixes an issue with the thirdparty jansson's include paths.
For out of tree builds both the source tree and the build tree have to be
included.
