### PR TITLE
Add missing self references

### DIFF
--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -410,7 +410,7 @@ class client(object):
                 return True
         return False
 
-    def getLog(remove=True):
+    def getLog(self, remove=True):
         """ Retrieve buffered log data
 
         If remove is true the data will be removed from the buffer.
@@ -421,7 +421,7 @@ class client(object):
             self.logs = []
         return res
 
-    def getSubscription(name, remove=True):
+    def getSubscription(self, name, remove=True):
         """ Retrieve the data associated with a named subscription
 
         If remove is True (the default), the subscription data is removed


### PR DESCRIPTION
before:

```
[illuminati ~]$ pex pywatchman==1.0.0
Python 2.7.8 (default, Jul 17 2014, 17:43:08) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import pywatchman
>>> pywatchman.client().getSubscription('blah')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/private/var/folders/3t/xkwqrkld4xxgklk2s4n41jb80000gn/T/tmp2fZtSy/.deps/pywatchman-1.0.0-cp27-none-macosx_10_4_x86_64.whl/pywatchman/__init__.py", line 434, in getSubscription
    if not (name in self.subs):
NameError: global name 'self' is not defined
>>> pywatchman.client().getLog()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/private/var/folders/3t/xkwqrkld4xxgklk2s4n41jb80000gn/T/tmp2fZtSy/.deps/pywatchman-1.0.0-cp27-none-macosx_10_4_x86_64.whl/pywatchman/__init__.py", line 419, in getLog
    res = self.logs
NameError: global name 'self' is not defined
>>>
```

after:
```
[illuminati watchman (kwlzn/pywatchman_selfless)]$ pex python/.
Python 2.7.8 (default, Jul 17 2014, 17:43:08) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import pywatchman
>>> pywatchman.client().getSubscription('blah')
>>> pywatchman.client().getLog()
[]
>>> 
```