### PR TITLE
Fixup `-j` option and multi-line json input

### DIFF
--- a/tests/integration/test_bser_cli.py
+++ b/tests/integration/test_bser_cli.py
@@ -17,9 +17,12 @@ class TestDashJCliOption(unittest.TestCase):
     def getSockPath(self):
         return WatchmanInstance.getSharedInstance().getSockPath()
 
-    def doJson(self, addNewLine):
+    def doJson(self, addNewLine, pretty=False):
         sockname = self.getSockPath()
-        watchman_cmd = json.dumps(['get-sockname'])
+        if pretty:
+            watchman_cmd = "[\n\"get-sockname\"\n]"
+        else:
+            watchman_cmd = json.dumps(['get-sockname'])
         if addNewLine:
             watchman_cmd = watchman_cmd + "\n"
 
@@ -48,6 +51,9 @@ class TestDashJCliOption(unittest.TestCase):
 
     def test_jsonInputNewLine(self):
         self.doJson(True)
+
+    def test_jsonInputPretty(self):
+        self.doJson(True, True)
 
     def test_bserInput(self):
         sockname = self.getSockPath()


### PR DESCRIPTION
Summary: accidentally broke this when we refactored the guts for windows
support.  We previously allowed `-j` to read the whole of stdin and
parse it into a JSON value.  Since the windows code merge, we would
only read the first line.

This diff special cases json input when the stream is stdin; it sets
the mode to pretty json mode and we attempt to use the whole buffer
to process the input instead.