### PR TITLE
Fix installation paths in gemspec

### DIFF
--- a/ruby/ruby-watchman/ext/ruby-watchman/extconf.rb
+++ b/ruby/ruby-watchman/ext/ruby-watchman/extconf.rb
@@ -21,4 +21,4 @@ have_header('st.h')      # 1.8; sets HAVE_ST_H
 
 RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
 
-create_makefile('ext')
+create_makefile('ruby-watchman/ext')

--- a/ruby/ruby-watchman/lib/ruby-watchman/version.rb
+++ b/ruby/ruby-watchman/lib/ruby-watchman/version.rb
@@ -1,5 +1,5 @@
 # Copyright (c) 2014-present Facebook. All Rights Reserved.
 
 module RubyWatchman
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/ruby/ruby-watchman/ruby-watchman.gemspec
+++ b/ruby/ruby-watchman/ruby-watchman.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     'spec/**/*.rb'
   ]
   s.test_files    = s.files.grep(%r{^spec/})
-  s.require_paths = %w[ext lib]
+  s.require_paths = %w[lib]
 
   s.add_development_dependency 'bundler', '~> 1.5'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
There is no need to explicitly add "ext" to the require_paths; RubyGems
will automatically copy the built bundle over to the lib during
installation:

http://guides.rubygems.org/specification-reference/#require_paths

Use "ruby-watchman" as a prefix in the extension configuration to ensure
that it gets installed in a subdirectory of lib; thus we can continue to
use a "ruby-watchman/ext" as a require target and not have to come up
with something globally unique.

Bumped the version number so that I could test this independently with:

```
bundle exec rake # compiles, tests
bundle exec rake build # makes new gem
sudo gem install ./ruby-watchman-0.0.2.gem # installs
irb -rrubygems -rruby-watchman # test using example from README
```
