### PR TITLE
Employ very strict O_NOFOLLOW semantics when we opendir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,7 @@ AC_SEARCH_LIBS([socket], [socket])
 
 AC_CHECK_HEADERS(sys/types.h inttypes.h locale.h port.h sys/inotify.h sys/event.h)
 AC_CHECK_FUNCS(mkostemp kqueue port_create inotify_init strtoll localeconv statfs)
-AC_CHECK_FUNCS(accept4 inotify_init1 getattrlistbulk)
+AC_CHECK_FUNCS(accept4 inotify_init1 getattrlistbulk openat fdopendir)
 AC_CHECK_HEADERS(sys/vfs.h sys/param.h sys/mount.h sys/statfs.h sys/statvfs.h, [], [],
 [[#ifdef __OpenBSD__
 # include <sys/param.h>

--- a/root.c
+++ b/root.c
@@ -1192,7 +1192,7 @@ void handle_open_errno(w_root_t *root, struct watchman_dir *dir,
   }
 
   warn = w_string_make_printf(
-      "%s(%.*s) -> %s. Marking this portion of the tree deleted\n",
+      "%s(%.*s) -> %s. Marking this portion of the tree deleted",
       syscall, dir_name->len, dir_name->buf,
       reason ? reason : strerror(err));
 


### PR DESCRIPTION
Summary: There are a couple of scenarios where a dir can be replaced
with a symlink that can skirt around our checks for symlinks.

We want to avoid traversing symlinks as this can be a costly operation
that takes us across filesystem boundaries.

This diff adds a stricter open operation that exclusively applies
O_NOFOLLOW to each component of the path that we want to open.
If any component of this fails, then the entire open operation fails.

We use this as part of our opendir_nofollow function.

We'll catch the failure to open in the various watcher
`root_start_watch_dir` functions, which then call `handle_open_errno`
and will recursively prune out the nodes from the tree.

Test Plan: `make integration` and run on my devserver.  Relatively lame.