### PR TITLE
Bulkstat

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@ watchman_SOURCES = \
 	hash.c       \
 	ht.c         \
 	ioprio.c        \
+	opendir.c       \
 	pending.c       \
 	stream.c        \
 	stream_stdout.c \

--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,7 @@ AC_SEARCH_LIBS([socket], [socket])
 
 AC_CHECK_HEADERS(sys/types.h inttypes.h locale.h port.h sys/inotify.h sys/event.h)
 AC_CHECK_FUNCS(mkostemp kqueue port_create inotify_init strtoll localeconv statfs)
-AC_CHECK_FUNCS(accept4 inotify_init1)
+AC_CHECK_FUNCS(accept4 inotify_init1 getattrlistbulk)
 AC_CHECK_HEADERS(sys/vfs.h sys/param.h sys/mount.h sys/statfs.h sys/statvfs.h, [], [],
 [[#ifdef __OpenBSD__
 # include <sys/param.h>

--- a/opendir.c
+++ b/opendir.c
@@ -2,9 +2,49 @@
  * Licensed under the Apache License, Version 2.0 */
 
 #include "watchman.h"
+#ifdef __APPLE__
+# include <sys/attr.h>
+# include <sys/vnode.h>
+#endif
+
+#ifdef HAVE_GETATTRLISTBULK
+typedef struct {
+  uint32_t len;
+  attribute_set_t returned;
+  uint32_t err;
+
+  /* The attribute data length will not be greater than NAME_MAX + 1
+   * characters, which is NAME_MAX * 3 + 1 bytes (as one UTF-8-encoded
+   * character may take up to three bytes
+   */
+  attrreference_t name; // ATTR_CMN_NAME
+  dev_t dev;            // ATTR_CMN_DEVID
+  fsobj_type_t objtype; // ATTR_CMN_OBJTYPE
+  struct timespec mtime; // ATTR_CMN_MODTIME
+  struct timespec ctime; // ATTR_CMN_CHGTIME
+  struct timespec atime; // ATTR_CMN_ACCTIME
+  uid_t uid; // ATTR_CMN_OWNERID
+  gid_t gid; // ATTR_CMN_GRPID
+  uint32_t mode; // ATTR_CMN_ACCESSMASK, Only the permission bits of st_mode
+                 // are valid; other bits should be ignored,
+                 // e.g., by masking with ~S_IFMT.
+  uint64_t ino;  // ATTR_CMN_FILEID
+  uint32_t link; // ATTR_FILE_LINKCOUNT or ATTR_DIR_LINKCOUNT
+  off_t file_size; // ATTR_FILE_TOTALSIZE
+
+} __attribute__((packed)) bulk_attr_item;
+#endif
 
 struct watchman_dir_handle {
+#ifdef HAVE_GETATTRLISTBULK
+  int fd;
+  struct attrlist attrlist;
+  int retcount;
+  char buf[64 * (sizeof(bulk_attr_item) + NAME_MAX * 3 + 1)];
+  char *cursor;
+#else
   DIR *d;
+#endif
   struct watchman_dir_ent ent;
 };
 
@@ -35,6 +75,32 @@ struct watchman_dir_handle *w_dir_open(const char *path) {
   if (!dir) {
     return NULL;
   }
+#ifdef HAVE_GETATTRLISTBULK
+  dir->fd = open(path, O_NOFOLLOW | O_CLOEXEC | O_RDONLY);
+  if (dir->fd == -1) {
+    err = errno;
+    free(dir);
+    errno = err;
+    return NULL;
+  }
+
+  dir->attrlist.bitmapcount = ATTR_BIT_MAP_COUNT;
+  dir->attrlist.commonattr = ATTR_CMN_RETURNED_ATTRS |
+                             ATTR_CMN_ERROR |
+                             ATTR_CMN_NAME |
+                             ATTR_CMN_DEVID |
+                             ATTR_CMN_OBJTYPE |
+                             ATTR_CMN_MODTIME |
+                             ATTR_CMN_CHGTIME |
+                             ATTR_CMN_ACCTIME |
+                             ATTR_CMN_OWNERID |
+                             ATTR_CMN_GRPID |
+                             ATTR_CMN_ACCESSMASK |
+                             ATTR_CMN_FILEID;
+  dir->attrlist.dirattr = ATTR_DIR_LINKCOUNT;
+  dir->attrlist.fileattr = ATTR_FILE_TOTALSIZE |
+                           ATTR_FILE_LINKCOUNT;
+#else
   dir->d = opendir_nofollow(path);
 
   if (!dir->d) {
@@ -43,17 +109,96 @@ struct watchman_dir_handle *w_dir_open(const char *path) {
     errno = err;
     return NULL;
   }
+#endif
 
   return dir;
 }
 
 struct watchman_dir_ent *w_dir_read(struct watchman_dir_handle *dir) {
+#ifdef HAVE_GETATTRLISTBULK
+  bulk_attr_item *item;
+
+  if (!dir->cursor) {
+    // Read the next batch of results
+    int retcount;
+
+    retcount = getattrlistbulk(dir->fd, &dir->attrlist,
+                dir->buf, sizeof(dir->buf), FSOPT_PACK_INVAL_ATTRS);
+    if (retcount == -1) {
+      w_log(W_LOG_ERR, "getattrlistbulk: error %d %s\n",
+          errno, strerror(errno));
+      return NULL;
+    }
+    if (retcount == 0) {
+      // End of the stream
+      errno = 0;
+      return NULL;
+    }
+
+    dir->retcount = retcount;
+    dir->cursor = dir->buf;
+  }
+
+  // Decode the next item
+  item = (bulk_attr_item*)dir->cursor;
+  dir->cursor += item->len;
+  if (--dir->retcount == 0) {
+    dir->cursor = NULL;
+  }
+
+  dir->ent.d_name = ((char*)&item->name) + item->name.attr_dataoffset;
+  if (item->err) {
+    w_log(W_LOG_ERR, "item error %s: %d %s\n", dir->ent.d_name,
+        item->err, strerror(item->err));
+    // We got the name, so we can return something useful
+    dir->ent.has_stat = false;
+    return &dir->ent;
+  }
+
+  memset(&dir->ent.stat, 0, sizeof(dir->ent.stat));
+
+  dir->ent.stat.dev = item->dev;
+  memcpy(&dir->ent.stat.mtime, &item->mtime, sizeof(item->mtime));
+  memcpy(&dir->ent.stat.ctime, &item->ctime, sizeof(item->ctime));
+  memcpy(&dir->ent.stat.atime, &item->atime, sizeof(item->atime));
+  dir->ent.stat.uid = item->uid;
+  dir->ent.stat.gid = item->gid;
+  dir->ent.stat.mode = item->mode & ~S_IFMT;
+  dir->ent.stat.ino = item->ino;
+
+  switch (item->objtype) {
+    case VREG:
+      dir->ent.stat.mode |= S_IFREG;
+      dir->ent.stat.size = item->file_size;
+      dir->ent.stat.nlink = item->link;
+      break;
+    case VDIR:
+      dir->ent.stat.mode |= S_IFDIR;
+      dir->ent.stat.nlink = item->link;
+      break;
+    case VLNK:
+      dir->ent.stat.mode |= S_IFLNK;
+      break;
+    case VBLK:
+      dir->ent.stat.mode |= S_IFBLK;
+      break;
+    case VCHR:
+      dir->ent.stat.mode |= S_IFCHR;
+      break;
+    case VFIFO:
+      dir->ent.stat.mode |= S_IFIFO;
+      break;
+    case VSOCK:
+      dir->ent.stat.mode |= S_IFSOCK;
+      break;
+  }
+  dir->ent.has_stat = true;
+#else
   struct dirent *ent;
 
   if (!dir->d) {
     return NULL;
   }
-
   ent = readdir(dir->d);
   if (!ent) {
     return NULL;
@@ -61,17 +206,28 @@ struct watchman_dir_ent *w_dir_read(struct watchman_dir_handle *dir) {
 
   dir->ent.d_name = ent->d_name;
   dir->ent.has_stat = false;
+#endif
   return &dir->ent;
 }
 
 void w_dir_close(struct watchman_dir_handle *dir) {
+#ifdef HAVE_GETATTRLISTBULK
+  close(dir->fd);
+#else
   closedir(dir->d);
+#endif
   free(dir);
 }
 
+#ifndef _WIN32
 int w_dir_fd(struct watchman_dir_handle *dir) {
+#ifdef HAVE_GETATTRLISTBULK
+  return dir->fd;
+#else
   return dirfd(dir->d);
+#endif
 }
+#endif
 
 /* vim:ts=2:sw=2:et:
  */

--- a/opendir.c
+++ b/opendir.c
@@ -1,0 +1,77 @@
+/* Copyright 2012-present Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 */
+
+#include "watchman.h"
+
+struct watchman_dir_handle {
+  DIR *d;
+  struct watchman_dir_ent ent;
+};
+
+/* Opens a directory making sure it's not a symlink */
+DIR *opendir_nofollow(const char *path)
+{
+#ifdef _WIN32
+  return win_opendir(path, 1 /* no follow */);
+#else
+  int fd = open(path, O_NOFOLLOW | O_CLOEXEC);
+  if (fd == -1) {
+    return NULL;
+  }
+#if defined(__APPLE__)
+  close(fd);
+  return opendir(path);
+#else
+  // errno should be set appropriately if this is not a directory
+  return fdopendir(fd);
+#endif
+#endif
+}
+
+struct watchman_dir_handle *w_dir_open(const char *path) {
+  struct watchman_dir_handle *dir = calloc(1, sizeof(*dir));
+  int err;
+
+  if (!dir) {
+    return NULL;
+  }
+  dir->d = opendir_nofollow(path);
+
+  if (!dir->d) {
+    err = errno;
+    free(dir);
+    errno = err;
+    return NULL;
+  }
+
+  return dir;
+}
+
+struct watchman_dir_ent *w_dir_read(struct watchman_dir_handle *dir) {
+  struct dirent *ent;
+
+  if (!dir->d) {
+    return NULL;
+  }
+
+  ent = readdir(dir->d);
+  if (!ent) {
+    return NULL;
+  }
+
+  dir->ent.d_name = ent->d_name;
+  dir->ent.has_stat = false;
+  return &dir->ent;
+}
+
+void w_dir_close(struct watchman_dir_handle *dir) {
+  closedir(dir->d);
+  free(dir);
+}
+
+int w_dir_fd(struct watchman_dir_handle *dir) {
+  return dirfd(dir->d);
+}
+
+/* vim:ts=2:sw=2:et:
+ */

--- a/query/empty.c
+++ b/query/empty.c
@@ -32,8 +32,8 @@ static bool eval_empty(struct w_query_ctx *ctx,
     return false;
   }
 
-  if (S_ISDIR(file->st.st_mode) || S_ISREG(file->st.st_mode)) {
-    return file->st.st_size == 0;
+  if (S_ISDIR(file->stat.mode) || S_ISREG(file->stat.mode)) {
+    return file->stat.size == 0;
   }
 
   return false;

--- a/query/eval.c
+++ b/query/eval.c
@@ -290,7 +290,7 @@ static bool path_generator(
       w_string_delref(file_name);
 
       // If it's a file (but not an existent dir)
-      if (f && (!f->exists || !S_ISDIR(f->st.st_mode))) {
+      if (f && (!f->exists || !S_ISDIR(f->stat.mode))) {
         w_string_delref(full_name);
         if (!w_query_process_file(query, ctx, f)) {
           return false;

--- a/query/fieldlist.c
+++ b/query/fieldlist.c
@@ -35,12 +35,12 @@ MAKE_CLOCK_FIELD(oclock, otime)
 // runs into an issue and deal with it then...
 #define MAKE_INT_FIELD(name, member) \
   static json_t *make_##name(struct watchman_rule_match *match) { \
-    return json_integer(match->file->st.member); \
+    return json_integer(match->file->stat.member); \
   }
 
 #define MAKE_TIME_INT_FIELD(name, type, scale) \
   static json_t *make_##name(struct watchman_rule_match *match) { \
-    struct timespec spec = match->file->st.WATCHMAN_ST_TIMESPEC(type); \
+    struct timespec spec = match->file->stat.type##time; \
     return json_integer(((int64_t) spec.tv_sec * scale) + \
                         ((int64_t) spec.tv_nsec * scale / \
                          WATCHMAN_NSEC_IN_SEC)); \
@@ -48,7 +48,7 @@ MAKE_CLOCK_FIELD(oclock, otime)
 
 #define MAKE_TIME_DOUBLE_FIELD(name, type) \
   static json_t *make_##name(struct watchman_rule_match *match) { \
-    struct timespec spec = match->file->st.WATCHMAN_ST_TIMESPEC(type); \
+    struct timespec spec = match->file->stat.type##time; \
     return json_real(spec.tv_sec + 1e-9 * spec.tv_nsec); \
   }
 
@@ -60,22 +60,22 @@ MAKE_CLOCK_FIELD(oclock, otime)
  * - mtime_f: mtime as a double
  */
 #define MAKE_TIME_FIELDS(type) \
-  MAKE_INT_FIELD(type##time, st_##type##time) \
+  MAKE_INT_FIELD(type##time, type##time.tv_sec) \
   MAKE_TIME_INT_FIELD(type##time_ms, type, 1000) \
   MAKE_TIME_INT_FIELD(type##time_us, type, 1000 * 1000) \
   MAKE_TIME_INT_FIELD(type##time_ns, type, 1000 * 1000 * 1000) \
   MAKE_TIME_DOUBLE_FIELD(type##time_f, type)
 
-MAKE_INT_FIELD(size, st_size)
-MAKE_INT_FIELD(mode, st_mode)
-MAKE_INT_FIELD(uid, st_uid)
-MAKE_INT_FIELD(gid, st_gid)
+MAKE_INT_FIELD(size, size)
+MAKE_INT_FIELD(mode, mode)
+MAKE_INT_FIELD(uid, uid)
+MAKE_INT_FIELD(gid, gid)
 MAKE_TIME_FIELDS(a)
 MAKE_TIME_FIELDS(m)
 MAKE_TIME_FIELDS(c)
-MAKE_INT_FIELD(ino, st_ino)
-MAKE_INT_FIELD(dev, st_dev)
-MAKE_INT_FIELD(nlink, st_nlink)
+MAKE_INT_FIELD(ino, ino)
+MAKE_INT_FIELD(dev, dev)
+MAKE_INT_FIELD(nlink, nlink)
 
 #define MAKE_TIME_FIELD_DEFS(type) \
   { #type "time", make_##type##time }, \
@@ -86,29 +86,29 @@ MAKE_INT_FIELD(nlink, st_nlink)
 
 static json_t *make_type_field(struct watchman_rule_match *match) {
   // Bias towards the more common file types first
-  if (S_ISREG(match->file->st.st_mode)) {
+  if (S_ISREG(match->file->stat.mode)) {
     return json_string_nocheck("f");
   }
-  if (S_ISDIR(match->file->st.st_mode)) {
+  if (S_ISDIR(match->file->stat.mode)) {
     return json_string_nocheck("d");
   }
-  if (S_ISLNK(match->file->st.st_mode)) {
+  if (S_ISLNK(match->file->stat.mode)) {
     return json_string_nocheck("l");
   }
-  if (S_ISBLK(match->file->st.st_mode)) {
+  if (S_ISBLK(match->file->stat.mode)) {
     return json_string_nocheck("b");
   }
-  if (S_ISCHR(match->file->st.st_mode)) {
+  if (S_ISCHR(match->file->stat.mode)) {
     return json_string_nocheck("c");
   }
-  if (S_ISFIFO(match->file->st.st_mode)) {
+  if (S_ISFIFO(match->file->stat.mode)) {
     return json_string_nocheck("p");
   }
-  if (S_ISSOCK(match->file->st.st_mode)) {
+  if (S_ISSOCK(match->file->stat.mode)) {
     return json_string_nocheck("s");
   }
 #ifdef S_ISDOOR
-  if (S_ISDOOR(match->file->st.st_mode)) {
+  if (S_ISDOOR(match->file->stat.mode)) {
     return json_string_nocheck("D");
   }
 #endif

--- a/query/intcompare.c
+++ b/query/intcompare.c
@@ -91,7 +91,7 @@ static bool eval_size(struct w_query_ctx *ctx, struct watchman_file *file,
     return false;
   }
 
-  return eval_int_compare(file->st.st_size, comp);
+  return eval_int_compare(file->stat.size, comp);
 }
 
 static w_query_expr *size_parser(w_query *query, json_t *term) {

--- a/query/since.c
+++ b/query/since.c
@@ -37,10 +37,10 @@ static bool eval_since(struct w_query_ctx *ctx,
       }
       return clock.ticks > since.clock.ticks;
     case SINCE_MTIME:
-      tval = file->st.st_mtime;
+      tval = file->stat.mtime.tv_sec;
       break;
     case SINCE_CTIME:
-      tval = file->st.st_ctime;
+      tval = file->stat.ctime.tv_sec;
       break;
   }
 

--- a/query/type.c
+++ b/query/type.c
@@ -13,22 +13,22 @@ static bool eval_type(struct w_query_ctx *ctx,
 
   switch (arg) {
     case 'b':
-      return S_ISBLK(file->st.st_mode);
+      return S_ISBLK(file->stat.mode);
     case 'c':
-      return S_ISCHR(file->st.st_mode);
+      return S_ISCHR(file->stat.mode);
     case 'd':
-      return S_ISDIR(file->st.st_mode);
+      return S_ISDIR(file->stat.mode);
     case 'f':
-      return S_ISREG(file->st.st_mode);
+      return S_ISREG(file->stat.mode);
     case 'p':
-      return S_ISFIFO(file->st.st_mode);
+      return S_ISFIFO(file->stat.mode);
     case 'l':
-      return S_ISLNK(file->st.st_mode);
+      return S_ISLNK(file->stat.mode);
     case 's':
-      return S_ISSOCK(file->st.st_mode);
+      return S_ISSOCK(file->stat.mode);
 #ifdef S_ISDOOR
     case 'D':
-      return S_ISDOOR(file->st.st_mode);
+      return S_ISDOOR(file->stat.mode);
 #endif
     default:
       return false;

--- a/root.c
+++ b/root.c
@@ -886,9 +886,10 @@ static void stat_path(w_root_t *root,
       w_string_t *lc_file_name;
       struct watchman_file *lc_file = NULL;
 
-      if (pre_stat) {
-        // Optimization: if we're reading the dir, we assume that the
-        // name we were given is the canonical name
+      if (pre_stat || !via_notify) {
+        // Optimization: if we're reading the dir, or were passed this path
+        // as part of a recursive walk, then we assume that the name we were
+        // given is already the canonical name
         canon_name = file_name;
         w_string_addref(canon_name);
       } else {

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -456,13 +456,14 @@ static void fsevents_root_stop_watch_file(watchman_global_watcher_t watcher,
   unused_parameter(file);
 }
 
-static DIR *fsevents_root_start_watch_dir(watchman_global_watcher_t watcher,
+static struct watchman_dir_handle *fsevents_root_start_watch_dir(
+      watchman_global_watcher_t watcher,
       w_root_t *root, struct watchman_dir *dir, struct timeval now,
       const char *path) {
-  DIR *osdir;
+  struct watchman_dir_handle *osdir;
   unused_parameter(watcher);
 
-  osdir = opendir_nofollow(path);
+  osdir = w_dir_open(path);
   if (!osdir) {
     handle_open_errno(root, dir, now, "opendir", errno, NULL);
     return NULL;

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -303,7 +303,8 @@ break_out:
                  kFSEventStreamEventFlagItemRenamed))
               ? true : false;
 
-    w_pending_coll_add(coll, evt->path, recurse, now, true);
+    w_pending_coll_add(coll, evt->path, now,
+        W_PENDING_VIA_NOTIFY | (recurse ? W_PENDING_RECURSIVE : 0));
 
     w_string_delref(evt->path);
     free(evt);

--- a/watcher/inotify.c
+++ b/watcher/inotify.c
@@ -195,11 +195,12 @@ static void inot_root_stop_watch_file(watchman_global_watcher_t watcher,
   unused_parameter(file);
 }
 
-static DIR *inot_root_start_watch_dir(watchman_global_watcher_t watcher,
+static struct watchman_dir_handle *inot_root_start_watch_dir(
+    watchman_global_watcher_t watcher,
     w_root_t *root, struct watchman_dir *dir, struct timeval now,
     const char *path) {
   struct inot_root_state *state = root->watch;
-  DIR *osdir = NULL;
+  struct watchman_dir_handle *osdir = NULL;
   int newwd;
   unused_parameter(watcher);
 
@@ -224,7 +225,7 @@ static DIR *inot_root_start_watch_dir(watchman_global_watcher_t watcher,
   pthread_mutex_unlock(&state->lock);
   w_log(W_LOG_DBG, "adding %d -> %s mapping\n", newwd, path);
 
-  osdir = opendir_nofollow(path);
+  osdir = w_dir_open(path);
   if (!osdir) {
     handle_open_errno(root, dir, now, "opendir", errno, NULL);
     return NULL;

--- a/watcher/inotify.c
+++ b/watcher/inotify.c
@@ -361,7 +361,8 @@ static void process_inotify_event(
 
       w_log(W_LOG_DBG, "add_pending for inotify mask=%x %.*s\n",
           ine->mask, name->len, name->buf);
-      w_pending_coll_add(coll, name, true, now, true);
+      w_pending_coll_add(coll, name, now,
+          W_PENDING_RECURSIVE|W_PENDING_VIA_NOTIFY);
 
       w_string_delref(name);
 

--- a/watcher/kqueue.c
+++ b/watcher/kqueue.c
@@ -315,7 +315,8 @@ static bool kqueue_root_consume_notify(watchman_global_watcher_t watcher,
     }
 
     pthread_mutex_unlock(&state->lock);
-    w_pending_coll_add(coll, path, !is_dir, now, !is_dir);
+    w_pending_coll_add(coll, path, now,
+        is_dir ? 0 : (W_PENDING_RECURSIVE|W_PENDING_VIA_NOTIFY));
     w_string_delref(path);
   }
 

--- a/watcher/portfs.c
+++ b/watcher/portfs.c
@@ -202,15 +202,16 @@ static void portfs_root_stop_watch_file(watchman_global_watcher_t watcher,
   unused_parameter(file);
 }
 
-static DIR *portfs_root_start_watch_dir(watchman_global_watcher_t watcher,
+static struct watchman_dir_handle *portfs_root_start_watch_dir(
+    watchman_global_watcher_t watcher,
     w_root_t *root, struct watchman_dir *dir, struct timeval now,
     const char *path) {
   struct portfs_root_state *state = root->watch;
-  DIR *osdir;
+  struct watchman_dir_handle *osdir;
   struct stat st;
   unused_parameter(watcher);
 
-  osdir = opendir_nofollow(path);
+  osdir = w_dir_open(path);
   if (!osdir) {
     handle_open_errno(root, dir, now, "opendir", errno, NULL);
     return NULL;
@@ -221,12 +222,12 @@ static DIR *portfs_root_start_watch_dir(watchman_global_watcher_t watcher,
     w_log(W_LOG_ERR, "fstat on opened dir %s failed: %s\n", path,
         strerror(errno));
     w_root_schedule_recrawl(root, "fstat failed");
-    closedir(osdir);
+    w_dir_close(osdir);
     return NULL;
   }
 
   if (!do_watch(state, dir->path, &st)) {
-    closedir(osdir);
+    w_dir_close(osdir);
     return NULL;
   }
 

--- a/watcher/portfs.c
+++ b/watcher/portfs.c
@@ -291,7 +291,8 @@ static bool portfs_root_consume_notify(watchman_global_watcher_t watcher,
       pthread_mutex_unlock(&state->lock);
       return false;
     }
-    w_pending_coll_add(coll, f->name, true, now, true);
+    w_pending_coll_add(coll, f->name, now,
+        W_PENDING_RECURSIVE|W_PENDING_VIA_NOTIFY);
 
     // It was port_dissociate'd implicitly.  We'll re-establish a
     // watch later when portfs_root_start_watch_(file|dir) are called again

--- a/watcher/win32.c
+++ b/watcher/win32.c
@@ -349,13 +349,14 @@ static void winwatch_root_stop_watch_file(watchman_global_watcher_t watcher,
   unused_parameter(watcher);
 }
 
-static DIR *winwatch_root_start_watch_dir(watchman_global_watcher_t watcher,
+static struct watchman_dir_handle *winwatch_root_start_watch_dir(
+    watchman_global_watcher_t watcher,
     w_root_t *root, struct watchman_dir *dir, struct timeval now,
     const char *path) {
-  DIR *osdir;
+  struct watchman_dir_handle *osdir;
   unused_parameter(watcher);
 
-  osdir = opendir(path);
+  osdir = w_dir_open(path);
   if (!osdir) {
     handle_open_errno(root, dir, now, "opendir", errno, strerror(errno));
     return NULL;

--- a/watcher/win32.c
+++ b/watcher/win32.c
@@ -133,7 +133,8 @@ static void *readchanges_thread(void *arg) {
   HANDLE handles[2] = { state->olap, state->ping };
   DWORD bytes;
 
-  w_set_thread_name("readchange %.*s", root->root_path->len, root->root_path->buf);
+  w_set_thread_name("readchange %.*s",
+      root->root_path->len, root->root_path->buf);
 
   // Block until winmatch_root_st is waiting for our initialization
   pthread_mutex_lock(&state->mtx);
@@ -396,7 +397,7 @@ static bool winwatch_root_consume_notify(watchman_global_watcher_t watcher,
 
     w_log(W_LOG_DBG, "readchanges: add pending %.*s\n",
         item->name->len, item->name->buf);
-    w_pending_coll_add(coll, item->name, false, now, true);
+    w_pending_coll_add(coll, item->name, now, W_PENDING_VIA_NOTIFY);
 
     w_string_delref(item->name);
     free(item);

--- a/watchman.h
+++ b/watchman.h
@@ -339,7 +339,8 @@ struct watchman_ops {
 
   // Initiate an OS-level watch on the provided dir, return a DIR
   // handle, or NULL on error
-  DIR *(*root_start_watch_dir)(watchman_global_watcher_t watcher,
+  struct watchman_dir_handle *(*root_start_watch_dir)(
+      watchman_global_watcher_t watcher,
       w_root_t *root, struct watchman_dir *dir, struct timeval now,
       const char *path);
 
@@ -375,6 +376,20 @@ struct watchman_stat {
   dev_t dev;
   nlink_t nlink;
 };
+
+/* opaque (system dependent) type for walking dir contents */
+struct watchman_dir_handle;
+
+struct watchman_dir_ent {
+  bool has_stat;
+  char *d_name;
+  struct watchman_stat stat;
+};
+
+struct watchman_dir_handle *w_dir_open(const char *path);
+struct watchman_dir_ent *w_dir_read(struct watchman_dir_handle *dir);
+void w_dir_close(struct watchman_dir_handle *dir);
+int w_dir_fd(struct watchman_dir_handle *dir);
 
 struct watchman_file {
   /* our name within the parent dir */

--- a/watchman.h
+++ b/watchman.h
@@ -365,6 +365,17 @@ struct watchman_ops {
       struct watchman_file *file);
 };
 
+struct watchman_stat {
+  struct timespec atime, mtime, ctime;
+  off_t size;
+  mode_t mode;
+  uid_t uid;
+  gid_t gid;
+  ino_t ino;
+  dev_t dev;
+  nlink_t nlink;
+};
+
 struct watchman_file {
   /* our name within the parent dir */
   w_string_t *name;
@@ -391,7 +402,7 @@ struct watchman_file {
 
   /* cache stat results so we can tell if an entry
    * changed */
-  struct stat st;
+  struct watchman_stat stat;
 };
 
 #define WATCHMAN_COOKIE_PREFIX ".watchman-cookie-"

--- a/watchman.h
+++ b/watchman.h
@@ -249,12 +249,14 @@ struct watchman_clock {
 };
 typedef struct watchman_clock w_clock_t;
 
+#define W_PENDING_RECURSIVE   1
+#define W_PENDING_VIA_NOTIFY 2
+#define W_PENDING_CRAWL_ONLY  4
 struct watchman_pending_fs {
   struct watchman_pending_fs *next;
   w_string_t *path;
-  bool recursive;
   struct timeval now;
-  bool via_notify;
+  int flags;
 };
 
 struct watchman_pending_collection {
@@ -271,10 +273,10 @@ void w_pending_coll_drain(struct watchman_pending_collection *coll);
 void w_pending_coll_lock(struct watchman_pending_collection *coll);
 void w_pending_coll_unlock(struct watchman_pending_collection *coll);
 bool w_pending_coll_add(struct watchman_pending_collection *coll,
-    w_string_t *path, bool recursive, struct timeval now, bool via_notify);
+    w_string_t *path, struct timeval now, int flags);
 bool w_pending_coll_add_rel(struct watchman_pending_collection *coll,
-    struct watchman_dir *dir, const char *name, bool recursive,
-    struct timeval now, bool via_notify);
+    struct watchman_dir *dir, const char *name,
+    struct timeval now, int flags);
 void w_pending_coll_append(struct watchman_pending_collection *target,
     struct watchman_pending_collection *src);
 struct watchman_pending_fs *w_pending_coll_pop(
@@ -668,7 +670,8 @@ struct watchman_dir *w_root_resolve_dir(w_root_t *root,
     w_string_t *dir_name, bool create);
 void w_root_process_path(w_root_t *root,
     struct watchman_pending_collection *coll, w_string_t *full_path,
-    struct timeval now, bool recursive, bool via_notify);
+    struct timeval now, int flags,
+    struct watchman_dir_ent *pre_stat);
 bool w_root_process_pending(w_root_t *root,
     struct watchman_pending_collection *coll,
     bool pull_from_root);

--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -45,6 +45,7 @@ SRCS=\
 	expflags.c   \
 	hash.c       \
 	ioprio.c     \
+	opendir.c    \
 	pending.c    \
 	stream.c     \
 	stream_win.c \

--- a/winbuild/sys/stat.h
+++ b/winbuild/sys/stat.h
@@ -10,13 +10,23 @@
 extern "C" {
 #endif
 
+typedef int mode_t;
+typedef int uid_t;
+typedef int gid_t;
+typedef int nlink_t;
+
 // FIXME: don't do this, define our own layer
 struct stat {
   uint64_t st_size;
-  int st_mode;
+  mode_t st_mode;
   struct timespec st_atim, st_mtim, st_ctim;
   time_t st_atime, st_mtime, st_ctime;
-  int st_uid, st_gid, st_ino, st_dev, st_nlink, st_rdev;
+  uid_t st_uid;
+  gid_t st_gid;
+  ino_t st_ino;
+  dev_t st_dev;
+  nlink_t st_nlink;
+  dev_t st_rdev;
 };
 
 int lstat(const char *path, struct stat *st);


### PR DESCRIPTION
This is a short series of diffs that makes it possible for us to use the `getattrlistbulk` function (available since OS X 10.10).  We don't use `getdirentriesattr` (used by mercurial) because that function is deprecated in favor of `getattrlistbulk`.

This speeds up the crawl for a large repoo on OS X, reducing it from ~12 seconds to ~8 seconds.

The main thrust of these changes is to make it possible to propagate pre-fetched stat information from the directory walk to our `stat_path` function.

A nice side effect of this diff is that we gain true NOFOLLOW for our replacement for opendir, something that just wasn't possible with the standard library on OS X.

(ignore the pre-size hash tables commit in this stack; see https://github.com/facebook/watchman/pull/165 for that bit.  I've included it here because there is a minor conflict between the two)