### PR TITLE
Specialized exception for socket timeouts

### DIFF
--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -40,6 +40,16 @@ class WatchmanError(Exception):
     pass
 
 
+class SocketTimeout(WatchmanError):
+    """A specialized exception raised for socket timeouts during communication to/from watchman.
+       This makes it easier to implement non-blocking loops as callers can easily distinguish
+       between a routine timeout and an actual error condition.
+
+       Note that catching WatchmanError will also catch this as it is a super-class, so backwards
+       compatibility in exception handling is preserved.
+    """
+
+
 class CommandError(WatchmanError):
     """error returned by watchman
 
@@ -134,13 +144,13 @@ class UnixSocketTransport(Transport):
                 raise WatchmanError('empty watchman response')
             return buf[0]
         except socket.timeout:
-            raise WatchmanError('timed out waiting for response')
+            raise SocketTimeout('timed out waiting for response')
 
     def write(self, data):
         try:
             self.sock.sendall(data)
         except socket.timeout:
-            raise WatchmanError('timed out sending query command')
+            raise SocketTimeout('timed out sending query command')
 
 
 class WindowsNamedPipeTransport(Transport):

--- a/python/tests/tests.py
+++ b/python/tests/tests.py
@@ -3,7 +3,16 @@
 import unittest
 import pywatchman
 import os
-from pywatchman import bser
+from pywatchman import bser, SocketTimeout, WatchmanError
+
+
+class TestSocketTimeout(unittest.TestCase):
+    def test_exception_handling(self):
+        try:
+            raise SocketTimeout('should not raise')
+        except WatchmanError:
+            pass
+
 
 class TestBSERDump(unittest.TestCase):
     def roundtrip(self, val):


### PR DESCRIPTION
Add a new specialized exception to pywatchman to help isolate routine socket timeouts from actual error conditions. This allows consumers to write non-blocking client code that properly handles error cases.

This should be a fully backwards compatible change and adds a test to prove that.