### PR TITLE
Add pure Python BSER implementation

### DIFF
--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -30,7 +30,14 @@ import os
 import errno
 import socket
 import subprocess
-import bser
+
+# Sometimes it's really hard to get Python extensions to compile,
+# so fall back to a pure Python implementation.
+try:
+    import bser
+except ImportError, e:
+    import pybser as bser
+
 import capabilities
 
 # 2 bytes marker, 1 byte int size, 8 bytes int64 value

--- a/python/pywatchman/pybser.py
+++ b/python/pywatchman/pybser.py
@@ -1,0 +1,293 @@
+# Copyright 2015 Facebook, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name Facebook nor the names of its contributors may be used to
+#    endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import collections
+import ctypes
+import struct
+
+BSER_ARRAY = '\x00'
+BSER_OBJECT = '\x01'
+BSER_STRING = '\x02'
+BSER_INT8 = '\x03'
+BSER_INT16 = '\x04'
+BSER_INT32 = '\x05'
+BSER_INT64 = '\x06'
+BSER_REAL = '\x07'
+BSER_TRUE = '\x08'
+BSER_FALSE = '\x09'
+BSER_NULL = '\x0a'
+BSER_TEMPLATE = '\x0b'
+BSER_SKIP = '\x0c'
+
+# Leave room for the serialization header, which includes
+# our overall length.  To make things simpler, we'll use an
+# int32 for the header
+EMPTY_HEADER = "\x00\x01\x05\x00\x00\x00\x00"
+
+
+def _int_size(x):
+    """Return the smallest size int that can store the value"""
+    abs_x = abs(x)
+    if abs_x <= 0x7F:
+        return 1
+    elif abs_x <= 0x7FFF:
+        return 2
+    elif abs_x <= 0x7FFFFFFF:
+        return 4
+    elif abs_x <= 0x7FFFFFFFFFFFFFFFL:
+        return 8
+    else:
+        raise RuntimeException('Cannot represent value: ' + str(x))
+
+
+class _bser_buffer(object):
+
+    def __init__(self):
+        self.buf = ctypes.create_string_buffer(8192)
+        struct.pack_into(str(len(EMPTY_HEADER)) + 's', self.buf, 0, EMPTY_HEADER)
+        self.wpos = len(EMPTY_HEADER)
+
+    def ensure_size(self, size):
+        while ctypes.sizeof(self.buf) - self.wpos < size:
+            ctypes.resize(self.buf, ctypes.sizeof(self.buf) * 2)
+
+    def append_long(self, val):
+        size = _int_size(val)
+        to_write = size + 1
+        self.ensure_size(to_write)
+        if size == 1:
+            struct.pack_into('=cb', self.buf, self.wpos, BSER_INT8, val)
+        elif size == 2:
+            struct.pack_into('=ch', self.buf, self.wpos, BSER_INT16, val)
+        elif size == 4:
+            struct.pack_into('=ci', self.buf, self.wpos, BSER_INT32, val)
+        elif size == 8:
+            struct.pack_into('=cq', self.buf, self.wpos, BSER_INT64, val)
+        else:
+            raise RuntimeError('Cannot represent this long value')
+        self.wpos += to_write
+
+
+    def append_string(self, s):
+        if isinstance(s, unicode):
+            s = s.encode('utf-8')
+        s_len = len(s)
+        size = _int_size(s_len)
+        to_write = 2 + size + s_len
+        self.ensure_size(to_write)
+        if size == 1:
+            struct.pack_into('=ccb' + str(s_len) + 's', self.buf, self.wpos, BSER_STRING, BSER_INT8, s_len, s)
+        elif size == 2:
+            struct.pack_into('=cch' + str(s_len) + 's', self.buf, self.wpos, BSER_STRING, BSER_INT16, s_len, s)
+        elif size == 4:
+            struct.pack_into('=cci' + str(s_len) + 's', self.buf, self.wpos, BSER_STRING, BSER_INT32, s_len, s)
+        elif size == 8:
+            struct.pack_into('=ccq' + str(s_len) + 's', self.buf, self.wpos, BSER_STRING, BSER_INT64, s_len, s)
+        else:
+            raise RuntimeError('Cannot represent this string value')
+        self.wpos += to_write
+
+
+    def append_recursive(self, val):
+        if isinstance(val, bool):
+            needed = 1
+            self.ensure_size(needed)
+            if val:
+                to_encode = BSER_TRUE
+            else:
+                to_encode = BSER_FALSE
+            struct.pack_into('=c', self.buf, self.wpos, to_encode)
+            self.wpos += needed
+        elif val is None:
+            needed = 1
+            self.ensure_size(needed)
+            struct.pack_into('=c', self.buf, self.wpos, BSER_NULL)
+            self.wpos += needed
+        elif isinstance(val, (int, long)):
+            self.append_long(val)
+        elif isinstance(val, (str, unicode)):
+            self.append_string(val)
+        elif isinstance(val, float):
+            needed = 9
+            self.ensure_size(needed)
+            struct.pack_into('=cd', self.buf, self.wpos, BSER_REAL, val)
+            self.wpos += needed
+        elif isinstance(val, collections.Mapping) and isinstance(val, collections.Sized):
+            val_len = len(val)
+            size = _int_size(val_len)
+            needed = 2 + size
+            self.ensure_size(needed)
+            if size == 1:
+                struct.pack_into('=ccb', self.buf, self.wpos, BSER_OBJECT, BSER_INT8, val_len)
+            elif size == 2:
+                struct.pack_into('=cch', self.buf, self.wpos, BSER_OBJECT, BSER_INT16, val_len)
+            elif size == 4:
+                struct.pack_into('=cci', self.buf, self.wpos, BSER_OBJECT, BSER_INT32, val_len)
+            elif size == 8:
+                struct.pack_into('=ccq', self.buf, self.wpos, BSER_OBJECT, BSER_INT64, val_len)
+            else:
+                raise RuntimeError('Cannot represent this mapping value')
+            self.wpos += needed
+            for k, v in val.iteritems():
+                self.append_string(k)
+                self.append_recursive(v)
+        elif isinstance(val, collections.Iterable) and isinstance(val, collections.Sized):
+            val_len = len(val)
+            size = _int_size(val_len)
+            needed = 2 + size
+            self.ensure_size(needed)
+            if size == 1:
+                struct.pack_into('=ccb', self.buf, self.wpos, BSER_ARRAY, BSER_INT8, val_len)
+            elif size == 2:
+                struct.pack_into('=cch', self.buf, self.wpos, BSER_ARRAY, BSER_INT16, val_len)
+            elif size == 4:
+                struct.pack_into('=cci', self.buf, self.wpos, BSER_ARRAY, BSER_INT32, val_len)
+            elif size == 8:
+                struct.pack_into('=ccq', self.buf, self.wpos, BSER_ARRAY, BSER_INT64, val_len)
+            else:
+                raise RuntimeError('Cannot represent this sequence value')
+            self.wpos += needed
+            for v in val:
+                self.append_recursive(v)
+        else:
+            raise RuntimeError('Cannot represent unknown value type')
+
+
+def dumps(obj):
+    bser_buf = _bser_buffer()
+    bser_buf.append_recursive(obj)
+    # Now fill in the overall length
+    obj_len = bser_buf.wpos - len(EMPTY_HEADER)
+    struct.pack_into('=i', bser_buf.buf, 3, obj_len)
+    return bser_buf.buf.raw[:bser_buf.wpos]
+
+
+def _bunser_int(buf, pos):
+    int_type = buf[pos]
+    if int_type == BSER_INT8:
+        needed = 2
+        fmt = '=b'
+    elif int_type == BSER_INT16:
+        needed = 3
+        fmt = '=h'
+    elif int_type == BSER_INT32:
+        needed = 5
+        fmt = '=i'
+    elif int_type == BSER_INT64:
+        needed = 9
+        fmt = '=q'
+    else:
+        raise RuntimeError('Invalid bser int encoding 0x%02x' % (int_type,))
+    int_val = struct.unpack_from(fmt, buf, pos + 1)[0]
+    return (int_val, pos + needed)
+
+
+def _bunser_string(buf, pos):
+    str_len, pos = _bunser_int(buf, pos + 1)
+    str_val = struct.unpack_from(str(str_len) + 's', buf, pos)[0]
+    return (str_val, pos + str_len)
+
+
+def _bunser_array(buf, pos):
+    arr_len, pos = _bunser_int(buf, pos + 1)
+    arr = []
+    for i in range(arr_len):
+        arr_item, pos = _bser_loads_recursive(buf, pos)
+        arr.append(arr_item)
+    return arr, pos
+
+
+def _bunser_object(buf, pos):
+    obj_len, pos = _bunser_int(buf, pos + 1)
+    obj = {}
+    for i in range(obj_len):
+        key, pos = _bunser_string(buf, pos)
+        val, pos = _bser_loads_recursive(buf, pos)
+        obj[key] = val
+    return obj, pos
+
+
+def _bunser_template(buf, pos):
+    if buf[pos + 1] != BSER_ARRAY:
+        raise RuntimeError('Expect ARRAY to follow TEMPLATE')
+    keys, pos = _bunser_array(buf, pos + 1)
+    nitems, pos = _bunser_int(buf, pos)
+    arr = []
+    for i in range(nitems):
+        obj = {}
+        for keyidx in range(len(keys)):
+            if buf[pos] == BSER_SKIP:
+                pos += 1
+                continue
+            key = keys[keyidx]
+            ele, pos = _bser_loads_recursive(buf, pos)
+            obj[key] = ele
+        arr.append(obj)
+    return arr, pos
+
+
+def _bser_loads_recursive(buf, pos):
+    val_type = buf[pos]
+    if (val_type == BSER_INT8 or val_type == BSER_INT16 or
+        val_type == BSER_INT32 or val_type == BSER_INT64):
+        return _bunser_int(buf, pos)
+    elif val_type == BSER_REAL:
+        val = struct.unpack_from('=d', buf, pos + 1)[0]
+        return (val, pos + 9)
+    elif val_type == BSER_TRUE:
+        return (True, pos + 1)
+    elif val_type == BSER_FALSE:
+        return (False, pos + 1)
+    elif val_type == BSER_NULL:
+        return (None, pos + 1)
+    elif val_type == BSER_STRING:
+        return _bunser_string(buf, pos)
+    elif val_type == BSER_ARRAY:
+        return _bunser_array(buf, pos)
+    elif val_type == BSER_OBJECT:
+        return _bunser_object(buf, pos)
+    elif val_type == BSER_TEMPLATE:
+        return _bunser_template(buf, pos)
+    else:
+        raise RuntimeError('unhandled bser opcode 0x%02x' % (val_type,))
+
+
+def pdu_len(buf):
+    if buf[0:2] != EMPTY_HEADER[0:2]:
+        raise RuntimeError('Invalid BSER header')
+    expected_len, pos = _bunser_int(buf, 2)
+    return expected_len + pos
+
+
+def loads(buf):
+    if buf[0:2] != EMPTY_HEADER[0:2]:
+        raise RuntimeError('Invalid BSER header')
+    expected_len, pos = _bunser_int(buf, 2)
+    if len(buf) != expected_len + pos:
+        raise RuntimeError('bser data len != header len')
+    return _bser_loads_recursive(buf, pos)[0]


### PR DESCRIPTION
The Buck project has to support multiple Python runtimes in a single distributable. It's sometimes difficult to get multiple native Python extensions working for all the various combinations of C and Python library runtimes, so this adds a native `pybser` implementation of BSER.

Updated tests to run with both `bser.so` and `pybser.py`. Tested with:

```
% PYTHONPATH=. python tests/tests.py                  
# True  -->  0001050100000008
# False  -->  0001050100000009
.# {'hello': 'there'}  -->  0001051300000001030102030568656c6c6f0203057468657265
.# 1.5  -->  0001050900000007000000000000f83f
.# 1  -->  000105020000000301
# 256  -->  00010503000000040001
# 65536  -->  000105050000000500000100
# 268435456  -->  000105050000000500000010
# 68719476736  -->  00010509000000060000000010000000
.# [1, 2, 3]  -->  00010509000000000303030103020303
# [1, 'helo', 2.5, False, None, True, 3]  -->  0001051a000000000307030102030468656c6f070000000000000440090a080303
.# None  -->  000105010000000a
..# hello  -->  0001050800000002030568656c6c6f
# Hello  -->  0001050800000002030548656c6c6f
# äöü  -->  00010509000000020306c3a4c3b6c3bc
..# (1, 2, 3)  -->  00010509000000000303030103020303
.# True  -->  0001050100000008
# False  -->  0001050100000009
.# {'hello': 'there'}  -->  0001051300000001030102030568656c6c6f0203057468657265
.# 1.5  -->  0001050900000007000000000000f83f
.# 1  -->  000105020000000301
# 256  -->  00010503000000040001
# 65536  -->  000105050000000500000100
# 268435456  -->  000105050000000500000010
# 68719476736  -->  00010509000000060000000010000000
.# [1, 2, 3]  -->  00010509000000000303030103020303
# [1, 'helo', 2.5, False, None, True, 3]  -->  0001051a000000000307030102030468656c6f070000000000000440090a080303
.# None  -->  000105010000000a
..# hello  -->  0001050800000002030568656c6c6f
# Hello  -->  0001050800000002030548656c6c6f
# äöü  -->  00010509000000020306c3a4c3b6c3bc
..# (1, 2, 3)  -->  00010509000000000303030103020303
.
----------------------------------------------------------------------
Ran 20 tests in 0.004s

OK
```

Compared the performance by running `buck build --profile buck` with and without `bser.so` available:

native bser.so
====

```
[2015-09-18 08:52:37.770] buck.py profile: /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck-py-profile8892525080198931986.pstats% /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck-py-profile8892525080198931986.pstats% Fri Sep 18 08:52:37 2015    /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck-py-profile8892525080198931986.pstats
[2015-09-18 08:52:37.770] buck.py profile: 
[2015-09-18 08:52:37.770] buck.py profile:          41430 function calls (40399 primitive calls) in 1.158 seconds
[2015-09-18 08:52:37.770] buck.py profile: 
[2015-09-18 08:52:37.770] buck.py profile:    Ordered by: cumulative time
[2015-09-18 08:52:37.770] buck.py profile:    List reduced from 542 to 25 due to restriction <25>
[2015-09-18 08:52:37.771] buck.py profile: 
[2015-09-18 08:52:37.772] buck.py profile:    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
[2015-09-18 08:52:37.772] buck.py profile:         1    0.005    0.005    1.159    1.159 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck2013015819085732536.py:1(<module>)
[2015-09-18 08:52:37.772] buck.py profile:         1    0.951    0.951    1.089    1.089 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck2013015819085732536.py:641(main)
[2015-09-18 08:52:37.772] buck.py profile:       120    0.002    0.000    0.132    0.001 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck2013015819085732536.py:606(process)
[2015-09-18 08:52:37.772] buck.py profile:       120    0.002    0.000    0.129    0.001 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck2013015819085732536.py:579(_process_build_file)
[2015-09-18 08:52:37.772] buck.py profile:   240/120    0.007    0.000    0.114    0.001 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck2013015819085732536.py:517(_process)
[2015-09-18 08:52:37.773] buck.py profile:       322    0.002    0.000    0.055    0.000 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck2013015819085732536.py:112(invoke)
[2015-09-18 08:52:37.773] buck.py profile:        67    0.001    0.000    0.052    0.001 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck2013015819085732536.py:169(glob)
[2015-09-18 08:52:37.773] buck.py profile:        67    0.001    0.000    0.051    0.001 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck2013015819085732536.py:151(__call__)
[2015-09-18 08:52:37.773] buck.py profile:        67    0.001    0.000    0.049    0.001 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck2013015819085732536.py:303(glob_watchman)
[2015-09-18 08:52:37.773] buck.py profile:        67    0.000    0.000    0.047    0.001 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:375(query)
[2015-09-18 08:52:37.773] buck.py profile:        67    0.000    0.000    0.030    0.000 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:367(receive)
[2015-09-18 08:52:37.773] buck.py profile:        67    0.001    0.000    0.030    0.000 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:231(receive)
[2015-09-18 08:52:37.773] buck.py profile:       121    0.030    0.000    0.030    0.000 {compile}
[2015-09-18 08:52:37.773] buck.py profile:         1    0.002    0.002    0.029    0.029 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/inspect.py:25(<module>)
[2015-09-18 08:52:37.773] buck.py profile:       134    0.000    0.000    0.029    0.000 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:128(readBytes)
[2015-09-18 08:52:37.773] buck.py profile:       134    0.028    0.000    0.028    0.000 {method 'recv' of '_socket.socket' objects}
[2015-09-18 08:52:37.773] buck.py profile:         1    0.007    0.007    0.025    0.025 /Users/bgertzfield/devtools/buck/third-party/py/pathlib/pathlib.py:1(<module>)
[2015-09-18 08:52:37.773] buck.py profile:         1    0.000    0.000    0.025    0.025 /Users/bgertzfield/devtools/buck/src/com/facebook/buck/cli/bootstrapper/BUCK:1(<module>)
[2015-09-18 08:52:37.773] buck.py profile:       131    0.000    0.000    0.022    0.000 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/re.py:226(_compile)
[2015-09-18 08:52:37.773] buck.py profile:        14    0.000    0.000    0.022    0.002 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/sre_compile.py:493(compile)
[2015-09-18 08:52:37.773] buck.py profile:        14    0.000    0.000    0.022    0.002 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/re.py:188(compile)
[2015-09-18 08:52:37.773] buck.py profile:         1    0.001    0.001    0.019    0.019 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tokenize.py:23(<module>)
[2015-09-18 08:52:37.774] buck.py profile:         9    0.000    0.000    0.017    0.002 {map}
[2015-09-18 08:52:37.774] buck.py profile:         1    0.007    0.007    0.016    0.016 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib.py:23(<module>)
[2015-09-18 08:52:37.774] buck.py profile:       134    0.000    0.000    0.013    0.000 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:344(_connect)
[2015-09-18 08:52:37.774] buck.py profile: 
[2015-09-18 08:52:37.774] buck.py profile: 
[2015-09-18 08:52:37.774] buck.py profile: /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.6kNoqb/buck-py-profile8892525080198931986.pstats% 
[2015-09-18 08:52:37.774] buck.py profile: Goodbye.
```

Pure Python pybser.py
======

```
[2015-09-18 08:50:56.840] buck.py profile: /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck-py-profile4692913619295524403.pstats% /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck-py-profile4692913619295524403.pstats% Fri Sep 18 08:50:56 2015    /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck-py-profile4692913619295524403.pstats
[2015-09-18 08:50:56.840] buck.py profile: 
[2015-09-18 08:50:56.841] buck.py profile:          269838 function calls (255420 primitive calls) in 1.215 seconds
[2015-09-18 08:50:56.841] buck.py profile: 
[2015-09-18 08:50:56.841] buck.py profile:    Ordered by: cumulative time
[2015-09-18 08:50:56.841] buck.py profile:    List reduced from 608 to 25 due to restriction <25>
[2015-09-18 08:50:56.841] buck.py profile: 
[2015-09-18 08:50:56.841] buck.py profile:    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
[2015-09-18 08:50:56.841] buck.py profile:         1    0.006    0.006    1.215    1.215 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:1(<module>)
[2015-09-18 08:50:56.841] buck.py profile:         1    0.815    0.815    1.156    1.156 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:641(main)
[2015-09-18 08:50:56.841] buck.py profile:       187    0.002    0.000    0.192    0.001 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/pybser.py:182(dumps)
[2015-09-18 08:50:56.841] buck.py profile: 12025/187    0.049    0.000    0.186    0.001 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/pybser.py:117(append_recursive)
[2015-09-18 08:50:56.841] buck.py profile:       120    0.001    0.000    0.183    0.002 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:606(process)
[2015-09-18 08:50:56.841] buck.py profile:       120    0.002    0.000    0.181    0.002 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:579(_process_build_file)
[2015-09-18 08:50:56.841] buck.py profile:   240/120    0.006    0.000    0.166    0.001 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:517(_process)
[2015-09-18 08:50:56.841] buck.py profile:       120    0.000    0.000    0.150    0.001 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:727(<lambda>)
[2015-09-18 08:50:56.841] buck.py profile:       322    0.002    0.000    0.111    0.000 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:112(invoke)
[2015-09-18 08:50:56.842] buck.py profile:        67    0.001    0.000    0.107    0.002 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:169(glob)
[2015-09-18 08:50:56.842] buck.py profile:        67    0.001    0.000    0.106    0.002 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:151(__call__)
[2015-09-18 08:50:56.842] buck.py profile:        67    0.001    0.000    0.105    0.002 /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck6552522081731685793.py:303(glob_watchman)
[2015-09-18 08:50:56.842] buck.py profile:        67    0.000    0.000    0.103    0.002 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:375(query)
[2015-09-18 08:50:56.842] buck.py profile:     11940    0.040    0.000    0.073    0.000 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/pybser.py:97(append_string)
[2015-09-18 08:50:56.842] buck.py profile: 61039/61034    0.029    0.000    0.058    0.000 {isinstance}
[2015-09-18 08:50:56.842] buck.py profile:        67    0.000    0.000    0.045    0.001 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:250(send)
[2015-09-18 08:50:56.842] buck.py profile:        67    0.000    0.000    0.043    0.001 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:367(receive)
[2015-09-18 08:50:56.842] buck.py profile:        67    0.001    0.000    0.043    0.001 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:231(receive)
[2015-09-18 08:50:56.842] buck.py profile:       121    0.031    0.000    0.031    0.000 {compile}
[2015-09-18 08:50:56.842] buck.py profile:       134    0.000    0.000    0.029    0.000 /Users/bgertzfield/devtools/buck/build/pywatchman/pywatchman/__init__.py:128(readBytes)
[2015-09-18 08:50:56.842] buck.py profile:       134    0.029    0.000    0.029    0.000 {method 'recv' of '_socket.socket' objects}
[2015-09-18 08:50:56.842] buck.py profile:     10288    0.017    0.000    0.029    0.000 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/abc.py:128(__instancecheck__)
[2015-09-18 08:50:56.842] buck.py profile:         1    0.000    0.000    0.026    0.026 /Users/bgertzfield/devtools/buck/src/com/facebook/buck/cli/bootstrapper/BUCK:1(<module>)
[2015-09-18 08:50:56.842] buck.py profile:         1    0.002    0.002    0.023    0.023 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/inspect.py:25(<module>)
[2015-09-18 08:50:56.842] buck.py profile:         1    0.006    0.006    0.019    0.019 /Users/bgertzfield/devtools/buck/third-party/py/pathlib/pathlib.py:1(<module>)
[2015-09-18 08:50:56.842] buck.py profile: 
[2015-09-18 08:50:56.842] buck.py profile: 
[2015-09-18 08:50:56.842] buck.py profile: /Users/bgertzfield/devtools/buck/.buckd/tmp/buck_run.Ono2YF/buck-py-profile4692913619295524403.pstats% 
[2015-09-18 08:50:56.842] buck.py profile: Goodbye.
```