### PR TITLE
Pypi publishing support for watchman/python

### DIFF
--- a/python/publish-pypi.sh
+++ b/python/publish-pypi.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# ===============================
+# pywatchman pypi publishing tool
+# ===============================
+#
+# this publishes the watchman python module to the pypi project
+# index located at https://pypi.python.org/pypi/pywatchman. the
+# metadata used for this process comes directly from setup.py.
+#
+# this requires write access to the pywatchman project on pypi
+# as well as a ~/.pypirc of the following form:
+#
+#    [distutils]
+#    index-servers = pypi
+#
+#    [pypi]
+#    repository: https://pypi.python.org/pypi
+#    username: <pypi_username>
+#    password: <pypi_password>
+#
+
+python setup.py sdist upload -r pypi

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,22 +1,31 @@
 #!/usr/bin/env python
 # vim:ts=4:sw=4:et:
-from distutils.core import setup, Extension
+
+from setuptools import setup, Extension
 
 setup(
     name = 'pywatchman',
-    version = '0.1',
+    version = '0.1.1',
     description = 'Watchman client for python',
     author = 'Wez Furlong, Siddharth Agarwal',
+    author_email = 'wez@fb.com',
     maintainer = 'Wez Furlong',
     maintainer_email = 'wez@fb.com',
     url = 'https://github.com/facebook/watchman',
     long_description = 'Connect and query Watchman to discover file changes',
-    keywords = \
-        'watchman inotify fsevents kevent kqueue portfs filesystem watcher',
-    license = 'Apache 2.0',
+    keywords = (
+        'watchman inotify fsevents kevent kqueue portfs filesystem watcher'
+    ),
+    license = 'Apache License (2.0)',
     packages = ['pywatchman'],
     ext_modules = [
         Extension('pywatchman.bser', sources = ['pywatchman/bser.c'])
+    ],
+    platforms = 'Platform Independent',
+    classifiers = [
+        'Development Status :: 5 - Production/Stable',
+        'Topic :: System :: Filesystems',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent'
     ]
 )
-


### PR DESCRIPTION
- Switch from older distutils style to setuptools for setup.py.
- Add required package metadata to setup.py for publishing.
- Add a utility (publish-pypi.sh) for publishing with embedded setup instructions.

Testing:
```
$ ./publish-pypi.sh
running sdist
running egg_info
writing pywatchman.egg-info/PKG-INFO
writing top-level names to pywatchman.egg-info/top_level.txt
writing dependency_links to pywatchman.egg-info/dependency_links.txt
reading manifest file 'pywatchman.egg-info/SOURCES.txt'
writing manifest file 'pywatchman.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt

running check
creating pywatchman-0.1.1
creating pywatchman-0.1.1/pywatchman
creating pywatchman-0.1.1/pywatchman.egg-info
making hard links in pywatchman-0.1.1...
hard linking setup.py -> pywatchman-0.1.1
hard linking pywatchman/__init__.py -> pywatchman-0.1.1/pywatchman
hard linking pywatchman/bser.c -> pywatchman-0.1.1/pywatchman
hard linking pywatchman.egg-info/PKG-INFO -> pywatchman-0.1.1/pywatchman.egg-info
hard linking pywatchman.egg-info/SOURCES.txt -> pywatchman-0.1.1/pywatchman.egg-info
hard linking pywatchman.egg-info/dependency_links.txt -> pywatchman-0.1.1/pywatchman.egg-info
hard linking pywatchman.egg-info/top_level.txt -> pywatchman-0.1.1/pywatchman.egg-info
Writing pywatchman-0.1.1/setup.cfg
Creating tar archive
removing 'pywatchman-0.1.1' (and everything under it)
running upload
Submitting dist/pywatchman-0.1.1.tar.gz to https://pypi.python.org/pypi
Server response (200): OK
```

Testing subsequent fetching of the published version from pypi:
```
$ pex -v pywatchman==0.1.1
  pywatchman 0.1.1:: Resolving distributions :: Packaging pywatchman
pex: Building pex: 996.5ms
pex:   Resolving distributions: 989.2ms
pex:       Packaging pywatchman: 293.8ms
Running PEX file at /var/folders/3t/xkwqrkld4xxgklk2s4n41jb80000gn/T/tmpS7EFMD with args []
pex: PEX.run invoking /Users/kwilson/Python/CPython-2.7.8/bin/python2.7 /var/folders/3t/xkwqrkld4xxgklk2s4n41jb80000gn/T/tmpS7EFMD
Python 2.7.8 (default, Jul 17 2014, 17:43:08)
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import pywatchman
>>> pywatchman.bser.__file__
'/private/var/folders/3t/xkwqrkld4xxgklk2s4n41jb80000gn/T/tmpS7EFMD/.deps/pywatchman-0.1.1-cp27-none-macosx_10_4_x86_64.whl/pywatchman/bser.so'
>>>
```
