### PR TITLE
Set zip_safe = True in setup.py to avoid warning when building

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -30,5 +30,6 @@ setup(
         'Topic :: System :: Filesystems',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent'
-    ]
+    ],
+    zip_safe = True
 )


### PR DESCRIPTION
When building pywatchman with python setup.py install, we get a warning:

```
zip_safe flag not set; analyzing archive contents...
```

I confirmed watchman is safe to run from inside a zip (Buck has to do this in its PEX archive), so this diff sets the flag to stifle the warning.