### PR TITLE
micro optimize w_pending_coll_add

### DIFF
--- a/pending.c
+++ b/pending.c
@@ -133,16 +133,14 @@ bool w_pending_coll_add_rel(struct watchman_pending_collection *coll,
     struct watchman_dir *dir, const char *name, bool recursive,
     struct timeval now, bool via_notify)
 {
-  char path[WATCHMAN_NAME_MAX];
   w_string_t *path_str;
   bool res;
 
-  snprintf(path, sizeof(path), "%.*s%c%s", dir->path->len,
-      dir->path->buf, WATCHMAN_DIR_SEP, name);
-  path_str = w_string_new(path);
-
+  path_str = w_string_path_cat_cstr(dir->path, name);
+  if (!path_str) {
+    return false;
+  }
   res = w_pending_coll_add(coll, path_str, recursive, now, via_notify);
-
   w_string_delref(path_str);
 
   return res;

--- a/string.c
+++ b/string.c
@@ -481,6 +481,40 @@ w_string_t *w_string_path_cat(w_string_t *parent, w_string_t *rhs)
   return s;
 }
 
+w_string_t *w_string_path_cat_cstr(w_string_t *parent, const char *rhs)
+{
+  w_string_t *s;
+  int len;
+  char *buf;
+  uint32_t rhs_len = u32_strlen(rhs);
+
+  if (rhs_len == 0) {
+    w_string_addref(parent);
+    return parent;
+  }
+
+  len = parent->len + rhs_len + 1;
+
+  s = malloc(sizeof(*s) + len + 1);
+  if (!s) {
+    perror("no memory available");
+    abort();
+  }
+
+  s->refcnt = 1;
+  s->len = len;
+  s->slice = NULL;
+  buf = (char*)(s + 1);
+  memcpy(buf, parent->buf, parent->len);
+  buf[parent->len] = WATCHMAN_DIR_SEP;
+  memcpy(buf + parent->len + 1, rhs, rhs_len);
+  buf[parent->len + 1 + rhs_len] = '\0';
+  s->buf = buf;
+  s->hval = w_hash_bytes(buf, len, 0);
+
+  return s;
+}
+
 char *w_string_dup_buf(const w_string_t *str)
 {
   char *buf;

--- a/watchman.h
+++ b/watchman.h
@@ -605,6 +605,7 @@ w_string_t *w_string_canon_path(w_string_t *str);
 void w_string_in_place_normalize_separators(w_string_t **str, char target_sep);
 w_string_t *w_string_normalize_separators(w_string_t *str, char target_sep);
 w_string_t *w_string_path_cat(w_string_t *parent, w_string_t *rhs);
+w_string_t *w_string_path_cat_cstr(w_string_t *parent, const char *rhs);
 bool w_string_startswith(w_string_t *str, w_string_t *prefix);
 bool w_string_startswith_caseless(w_string_t *str, w_string_t *prefix);
 w_string_t *w_string_shell_escape(const w_string_t *str);


### PR DESCRIPTION
This eliminates an snprintf call and an extraneous buffer copy.