### PR TITLE
fix up some references to --no-state-save in docs, actually: --no-save-state

### DIFF
--- a/docs/cmd.watch-del.markdown
+++ b/docs/cmd.watch-del.markdown
@@ -23,7 +23,7 @@ JSON:
 The removed watch and any associated triggers will be removed from the state
 file and will not be automatically watched if/when watchman is restarted.
 
-However, if `--no-state-save` was used to start the watchman service, the watch
+However, if `--no-save-state` was used to start the watchman service, the watch
 and triggers will be deleted from the running process but no changes will be
 made to the state file.  If this same directory is listed in the state file,
 the watch will be re-established if/when the service is restarted.

--- a/docs/cmd.watch.markdown
+++ b/docs/cmd.watch.markdown
@@ -33,7 +33,7 @@ already.  A newly watched directory is processed in a couple of stages:
    fashion
  * All newly observed files are considered changed
 
-Unless the `--no-state-save` server option was used to start the watchman
+Unless the `--no-save-state` server option was used to start the watchman
 service, watches and their associated triggers are saved and re-established
 across a process restart.
 


### PR DESCRIPTION
Just a docs fix.