### PR TITLE
makefile: add missing destdir for install-exec-local target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -138,8 +138,8 @@ endif
 all-local: py-build rb-build lint
 
 install-exec-local: py-install
-	${INSTALL} -d -m 777 ${WATCHMAN_STATE_DIR}
-	touch ${WATCHMAN_STATE_DIR}/.not-empty
+	${INSTALL} -d -m 777 ${DESTDIR}${WATCHMAN_STATE_DIR}
+	touch ${DESTDIR}${WATCHMAN_STATE_DIR}/.not-empty
 
 clean-local: py-clean rb-clean
 	-find python \( -name '*.py[cdo]' -o -name '*.so' \) -exec rm -f '{}' ';'


### PR DESCRIPTION
Seems to be a slight oversight that ${DESTDIR} was missing from this target.