### PR TITLE
Re-visit inotify move tracking

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ watchman_SOURCES = \
 	log.c        \
 	json.c       \
 	bser.c       \
+	expflags.c   \
 	hash.c       \
 	ht.c         \
 	ioprio.c        \

--- a/cmds/debug.c
+++ b/cmds/debug.c
@@ -119,7 +119,7 @@ static void cmd_debug_poison(struct watchman_client *client, json_t *args)
 
   gettimeofday(&now, NULL);
 
-  set_poison_state(root, dir, now, "debug-poison", ENOMEM, NULL);
+  set_poison_state(root, dir->path, now, "debug-poison", ENOMEM, NULL);
 
   resp = make_response();
   set_prop(resp, "poison", json_string_nocheck(poisoned_reason));

--- a/expflags.c
+++ b/expflags.c
@@ -1,0 +1,37 @@
+/* Copyright 2015-present Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 */
+
+#include "watchman.h"
+
+/* Given a flag map in `fmap`, and a set of flags in `flags`,
+ * expand the flag bits that are set in `flags` into the corresponding
+ * labels in `fmap` and print the result into the caller provided
+ * buffer `buf` of size `len` bytes. */
+void w_expand_flags(const struct flag_map *fmap, uint32_t flags,
+    char *buf, size_t len) {
+  bool first = true;
+  *buf = '\0';
+  while (fmap->label && len) {
+    if ((flags & fmap->value) == fmap->value) {
+      size_t space;
+
+      if (!first) {
+        *buf = ' ';
+        buf++;
+        len--;
+      } else {
+        first = false;
+      }
+
+      space = MIN(len, strlen(fmap->label) + 1);
+      memcpy(buf, fmap->label, space);
+
+      len -= space - 1;
+      buf += space - 1;
+    }
+    fmap++;
+  }
+}
+
+/* vim:ts=2:sw=2:et:
+ */

--- a/ht.c
+++ b/ht.c
@@ -395,6 +395,15 @@ const struct watchman_hash_funcs w_ht_string_funcs = {
   NULL
 };
 
+const struct watchman_hash_funcs w_ht_string_val_funcs = {
+  NULL, // copy_key
+  NULL, // del_key
+  NULL, // equal_key
+  NULL, // hash_key
+  w_ht_string_copy, // copy_val
+  w_ht_string_del   // del_val
+};
+
 const struct watchman_hash_funcs w_ht_dict_funcs = {
   w_ht_string_copy,
   w_ht_string_del,

--- a/python/pywatchman/capabilities.py
+++ b/python/pywatchman/capabilities.py
@@ -25,7 +25,15 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from pkg_resources import parse_version
+
+import re
+
+def parse_version(vstr):
+    res = 0
+    for n in vstr.split('.'):
+        res = res * 1000
+        res = res + int(n)
+    return res
 
 cap_versions = {
     "cmd-watch-del-all": "3.1.1",

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # vim:ts=4:sw=4:et:
 
-from setuptools import setup, Extension
+try:
+    from setuptools import setup, Extension
+except:
+    from distutils.core import setup, Extension
 
 setup(
     name = 'pywatchman',

--- a/root.c
+++ b/root.c
@@ -136,7 +136,6 @@ static bool w_root_init(w_root_t *root, char **errmsg)
   // try to find its parent and we don't want it to for the root
   dir = calloc(1, sizeof(*dir));
   dir->path = root->root_path;
-  dir->wd = -1;
   w_string_addref(dir->path);
   w_ht_set(root->dirname_to_dir, w_ht_ptr_val(dir->path), w_ht_ptr_val(dir));
 
@@ -499,7 +498,6 @@ struct watchman_dir *w_root_resolve_dir(w_root_t *root,
 
   dir = calloc(1, sizeof(*dir));
   dir->path = dir_name;
-  dir->wd = -1;
   w_string_addref(dir->path);
 
   if (!parent->dirs) {
@@ -1174,7 +1172,7 @@ void w_root_set_warning(w_root_t *root, w_string_t *str) {
   }
 }
 
-void set_poison_state(w_root_t *root, struct watchman_dir *dir,
+void set_poison_state(w_root_t *root, w_string_t *dir,
     struct timeval now, const char *syscall, int err, const char *reason)
 {
   char *why = NULL;
@@ -1193,8 +1191,8 @@ void set_poison_state(w_root_t *root, struct watchman_dir *dir,
 "%s#poison-%s\n",
     (long)now.tv_sec,
     syscall,
-    dir->path->len,
-    dir->path->buf,
+    dir->len,
+    dir->buf,
     reason ? reason : strerror(err),
     cfg_get_trouble_url(),
     syscall
@@ -1689,7 +1687,10 @@ static void notify_thread(w_root_t *root)
 
   // signal that we're done here, so that we can start the
   // io thread after this point
+  w_pending_coll_lock(&root->pending);
+  root->pending.pinged = true;
   w_pending_coll_ping(&root->pending);
+  w_pending_coll_unlock(&root->pending);
 
   while (!root->cancelled) {
     // big number because not all watchers can deal with

--- a/tests/integration/fstype.php
+++ b/tests/integration/fstype.php
@@ -15,6 +15,7 @@ class illegalFSTypeTestCase extends WatchmanTestCase {
         'hfs',
         'nfs',
         'smb',
+        'tmpfs',
         'ufs',
         'unknown',
         'zfs',

--- a/tests/integration/trigger.php
+++ b/tests/integration/trigger.php
@@ -183,7 +183,8 @@ class triggerTestCase extends WatchmanTestCase {
     $this->resumeWatchman();
 
     $this->watchmanCommand('log', 'debug', 'waiting for spawnp ' . __LINE__);
-    $this->assertWaitForLog('/posix_spawnp/');
+    $this->assertWaitForLog('/posix_spawnp: test/');
+    $this->assertWaitForLog('/posix_spawnp: other/');
     $this->assertWaitForLogOutput('/WOOT from trig/');
 
     $this->stopLogging();

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -21,6 +21,29 @@ struct fsevents_root_state {
   struct watchman_fsevent *fse_head, *fse_tail;
 };
 
+static const struct flag_map kflags[] = {
+  {kFSEventStreamEventFlagMustScanSubDirs, "MustScanSubDirs"},
+  {kFSEventStreamEventFlagUserDropped, "UserDropped"},
+  {kFSEventStreamEventFlagKernelDropped, "KernelDropped"},
+  {kFSEventStreamEventFlagEventIdsWrapped, "EventIdsWrapped"},
+  {kFSEventStreamEventFlagHistoryDone, "HistoryDone"},
+  {kFSEventStreamEventFlagRootChanged, "RootChanged"},
+  {kFSEventStreamEventFlagMount, "Mount"},
+  {kFSEventStreamEventFlagUnmount, "Unmount"},
+  {kFSEventStreamEventFlagItemCreated, "ItemCreated"},
+  {kFSEventStreamEventFlagItemRemoved, "ItemRemoved"},
+  {kFSEventStreamEventFlagItemInodeMetaMod, "InodeMetaMod"},
+  {kFSEventStreamEventFlagItemRenamed, "ItemRenamed"},
+  {kFSEventStreamEventFlagItemModified, "ItemModified"},
+  {kFSEventStreamEventFlagItemFinderInfoMod, "FinderInfoMod"},
+  {kFSEventStreamEventFlagItemChangeOwner, "ItemChangeOwner"},
+  {kFSEventStreamEventFlagItemXattrMod, "ItemXattrMod"},
+  {kFSEventStreamEventFlagItemIsFile, "ItemIsFile"},
+  {kFSEventStreamEventFlagItemIsDir, "ItemIsDir"},
+  {kFSEventStreamEventFlagItemIsSymlink, "ItemIsSymlink"},
+  {0, NULL},
+};
+
 static void fse_callback(ConstFSEventStreamRef streamRef,
    void *clientCallBackInfo,
    size_t numEvents,
@@ -32,6 +55,7 @@ static void fse_callback(ConstFSEventStreamRef streamRef,
   char **paths = eventPaths;
   w_root_t *root = clientCallBackInfo;
   char pathbuf[WATCHMAN_NAME_MAX];
+  char flags_label[128];
   struct watchman_fsevent *head = NULL, *tail = NULL, *evt;
   struct fsevents_root_state *state = root->watch;
 
@@ -75,7 +99,9 @@ static void fse_callback(ConstFSEventStreamRef streamRef,
     }
     tail = evt;
 
-    w_log(W_LOG_DBG, "fse_thread: add %s %" PRIx32 "\n", pathbuf, evt->flags);
+    w_expand_flags(kflags, evt->flags, flags_label, sizeof(flags_label));
+    w_log(W_LOG_DBG, "fse_thread: add %s 0x%" PRIx32 " %s\n", pathbuf,
+      evt->flags, flags_label);
   }
 
   pthread_mutex_lock(&state->fse_mtx);

--- a/watcher/inotify.c
+++ b/watcher/inotify.c
@@ -18,6 +18,26 @@
   IN_DELETE_SELF | IN_MODIFY | IN_MOVE_SELF | IN_MOVED_FROM | \
   IN_MOVED_TO | IN_DONT_FOLLOW | IN_ONLYDIR | WATCHMAN_IN_EXCL_UNLINK
 
+static const struct flag_map inflags[] = {
+  {IN_ACCESS, "IN_ACCESS"},
+  {IN_MODIFY, "IN_MODIFY"},
+  {IN_ATTRIB, "IN_ATTRIB"},
+  {IN_CLOSE_WRITE, "IN_CLOSE_WRITE"},
+  {IN_CLOSE_NOWRITE, "IN_CLOSE_NOWRITE"},
+  {IN_OPEN, "IN_OPEN"},
+  {IN_MOVED_FROM, "IN_MOVED_FROM"},
+  {IN_MOVED_TO, "IN_MOVED_TO"},
+  {IN_CREATE, "IN_CREATE"},
+  {IN_DELETE, "IN_DELETE"},
+  {IN_DELETE_SELF, "IN_DELETE_SELF"},
+  {IN_MOVE_SELF, "IN_MOVE_SELF"},
+  {IN_UNMOUNT, "IN_UNMOUNT"},
+  {IN_Q_OVERFLOW, "IN_Q_OVERFLOW"},
+  {IN_IGNORED, "IN_IGNORED"},
+  {IN_ISDIR, "IN_ISDIR"},
+  {0, NULL},
+};
+
 struct pending_move {
   time_t created;
   w_string_t *name;
@@ -228,9 +248,11 @@ static void process_inotify_event(
     struct timeval now)
 {
   struct inot_root_state *state = root->watch;
+  char flags_label[128];
 
-  w_log(W_LOG_DBG, "notify: wd=%d mask=%x %s\n", ine->wd, ine->mask,
-      ine->len > 0 ? ine->name : "");
+  w_expand_flags(inflags, ine->mask, flags_label, sizeof(flags_label));
+  w_log(W_LOG_DBG, "notify: wd=%d mask=0x%x %s %s\n", ine->wd, ine->mask,
+      flags_label, ine->len > 0 ? ine->name : "");
 
   if (ine->wd == -1 && (ine->mask & IN_Q_OVERFLOW)) {
     /* we missed something, will need to re-crawl */

--- a/watcher/portfs.c
+++ b/watcher/portfs.c
@@ -11,7 +11,16 @@
 
 struct portfs_root_state {
   int port_fd;
+  /* map of file name to watchman_port_file */
+  w_ht_t *port_files;
+  /* protects port_files */
+  pthread_mutex_t lock;
   port_event_t portevents[WATCHMAN_BATCH_LIMIT];
+};
+
+struct watchman_port_file {
+  file_obj_t port_file;
+  w_string_t *name;
 };
 
 static const struct flag_map pflags[] = {
@@ -24,6 +33,42 @@ static const struct flag_map pflags[] = {
   {UNMOUNTED, "UNMOUNTED"},
   {MOUNTEDOVER, "MOUNTEDOVER"},
   {0, NULL},
+};
+
+static struct watchman_port_file *make_port_file(w_string_t *name,
+    struct stat *st) {
+  struct watchman_port_file *f;
+
+  f = calloc(1, sizeof(*f));
+  if (!f) {
+    return NULL;
+  }
+  f->name = name;
+  w_string_addref(name);
+  f->port_file.fo_name = (char*)name->buf;
+  f->port_file.fo_atime = st->st_atim;
+  f->port_file.fo_mtime = st->st_mtim;
+  f->port_file.fo_ctime = st->st_ctim;
+
+  return f;
+}
+
+static void free_port_file(struct watchman_port_file *f) {
+  w_string_delref(f->name);
+  free(f);
+}
+
+static void portfs_del_port_file(w_ht_val_t key) {
+  free_port_file(w_ht_val_ptr(key));
+}
+
+const struct watchman_hash_funcs port_file_funcs = {
+  w_ht_string_copy,
+  w_ht_string_del,
+  w_ht_string_equal,
+  w_ht_string_hash,
+  NULL, // copy_val
+  portfs_del_port_file,
 };
 
 watchman_global_watcher_t portfs_global_init(void) {
@@ -45,6 +90,9 @@ bool portfs_root_init(watchman_global_watcher_t watcher, w_root_t *root,
     return false;
   }
   root->watch = state;
+
+  pthread_mutex_init(&state->lock, NULL);
+  state->port_files = w_ht_new(HINT_NUM_DIRS, &port_file_funcs);
 
   state->port_fd = port_create();
   if (state->port_fd == -1) {
@@ -68,6 +116,8 @@ void portfs_root_dtor(watchman_global_watcher_t watcher, w_root_t *root) {
 
   close(state->port_fd);
   state->port_fd = -1;
+  w_ht_free(state->port_files);
+  pthread_mutex_destroy(&state->lock);
 
   free(state);
   root->watch = NULL;
@@ -87,43 +137,69 @@ static bool portfs_root_start(watchman_global_watcher_t watcher,
   return true;
 }
 
-static bool portfs_root_start_watch_file(watchman_global_watcher_t watcher,
-      w_root_t *root, struct watchman_file *file) {
-  struct portfs_root_state *state = root->watch;
-  char buf[WATCHMAN_NAME_MAX];
-  unused_parameter(watcher);
+static bool do_watch(struct portfs_root_state *state, w_string_t *name,
+    struct stat *st) {
+  struct watchman_port_file *f;
+  bool success = false;
 
-  snprintf(buf, sizeof(buf), "%.*s/%.*s",
-      file->parent->path->len, file->parent->path->buf,
-      file->name->len, file->name->buf);
-
-  w_log(W_LOG_DBG, "watch_file(%s)\n", buf);
-
-  file->port_file.fo_atime = file->st.st_atim;
-  file->port_file.fo_mtime = file->st.st_mtim;
-  file->port_file.fo_ctime = file->st.st_ctim;
-  if (!file->port_file.fo_name) {
-    file->port_file.fo_name = strdup(buf);
+  pthread_mutex_lock(&state->lock);
+  if (w_ht_get(state->port_files, w_ht_ptr_val(name))) {
+    // Already watching it
+    success = true;
+    goto out;
   }
 
-  port_associate(state->port_fd, PORT_SOURCE_FILE,
-      (uintptr_t)&file->port_file, WATCHMAN_PORT_EVENTS,
-      (void*)file);
+  f = make_port_file(name, st);
+  if (!f) {
+    goto out;
+  }
 
-  return true;
+  if (!w_ht_set(state->port_files, w_ht_ptr_val(name), w_ht_ptr_val(f))) {
+    free_port_file(f);
+    goto out;
+  }
+
+  w_log(W_LOG_DBG, "watching %s\n", name->buf);
+  errno = 0;
+  if (port_associate(state->port_fd, PORT_SOURCE_FILE,
+        (uintptr_t)&f->port_file, WATCHMAN_PORT_EVENTS,
+        (void*)f)) {
+    w_log(W_LOG_ERR, "port_associate %s %s\n",
+        f->port_file.fo_name, strerror(errno));
+    w_ht_del(state->port_files, w_ht_ptr_val(name));
+    goto out;
+  }
+
+  success = true;
+
+out:
+  pthread_mutex_unlock(&state->lock);
+  return success;
+}
+
+static bool portfs_root_start_watch_file(watchman_global_watcher_t watcher,
+    w_root_t *root, struct watchman_file *file) {
+  struct portfs_root_state *state = root->watch;
+  w_string_t *name;
+  bool success = false;
+
+  unused_parameter(watcher);
+
+  name = w_string_path_cat(file->parent->path, file->name);
+  if (!name) {
+    return false;
+  }
+  success = do_watch(state, name, &file->st);
+  w_string_delref(name);
+
+  return success;
 }
 
 static void portfs_root_stop_watch_file(watchman_global_watcher_t watcher,
       w_root_t *root, struct watchman_file *file) {
-  struct portfs_root_state *state = root->watch;
   unused_parameter(watcher);
-
-  port_dissociate(state->port_fd, PORT_SOURCE_FILE,
-      (uintptr_t)&file->port_file);
-  if (file->port_file.fo_name) {
-    free(file->port_file.fo_name);
-    file->port_file.fo_name = NULL;
-  }
+  unused_parameter(root);
+  unused_parameter(file);
 }
 
 static DIR *portfs_root_start_watch_dir(watchman_global_watcher_t watcher,
@@ -149,17 +225,9 @@ static DIR *portfs_root_start_watch_dir(watchman_global_watcher_t watcher,
     return NULL;
   }
 
-  dir->port_file.fo_mtime = st.st_atim;
-  dir->port_file.fo_mtime = st.st_mtim;
-  dir->port_file.fo_ctime = st.st_ctim;
-  dir->port_file.fo_name = (char*)dir->path->buf;
-
-  errno = 0;
-  if (port_associate(state->port_fd, PORT_SOURCE_FILE,
-        (uintptr_t)&dir->port_file, WATCHMAN_PORT_EVENTS,
-        SET_DIR_BIT(dir))) {
-    w_log(W_LOG_ERR, "port_associate %s %s\n",
-        dir->port_file.fo_name, strerror(errno));
+  if (!do_watch(state, dir->path, &st)) {
+    closedir(osdir);
+    return NULL;
   }
 
   return osdir;
@@ -167,11 +235,9 @@ static DIR *portfs_root_start_watch_dir(watchman_global_watcher_t watcher,
 
 static void portfs_root_stop_watch_dir(watchman_global_watcher_t watcher,
       w_root_t *root, struct watchman_dir *dir) {
-  struct portfs_root_state *state = root->watch;
   unused_parameter(watcher);
-
-  port_dissociate(state->port_fd, PORT_SOURCE_FILE,
-      (uintptr_t)&dir->port_file);
+  unused_parameter(root);
+  unused_parameter(dir);
 }
 
 static bool portfs_root_consume_notify(watchman_global_watcher_t watcher,
@@ -200,38 +266,37 @@ static bool portfs_root_consume_notify(watchman_global_watcher_t watcher,
     return false;
   }
 
+  pthread_mutex_lock(&state->lock);
+
   for (i = 0; i < n; i++) {
-    if (IS_DIR_BIT_SET(state->portevents[i].portev_user)) {
-      struct watchman_dir *dir = DECODE_DIR(state->portevents[i].portev_user);
-      uint32_t pe = state->portevents[i].portev_events;
-      char flags_label[128];
+    struct watchman_port_file *f;
+    uint32_t pe = state->portevents[i].portev_events;
+    char flags_label[128];
 
-      w_expand_flags(pflags, pe, flags_label, sizeof(flags_label));
-      w_log(W_LOG_DBG, "port: dir %.*s [0x%x %s]\n",
-          dir->path->len, dir->path->buf, pe, flags_label);
+    f = (struct watchman_port_file*)state->portevents[i].portev_user;
+    w_expand_flags(pflags, pe, flags_label, sizeof(flags_label));
+    w_log(W_LOG_DBG, "port: %s [0x%x %s]\n",
+        f->port_file.fo_name,
+        pe, flags_label);
 
-      if ((pe & (FILE_RENAME_FROM|UNMOUNTED|MOUNTEDOVER|FILE_DELETE))
-          && w_string_equal(dir->path, root->root_path)) {
+    if ((pe & (FILE_RENAME_FROM|UNMOUNTED|MOUNTEDOVER|FILE_DELETE))
+        && w_string_equal(f->name, root->root_path)) {
 
-        w_log(W_LOG_ERR,
-          "root dir %s has been (re)moved (code 0x%x %s), canceling watch\n",
-          root->root_path->buf, pe, flags_label);
+      w_log(W_LOG_ERR,
+        "root dir %s has been (re)moved (code 0x%x %s), canceling watch\n",
+        root->root_path->buf, pe, flags_label);
 
-        w_root_cancel(root);
-        return false;
-      }
-      w_pending_coll_add(coll, dir->path, false, now, true);
-
-    } else {
-      struct watchman_file *file = state->portevents[i].portev_user;
-      w_string_t *path;
-
-      path = w_string_path_cat(file->parent->path, file->name);
-      w_pending_coll_add(coll, path, true, now, true);
-      w_log(W_LOG_DBG, "port: file %.*s\n", path->len, path->buf);
-      w_string_delref(path);
+      w_root_cancel(root);
+      pthread_mutex_unlock(&state->lock);
+      return false;
     }
+    w_pending_coll_add(coll, f->name, true, now, true);
+
+    // It was port_dissociate'd implicitly.  We'll re-establish a
+    // watch later when portfs_root_start_watch_(file|dir) are called again
+    w_ht_del(state->port_files, w_ht_ptr_val(f->name));
   }
+  pthread_mutex_unlock(&state->lock);
 
   return true;
 }
@@ -254,10 +319,7 @@ static bool portfs_root_wait_notify(watchman_global_watcher_t watcher,
 static void portfs_file_free(watchman_global_watcher_t watcher,
     struct watchman_file *file) {
   unused_parameter(watcher);
-
-  if (file->port_file.fo_name) {
-    free(file->port_file.fo_name);
-  }
+  unused_parameter(file);
 }
 
 struct watchman_ops portfs_watcher = {

--- a/watchman.h
+++ b/watchman.h
@@ -948,6 +948,13 @@ extern struct watchman_ops win32_watcher;
 void w_ioprio_set_low(void);
 void w_ioprio_set_normal(void);
 
+struct flag_map {
+  uint32_t value;
+  const char *label;
+};
+void w_expand_flags(const struct flag_map *fmap, uint32_t flags,
+    char *buf, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/watchman.h
+++ b/watchman.h
@@ -291,11 +291,6 @@ struct watchman_dir {
   w_ht_t *lc_files;
   /* child dirs contained in this dir (keyed by dir->path) */
   w_ht_t *dirs;
-
-  /* watch descriptor */
-#if HAVE_PORT_CREATE
-  file_obj_t port_file;
-#endif
 };
 
 struct watchman_ops {
@@ -390,10 +385,6 @@ struct watchman_file {
   /* cache stat results so we can tell if an entry
    * changed */
   struct stat st;
-
-#if HAVE_PORT_CREATE
-  file_obj_t port_file;
-#endif
 };
 
 #define WATCHMAN_COOKIE_PREFIX ".watchman-cookie-"

--- a/watchman.h
+++ b/watchman.h
@@ -259,6 +259,7 @@ struct watchman_pending_collection {
   w_ht_t *pending_uniq;
   pthread_mutex_t lock;
   pthread_cond_t cond;
+  bool pinged;
 };
 
 bool w_pending_coll_init(struct watchman_pending_collection *coll);
@@ -292,7 +293,6 @@ struct watchman_dir {
   w_ht_t *dirs;
 
   /* watch descriptor */
-  int wd;
 #if HAVE_PORT_CREATE
   file_obj_t port_file;
 #endif
@@ -393,9 +393,6 @@ struct watchman_file {
 
 #if HAVE_PORT_CREATE
   file_obj_t port_file;
-#endif
-#if HAVE_KQUEUE
-  int kq_fd;
 #endif
 };
 
@@ -644,7 +641,6 @@ void w_root_set_warning(w_root_t *root, w_string_t *str);
 
 struct watchman_dir *w_root_resolve_dir(w_root_t *root,
     w_string_t *dir_name, bool create);
-struct watchman_dir *w_root_resolve_dir_by_wd(w_root_t *root, int wd);
 void w_root_process_path(w_root_t *root,
     struct watchman_pending_collection *coll, w_string_t *full_path,
     struct timeval now, bool recursive, bool via_notify);
@@ -930,7 +926,7 @@ void w_assess_trigger(w_root_t *root, struct watchman_trigger_command *cmd);
 struct watchman_trigger_command *w_build_trigger_from_def(
   w_root_t *root, json_t *trig, char **errmsg);
 
-void set_poison_state(w_root_t *root, struct watchman_dir *dir,
+void set_poison_state(w_root_t *root, w_string_t *dir,
     struct timeval now, const char *syscall, int err,
     const char *reason);
 

--- a/watchman_hash.h
+++ b/watchman_hash.h
@@ -173,6 +173,12 @@ uint32_t w_ht_string_hash(w_ht_val_t val);
  */
 extern const struct watchman_hash_funcs w_ht_string_funcs;
 
+/* if you're building a hash table that uses w_string_t as values,
+ * then you can use w_ht_string_val_funcs as the second parameter
+ * to w_ht_new to safely reference the values as the table is updated.
+ */
+extern const struct watchman_hash_funcs w_ht_string_val_funcs;
+
 /* if you're building a dictionary of string => string,
  * then you can use w_ht_dict_funcs as the second parameter
  * to w_ht_new to safely reference the keys and values as the

--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -42,6 +42,7 @@ SRCS=\
 	log.c        \
 	json.c       \
 	bser.c       \
+	expflags.c   \
 	hash.c       \
 	ioprio.c     \
 	pending.c    \


### PR DESCRIPTION
Previously, in https://reviews.facebook.net/D40155, we were trying to solve an issue where we weren't correctly dealing with inotify renames.

While that diff appeared to be correct it was actually prone to hitting other kinds of consistency issues and recrawling anyway.

This PR is a short series of diffs that tackles the root of this problem: the watch descriptor -> name map is logically a separate set of information from our view of the tree that we maintain in a given `root`.  I originally blended them together because it was almost "free" from an additional memory overhead perspective.

The approach taken here is to formally split these data structures; it does mean that we'll use a little bit more memory to track the inotify structures separately, but we can reclaim some of the space from the file node structures by eliminating the watcher tracking fields from them.

This is important because the recent changes to allow collecting notifications independent from having processed them makes it impossible to correctly reconcile moves if the io thread has not yet picked up some of the changes in `root->pending`.

In a follow-on diff I'll remove the stop_watching_file and stop_watching_dir methods from the watcher subsystem, because it is only ever correct to do so in response to changes reported by the notification mechanism.

This PR includes a couple of small changes to fix up some racy tests and add a utility to help print the various notification flags with labels.

I've tested this by hand on OS X (with both kevent and fsevents), Linux, Solaris and Windows.
Will let Travis and Appveyor confirm that this is good.

I'm also running this on my FB dev box where the original problem was previously easily reproduced simply by running `fbconfig`.  Things are looking nice and solid there so far.
