### PR TITLE
Add the "foreign" flag to Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+AUTOMAKE_OPTIONS = foreign
+
 bin_PROGRAMS = watchman
 # ensure that we have a reasonable default for the python install
 DESTDIR ?= /


### PR DESCRIPTION
The structure of the watchman package does not conform to GNU's packaging standard;  namely it lacks files such as `NEWS`, `README` (not `README.md`) and Autoconf is not happy about it.

- http://stackoverflow.com/questions/15013672/use-autotools-with-readme-md