### PR TITLE
inotify: fixup state on race condition

### DIFF
--- a/root.c
+++ b/root.c
@@ -416,7 +416,8 @@ bool w_root_sync_to_now(w_root_t *root, int timeoutms)
   while (!cookie.seen) {
     errcode = pthread_cond_timedwait(&cookie.cond, &root->lock, &deadline);
     if (errcode && !cookie.seen) {
-      w_log(W_LOG_ERR, "sync_to_now: %s timedwait failed: %d: istimeout=%d %s\n",
+      w_log(W_LOG_ERR,
+          "sync_to_now: %s timedwait failed: %d: istimeout=%d %s\n",
           path_str->buf, errcode, errcode == ETIMEDOUT, strerror(errcode));
       goto out;
     }
@@ -1277,7 +1278,7 @@ static void crawler(w_root_t *root, struct watchman_pending_collection *coll,
     if (file) {
       file->maybe_deleted = false;
     }
-    if (!file || !file->exists || (stat_all && recursive)) {
+    if (!file || !file->exists || stat_all || recursive) {
       w_pending_coll_add_rel(coll, dir, dirent->d_name,
           true, now, false);
     }


### PR DESCRIPTION
Summary: took some time to track this down.  The conditions to trigger
the problem are:

0. DIR and DIR/foo exist
1. Recursively remove DIR
2. Create DIR and DIR/foo

The problem manifests in the following sequence:

1. [mutator] remove DIR/foo, DIR
2. [notify thread] IN_DELETE DIR/foo, add_pending(DIR/foo)
3. [notify thread] IN_DELETE_SELF DIR, add_pending(DIR)
4. [notify thread] IN_IGNORED DIR
5. [mutator] create DIR, open(DIR/foo), but don't write to it yet
6. [notify thread] IN_CREATE DIR, add_pending(DIR)
7. [io thread] processing the add_pending from (2.), lstat(DIR/foo).
   It exists but has zero size.  The file node is updated with
   size=0
8. [mutator] write to DIR/foo
9. [io thread] processing the add_pending from either (2.) or (3.),
   opens DIR and establishes watch on it, but doesn't update any of the
   entries due to the stat avoiding optimization.  Because the
   write happened in (8.), before the watch was established, we
   never observe a notification for the changes made there
10. hgwatchman queries the state and observes size=0, flagging the
   DIR/foo as modified.
11. hgwatchman queries the state a second time in a later hg status
    run.  This time the cached DIR/foo information is passed through
    a different layer and the size discrepancy is handled correctly,
    and the file does not show up as modified.

We fix this by removing the stat avoiding optimization in the recursive
case.  We don't have a great way to recognize when we might have missed
something.  One way to do that might be to pass out a flag when we
notice that the watch descriptor is different, but let's go for simple
first and then figure out if we need to optimize it.

In addition, I noticed that we were sometimes trying to track moves
for files; let's take advantage of the ISDIR flag that is set by
inotify to make sure we're focused on the right things.