### PR TITLE
Properly resolve spin in the crash handler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,7 +229,7 @@ AC_CHECK_HEADERS(execinfo.h)
 AC_CHECK_HEADERS(CoreServices/CoreServices.h, [
   LIBS="$LIBS -framework CoreServices"
 ])
-AC_CHECK_FUNCS(backtrace backtrace_symbols)
+AC_CHECK_FUNCS(backtrace backtrace_symbols backtrace_symbols_fd)
 
 if test -n "$ac_cv_header_sys_statvfs_h"; then
 AC_CHECK_MEMBERS([struct statvfs.f_fstypename,struct statvfs.f_basetype],


### PR DESCRIPTION
Summary: 3405fe50584a8d0da98dc42a7e97231aa5272ffc was a simplistic
and ineffective take on resolving this.  I dug in a bit deeper and
traced this to `backtrace_symbols`.  I've switched this to
`backtrace_symbols_fd` which has a better chance of success when called in a
signal handler where most bets are off.

Test Plan:

```
--- a/cmds/watch.c
+++ b/cmds/watch.c
@@ -44,7 +44,7 @@ static void cmd_clock(struct watchman_client *client, json_t *args)
     const char *ignored;
     if (0 != json_unpack(args, "[s, s, {s?:i*}]",
                          &ignored, &ignored,
-                         "sync_timeout", &sync_timeout)) {
+                         "sync_timeout", 1)) {
       send_error_response(client, "malformated argument list for 'clock'");
       return;
     }
```

Then:

```
rm -rf /var/tmp/watchmantest*
./runtests.py tests/integration/clock.php --keep
tail /private/var/tmp/watchmantest*/inst*/log
```

and observe that we've logged the stack trace rather than either spinning
forever or just terminating with no context.