### PR TITLE
fsevents coalesces directory renames to top level

### DIFF
--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -298,7 +298,9 @@ break_out:
       goto break_out;
     }
 
-    recurse = (evt->flags & kFSEventStreamEventFlagMustScanSubDirs)
+    recurse = (evt->flags &
+                (kFSEventStreamEventFlagMustScanSubDirs|
+                 kFSEventStreamEventFlagItemRenamed))
               ? true : false;
 
     w_pending_coll_add(coll, evt->path, recurse, now, true);
@@ -484,7 +486,8 @@ static void fsevents_file_free(watchman_global_watcher_t watcher,
 
 struct watchman_ops fsevents_watcher = {
   "fsevents",
-  true, // per_file_notifications
+  WATCHER_HAS_PER_FILE_NOTIFICATIONS|
+    WATCHER_COALESCED_RENAME,
   fsevents_global_init,
   fsevents_global_dtor,
   fsevents_root_init,

--- a/watcher/inotify.c
+++ b/watcher/inotify.c
@@ -461,7 +461,7 @@ static void inot_file_free(watchman_global_watcher_t watcher,
 
 struct watchman_ops inotify_watcher = {
   "inotify",
-  true, // per_file_notifications
+  WATCHER_HAS_PER_FILE_NOTIFICATIONS,
   inot_global_init,
   inot_global_dtor,
   inot_root_init,

--- a/watcher/kqueue.c
+++ b/watcher/kqueue.c
@@ -344,7 +344,7 @@ static void kqueue_file_free(watchman_global_watcher_t watcher,
 
 struct watchman_ops kqueue_watcher = {
   "kqueue",
-  false, // per_file_notifications
+  0,
   kqueue_global_init,
   kqueue_global_dtor,
   kqueue_root_init,

--- a/watcher/portfs.c
+++ b/watcher/portfs.c
@@ -324,7 +324,7 @@ static void portfs_file_free(watchman_global_watcher_t watcher,
 
 struct watchman_ops portfs_watcher = {
   "portfs",
-  false, // per_file_notifications
+  0,
   portfs_global_init,
   portfs_global_dtor,
   portfs_root_init,

--- a/watcher/win32.c
+++ b/watcher/win32.c
@@ -436,7 +436,7 @@ static void winwatch_file_free(watchman_global_watcher_t watcher,
 
 struct watchman_ops win32_watcher = {
   "win32",
-  true, // per_file_notifications
+  WATCHER_HAS_PER_FILE_NOTIFICATIONS,
   winwatch_global_init,
   winwatch_global_dtor,
   winwatch_root_init,

--- a/watchman.h
+++ b/watchman.h
@@ -297,9 +297,13 @@ struct watchman_ops {
   // What's it called??
   const char *name;
 
-  // true if this watcher notifies for individual files,
-  // false if it only notifies for dirs
-  bool has_per_file_notifications;
+  // if this watcher notifies for individual files contained within
+  // a watched dir, false if it only notifies for dirs
+#define WATCHER_HAS_PER_FILE_NOTIFICATIONS 1
+  // if renames do not reliably report the individual
+  // files renamed in the hierarchy
+#define WATCHER_COALESCED_RENAME 2
+  unsigned flags;
 
   // Perform any global initialization needed for the watcher mechanism
   // and return a context pointer that will be passed to all other ops


### PR DESCRIPTION
Summary: OS X commonly saves "documents" as a directory containing a
collection of files.  When updating one of these documents, the pattern
is to build out a temporary directory containing the target set of files
and then to rename this directory in place of the old directory.

When fsevents reports these events, there is a good chance that the
events will get coalesced and reported as a rename event on the document
dir followed by change events on the temporary dir structure.

We have two problems in tracking and dealing with this scenario:

1. We didn't consider that the rename event on the document dir should
   be recursive, so we'd only add_pending and stat just the dir

2. Once making it recursive, we had an optimization in the `crawler`
   function that would only directly stat the contents if the file
   had transitioned between existing or not existing.
   This optimization is valid only if the watcher has
   per-file-notifications that are reliably reported for every file
   in a watched dir.

This diff adds a flag to the watcher layer to identify this
coalesce-on-rename behavior and fixes up the crawler optimization so
that we will add_pending if the watcher has the coalescing behavior.

Test Plan: `make integration`, but also tested Blair's repro scenario
and cross-checked the watchman results via:

```
watchman find . path/to/document/file
/usr/bin/stat -r path/to/document/file
```