### PR TITLE
Improve PCRE detection in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,6 @@ AC_ARG_WITH(ruby, [
 ])
 AM_CONDITIONAL(HAVE_RUBY, [test "x$want_ruby" = "xyes"])
 
-pcre_config="yes"
 AC_ARG_WITH(pcre, [
   --without-pcre       Don't enable pcre support.
   --with-pcre=PATH     Enable pcre support.  PATH is location of pcre-config.
@@ -103,17 +102,44 @@ AC_ARG_WITH(pcre, [
                        $PATH
 ],[
   pcre_config="$withval"
+],[
+  pcre_config="check"
 ])
 
 if test "$pcre_config" != "no" ; then
-  if test "$pcre_config" = "yes" ; then
-    pcre_config="pcre-config"
+  if test "$pcre_config" = "yes" -o "$pcre_config" = "check"; then
+    AC_PATH_PROG(PCRE_CONFIG_PATH, pcre-config, false)
+    dnl If --with-pcre was specified but pcre-config not found, fail hard now.
+    if test "$pcre_config" = "yes" -a "$PCRE_CONFIG_PATH" = "false"; then
+      AC_MSG_FAILURE([--with-pcre was given, but pcre-config not found in PATH])
+    fi
+  else
+    PCRE_CONFIG_PATH="$pcre_config"
   fi
 
-  if $pcre_config --version >/dev/null ; then
-    LIBS="$LIBS `$pcre_config --libs`"
-    CFLAGS="$CFLAGS `$pcre_config --cflags`"
-    AC_CHECK_HEADERS(pcre.h)
+  AC_MSG_CHECKING(for PCRE using $PCRE_CONFIG_PATH)
+  pcre_version=`"$PCRE_CONFIG_PATH" --version 2>/dev/null`
+  if test $? -ne 0; then
+    AC_MSG_RESULT(failed)
+  else
+    AC_MSG_RESULT($pcre_version)
+  fi
+
+  if test -n "$pcre_version"; then
+    PCRE_LIBS=`$PCRE_CONFIG_PATH --libs`
+    LIBS="$LIBS $PCRE_LIBS"
+    PCRE_CFLAGS=`$PCRE_CONFIG_PATH --cflags`
+    CFLAGS="$CFLAGS $PCRE_CFLAGS"
+    CPPFLAGS="$CPPFLAGS $PCRE_CFLAGS"
+    AC_CHECK_HEADERS(pcre.h, [], [
+      if test "$pcre_config" != "check"; then
+         AC_MSG_FAILURE([--with-pcre was given, but pcre not found:
+  pcre-config --libs=$PCRE_LIBS
+  pcre-config --cflags=$PCRE_CFLAGS])
+      fi
+    ])
+  elif test "$pcre_config" != "check"; then
+    AC_MSG_FAILURE([$PCRE_CONFIG_PATH failed to run, could not check for PCRE])
   fi
 fi
 


### PR DESCRIPTION
Previously, calling `configure --with-pcre` would result in a Watchman build silently succeeding but failing to include PCRE if `pcre-config` printed `CFLAGS` in a non-standard location.

This was because we failed to set `CPPFLAGS` before calling `AC_CHECK_HEADERS` (that macro does not use `CFLAGS` for some unknown reason).

I fixed this as well as improved PCRE detection by:

1. Failing fast if `pcre-config` could not be found if `--with-pcre` is specified
2. Printing the version of PCRE if found
3. Setting `CPPFLAGS` to ensure `AC_CHECK_HEADERS` works correctly with headers in a nonstandard location
4. Failing fast if `pcre-config` emits flags which don't work