### PR TITLE
allow consuming notifications while root lock is held

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ watchman_SOURCES = \
 	hash.c       \
 	ht.c         \
 	ioprio.c        \
+	pending.c       \
 	stream.c        \
 	stream_stdout.c \
 	stream_unix.c   \

--- a/pending.c
+++ b/pending.c
@@ -1,0 +1,199 @@
+/* Copyright 2012-present Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 */
+
+#include "watchman.h"
+
+/* Free a pending_fs node */
+void w_pending_fs_free(struct watchman_pending_fs *p) {
+  w_string_delref(p->path);
+  free(p);
+}
+
+/* initialize a pending_coll */
+bool w_pending_coll_init(struct watchman_pending_collection *coll) {
+  coll->pending = NULL;
+  coll->pending_uniq = w_ht_new(WATCHMAN_BATCH_LIMIT, &w_ht_string_funcs);
+  if (!coll->pending_uniq) {
+    return false;
+  }
+  if (pthread_mutex_init(&coll->lock, NULL)) {
+    return false;
+  }
+  if (pthread_cond_init(&coll->cond, NULL)) {
+    return false;
+  }
+  return true;
+}
+
+/* destroy a pending_coll */
+void w_pending_coll_destroy(struct watchman_pending_collection *coll) {
+  w_pending_coll_drain(coll);
+  w_ht_free(coll->pending_uniq);
+  pthread_mutex_destroy(&coll->lock);
+  pthread_cond_destroy(&coll->cond);
+}
+
+/* drain and discard the content of a pending_coll, but do not destroy it */
+void w_pending_coll_drain(struct watchman_pending_collection *coll) {
+  struct watchman_pending_fs *p;
+
+  while ((p = w_pending_coll_pop(coll)) != NULL) {
+    w_pending_fs_free(p);
+  }
+
+  w_ht_free_entries(coll->pending_uniq);
+}
+
+/* compute a deadline on entry, then obtain the collection lock
+ * and wait until the deadline expires or until the collection is
+ * pinged.  On Return, the caller owns the collection lock. */
+bool w_pending_coll_lock_and_wait(struct watchman_pending_collection *coll,
+    int timeoutms) {
+  struct timespec deadline;
+  int errcode;
+
+  if (timeoutms != -1) {
+    w_timeoutms_to_abs_timespec(timeoutms, &deadline);
+  }
+  w_pending_coll_lock(coll);
+  if (coll->pending) {
+    return true;
+  }
+  if (timeoutms == -1) {
+    errcode = pthread_cond_wait(&coll->cond, &coll->lock);
+  } else {
+    errcode = pthread_cond_timedwait(&coll->cond, &coll->lock, &deadline);
+  }
+
+  return errcode == 0;
+}
+
+void w_pending_coll_ping(struct watchman_pending_collection *coll) {
+  pthread_cond_broadcast(&coll->cond);
+}
+
+/* obtain the collection lock */
+void w_pending_coll_lock(struct watchman_pending_collection *coll) {
+  int err = pthread_mutex_lock(&coll->lock);
+  if (err != 0) {
+    w_log(W_LOG_FATAL, "lock assertion: %s\n", strerror(err));
+  }
+}
+
+/* release the collection lock */
+void w_pending_coll_unlock(struct watchman_pending_collection *coll) {
+  int err = pthread_mutex_unlock(&coll->lock);
+  if (err != 0) {
+    w_log(W_LOG_FATAL, "unlock assertion: %s\n", strerror(err));
+  }
+}
+
+/* add a pending entry.  Will consolidate an existing entry with the
+ * same name.  Returns false if an allocation fails.
+ * The caller must own the collection lock. */
+bool w_pending_coll_add(struct watchman_pending_collection *coll,
+    w_string_t *path, bool recursive, struct timeval now, bool via_notify) {
+  struct watchman_pending_fs *p;
+
+  p = w_ht_val_ptr(w_ht_get(coll->pending_uniq, w_ht_ptr_val(path)));
+  if (p) {
+    /* Entry already exists: consolidate */
+    if (!p->recursive && recursive) {
+      /* Upgrade to recursive */
+      p->recursive = true;
+    }
+    /* all done */
+    return true;
+  }
+
+  p = calloc(1, sizeof(*p));
+  if (!p) {
+    return false;
+  }
+
+  w_log(W_LOG_DBG, "add_pending: %.*s\n", path->len, path->buf);
+
+  p->recursive = recursive;
+  p->now = now;
+  p->via_notify = via_notify;
+  p->path = path;
+  w_string_addref(path);
+
+  p->next = coll->pending;
+  coll->pending = p;
+  w_ht_set(coll->pending_uniq, w_ht_ptr_val(path), w_ht_ptr_val(p));
+
+  return true;
+}
+
+bool w_pending_coll_add_rel(struct watchman_pending_collection *coll,
+    struct watchman_dir *dir, const char *name, bool recursive,
+    struct timeval now, bool via_notify)
+{
+  char path[WATCHMAN_NAME_MAX];
+  w_string_t *path_str;
+  bool res;
+
+  snprintf(path, sizeof(path), "%.*s%c%s", dir->path->len,
+      dir->path->buf, WATCHMAN_DIR_SEP, name);
+  path_str = w_string_new(path);
+
+  res = w_pending_coll_add(coll, path_str, recursive, now, via_notify);
+
+  w_string_delref(path_str);
+
+  return res;
+}
+
+/* Append the contents of src to target, consolidating in target.
+ * src is effectively drained in the process.
+ * Caller must own the lock on both src and target. */
+void w_pending_coll_append(struct watchman_pending_collection *target,
+    struct watchman_pending_collection *src) {
+  struct watchman_pending_fs *p, *target_p;
+
+  while ((p = w_pending_coll_pop(src)) != NULL) {
+    target_p = w_ht_val_ptr(w_ht_get(target->pending_uniq,
+                            w_ht_ptr_val(p->path)));
+    if (target_p) {
+      /* Entry already exists: consolidate */
+      if (!target_p->recursive && p->recursive) {
+        /* Upgrade to recursive */
+        target_p->recursive = true;
+      }
+      w_pending_fs_free(p);
+      continue;
+    }
+
+    p->next = target->pending;
+    target->pending = p;
+    w_ht_set(target->pending_uniq, w_ht_ptr_val(p->path), w_ht_ptr_val(p));
+  }
+
+  w_ht_free_entries(src->pending_uniq);
+  src->pending = NULL;
+}
+
+/* Logically pop an entry from the collection.
+ * Does NOT remove the entry from the uniq hash.
+ * The intent is that the caller will call this in a tight loop and
+ * then _drain() it at the end to clear the uniq hash */
+struct watchman_pending_fs *w_pending_coll_pop(
+    struct watchman_pending_collection *coll) {
+  struct watchman_pending_fs *p = coll->pending;
+
+  if (p) {
+    coll->pending = p->next;
+    p->next = NULL;
+  }
+
+  return p;
+}
+
+/* Returns the number of unique pending items in the collection */
+uint32_t w_pending_coll_size(struct watchman_pending_collection *coll) {
+  return w_ht_size(coll->pending_uniq);
+}
+
+/* vim:ts=2:sw=2:et:
+ */

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -222,7 +222,7 @@ done:
 }
 
 static bool fsevents_root_consume_notify(watchman_global_watcher_t watcher,
-    w_root_t *root)
+    w_root_t *root, struct watchman_pending_collection *coll)
 {
   struct watchman_fsevent *head, *evt;
   int n = 0;
@@ -275,7 +275,7 @@ break_out:
     recurse = (evt->flags & kFSEventStreamEventFlagMustScanSubDirs)
               ? true : false;
 
-    w_root_add_pending(root, evt->path, recurse, now, true);
+    w_pending_coll_add(coll, evt->path, recurse, now, true);
 
     w_string_delref(evt->path);
     free(evt);

--- a/watcher/inotify.c
+++ b/watcher/inotify.c
@@ -231,6 +231,7 @@ static void invalidate_watch_descriptors(w_root_t *root,
 
 static void process_inotify_event(
     w_root_t *root,
+    struct watchman_pending_collection *coll,
     struct inotify_event *ine,
     struct timeval now)
 {
@@ -341,7 +342,7 @@ static void process_inotify_event(
 
       w_log(W_LOG_DBG, "add_pending for inotify mask=%x %.*s\n",
           ine->mask, name->len, name->buf);
-      w_root_add_pending(root, name, true, now, true);
+      w_pending_coll_add(coll, name, true, now, true);
 
       w_string_delref(name);
 
@@ -357,7 +358,7 @@ static void process_inotify_event(
 }
 
 static bool inot_root_consume_notify(watchman_global_watcher_t watcher,
-    w_root_t *root)
+    w_root_t *root, struct watchman_pending_collection *coll)
 {
   struct inot_root_state *state = root->watch;
   struct inotify_event *ine;
@@ -382,7 +383,7 @@ static bool inot_root_consume_notify(watchman_global_watcher_t watcher,
       iptr = iptr + sizeof(*ine) + ine->len) {
     ine = (struct inotify_event*)iptr;
 
-    process_inotify_event(root, ine, now);
+    process_inotify_event(root, coll, ine, now);
 
     if (root->cancelled) {
       return false;

--- a/watcher/kqueue.c
+++ b/watcher/kqueue.c
@@ -211,7 +211,7 @@ static void kqueue_root_stop_watch_dir(watchman_global_watcher_t watcher,
 }
 
 static bool kqueue_root_consume_notify(watchman_global_watcher_t watcher,
-    w_root_t *root)
+    w_root_t *root, struct watchman_pending_collection *coll)
 {
   struct kqueue_root_state *state = root->watch;
   int n;
@@ -248,7 +248,7 @@ static bool kqueue_root_consume_notify(watchman_global_watcher_t watcher,
         w_root_cancel(root);
         return 0;
       }
-      w_root_add_pending(root, dir->path, false, now, false);
+      w_pending_coll_add(coll, dir->path, false, now, false);
     } else {
       // NetBSD defines udata as intptr type, so the cast is necessary
       struct watchman_file *file = (void *)state->keventbuf[i].udata;
@@ -256,7 +256,7 @@ static bool kqueue_root_consume_notify(watchman_global_watcher_t watcher,
       w_string_t *path;
 
       path = w_string_path_cat(file->parent->path, file->name);
-      w_root_add_pending(root, path, true, now, true);
+      w_pending_coll_add(coll, path, true, now, true);
       w_log(W_LOG_DBG, " KQ file %.*s [0x%x]\n", path->len, path->buf, fflags);
       w_string_delref(path);
     }

--- a/watcher/portfs.c
+++ b/watcher/portfs.c
@@ -163,7 +163,7 @@ static void portfs_root_stop_watch_dir(watchman_global_watcher_t watcher,
 }
 
 static bool portfs_root_consume_notify(watchman_global_watcher_t watcher,
-    w_root_t *root)
+    w_root_t *root, struct watchman_pending_collection *coll)
 {
   struct portfs_root_state *state = root->watch;
   uint_t i, n;
@@ -206,14 +206,14 @@ static bool portfs_root_consume_notify(watchman_global_watcher_t watcher,
         w_root_cancel(root);
         return false;
       }
-      w_root_add_pending(root, dir->path, false, now, true);
+      w_pending_coll_add(coll, dir->path, false, now, true);
 
     } else {
       struct watchman_file *file = state->portevents[i].portev_user;
       w_string_t *path;
 
       path = w_string_path_cat(file->parent->path, file->name);
-      w_root_add_pending(root, path, true, now, true);
+      w_pending_coll_add(coll, path, true, now, true);
       w_log(W_LOG_DBG, "port: file %.*s\n", path->len, path->buf);
       w_string_delref(path);
     }

--- a/watcher/win32.c
+++ b/watcher/win32.c
@@ -372,7 +372,7 @@ static void winwatch_root_stop_watch_dir(watchman_global_watcher_t watcher,
 }
 
 static bool winwatch_root_consume_notify(watchman_global_watcher_t watcher,
-    w_root_t *root)
+    w_root_t *root, struct watchman_pending_collection *coll)
 {
   struct winwatch_root_state *state = root->watch;
   struct winwatch_changed_item *head, *item;
@@ -395,7 +395,7 @@ static bool winwatch_root_consume_notify(watchman_global_watcher_t watcher,
 
     w_log(W_LOG_DBG, "readchanges: add pending %.*s\n",
         item->name->len, item->name->buf);
-    w_root_add_pending(root, item->name, false, now, true);
+    w_pending_coll_add(coll, item->name, false, now, true);
 
     w_string_delref(item->name);
     free(item);

--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -44,6 +44,7 @@ SRCS=\
 	bser.c       \
 	hash.c       \
 	ioprio.c     \
+	pending.c    \
 	stream.c     \
 	stream_win.c \
 	stream_stdout.c \


### PR DESCRIPTION
Summary: The goal is to minimize the risk that we encounter a
notification queue overflow.

This factors out our pending-notification state into a type
that represents a collection of pending notifications.  This collection
has its own locking and can be waited upon and signalled.

The concept is that a notification thread will maintain a local
collection and accumulate pending paths until it reaches our
batch size or has consumed all current available notifications.

At that point, it locks the root->pending collection and moves its local
collection into root->pending, and then signals and unlocks
root->pending.  The notification thread can then continue to consume and
accumulate more notifications into its local collection.

The io thread also maintains a local collection.  It waits for
root->pending to become signalled, locks it, and moves root->pending
into its local collection and unlocks root->pending.  The io thread
will then process its local collection before returning to wait on
root->pending.

Refs: https://github.com/ember-cli/stress-app/issues/1