### PR TITLE
Re-enable Ruby tests, pegging to RSpec 2.x

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,13 +115,13 @@ endif
 
 if HAVE_RUBY
 rb-build:
-	cd ruby/ruby-watchman && bundle install && bundle exec rake make
+	cd ruby/ruby-watchman && bundle && bundle exec rake make
 
 rb-tests:
-	cd ruby/ruby-watchman && bundle exec rake spec
+	cd ruby/ruby-watchman && bundle && bundle exec rake spec
 
 rb-clean:
-	cd ruby/ruby-watchman && bundle exec rake clean
+	cd ruby/ruby-watchman && bundle && bundle exec rake clean
 else
 rb-build:
 rb-tests:

--- a/arcanist/lib/WatchmanIntegrationEngine.php
+++ b/arcanist/lib/WatchmanIntegrationEngine.php
@@ -24,8 +24,7 @@ class WatchmanIntegrationEngine extends WatchmanTapEngine {
       foreach (glob('python/tests/*.py') as $file) {
         $paths[] = $file;
       }
-      // Disable ruby tests temporarily (github issue #41)
-      // $paths[] = 'ruby/ruby-watchman/spec/ruby_watchman_spec.rb';
+      $paths[] = 'ruby/ruby-watchman/spec/ruby_watchman_spec.rb';
     } else {
       $paths = $this->getPaths();
     }

--- a/ruby/ruby-watchman/ruby-watchman.gemspec
+++ b/ruby/ruby-watchman/ruby-watchman.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', '~> 1.5'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '3.0.0'
 end

--- a/ruby/ruby-watchman/spec/ruby_watchman_spec.rb
+++ b/ruby/ruby-watchman/spec/ruby_watchman_spec.rb
@@ -69,11 +69,11 @@ describe RubyWatchman do
   end
 
   it 'roundtrips `true` booleans' do
-    expect(roundtrip(true)).to be_true
+    expect(roundtrip(true)).to eq(true)
   end
 
   it 'roundtrips `false` booleans' do
-    expect(roundtrip(false)).to be_false
+    expect(roundtrip(false)).to eq(false)
   end
 
   it 'roundtrips nil' do
@@ -276,12 +276,12 @@ describe RubyWatchman do
 
     it 'loads boolean `true` values' do
       input = binary("\x00\x01\x03\x01\x08")
-      expect(described_class.load(input)).to be_true
+      expect(described_class.load(input)).to eq(true)
     end
 
     it 'loads boolean `false` values' do
       input = binary("\x00\x01\x03\x01\x09")
-      expect(described_class.load(input)).to be_false
+      expect(described_class.load(input)).to eq(false)
     end
 
     it 'loads nil' do

--- a/travis/deps.sh
+++ b/travis/deps.sh
@@ -14,6 +14,9 @@ case `uname` in
 esac
 set -e
 sudo gem install bundler
+cd ruby/ruby-watchman
+bundle
+cd -
 if [ ! -d a ] ; then
   mkdir a
 fi


### PR DESCRIPTION
Hoping this will fix https://github.com/facebook/watchman/issues/41

Copy-pasta-ing my comment from that issue:

> I believe this is caused by the move to RSpec 3.0; I believe we can fix this by specifying a desired RSpec version in the gemspec. (We could also try to tweak the tests so that they pass in RSpec 2.x or 3.x, but that's going to be a game of whack-a-mole, possibly breaking whenever RSpec decides to make upstream changes.)
