### PR TITLE
Add periodic socket liveness check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@ watchman_SOURCES = \
 	spawn.c       \
 	opt.c        \
 	cfg.c        \
+	checksock.c  \
 	fstype.c     \
 	log.c        \
 	json.c       \

--- a/checksock.c
+++ b/checksock.c
@@ -1,0 +1,79 @@
+// Copyright 2004-present Facebook. All Rights Reserved
+
+#include "watchman.h"
+
+/* Periodically connect to our endpoint and verify that we're talking
+ * to ourselves.  This is normally a sign of madness, but if we don't
+ * get an answer, or get a reply from someone else, we know things
+ * are bad; someone removed our socket file or there was some kind of
+ * race condition that resulted in multiple instances starting up.
+ */
+
+static void *check_my_sock(void *unused) {
+  json_t *cmd = json_pack("[s]", "get-pid");
+  json_t *result;
+  w_stm_t client = NULL;
+  w_jbuffer_t buf;
+  json_error_t jerr;
+  json_int_t remote_pid = 0;
+  pid_t my_pid = getpid();
+
+  unused_parameter(unused);
+  w_set_thread_name("sockcheck");
+
+  client = w_stm_connect(get_sock_name(), 6000);
+  if (!client) {
+    w_log(W_LOG_FATAL, "Failed to connect to myself for get-pid check: %s\n",
+        strerror(errno));
+    /* NOTREACHED */
+  }
+
+  w_stm_set_nonblock(client, false);
+
+  w_json_buffer_init(&buf);
+  if (!w_ser_write_pdu(is_bser, &buf, client, cmd)) {
+    w_log(W_LOG_FATAL, "Failed to send get-pid PDU: %s\n",
+          strerror(errno));
+    /* NOTREACHED */
+  }
+
+  w_json_buffer_reset(&buf);
+  result = w_json_buffer_next(&buf, client, &jerr);
+  if (!result) {
+    w_log(W_LOG_FATAL, "Failed to decode get-pid response: %s %s\n",
+        jerr.text, strerror(errno));
+    /* NOTREACHED */
+  }
+
+  if (json_unpack_ex(result, &jerr, 0, "{s:i}",
+        "pid", &remote_pid) != 0) {
+    w_log(W_LOG_FATAL, "Failed to extract pid from get-pid response: %s\n",
+        jerr.text);
+    /* NOTREACHED */
+  }
+
+  if (remote_pid != my_pid) {
+    w_log(W_LOG_FATAL,
+        "remote pid from get-pid (%ld) doesn't match my pid (%ld)\n",
+        (long)remote_pid, (long)my_pid);
+    /* NOTREACHED */
+  }
+  json_decref(cmd);
+  json_decref(result);
+  w_json_buffer_free(&buf);
+  w_stm_close(client);
+  return NULL;
+}
+
+void w_check_my_sock(void) {
+  pthread_attr_t attr;
+  pthread_t thr;
+
+  pthread_attr_init(&attr);
+  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+  pthread_create(&thr, &attr, check_my_sock, NULL);
+  pthread_attr_destroy(&attr);
+}
+
+/* vim:ts=2:sw=2:et:
+ */

--- a/listener.c
+++ b/listener.c
@@ -897,6 +897,9 @@ static void accept_loop() {
     pfd.events = POLLIN;
     pfd.fd = listener_fd;
     if (poll(&pfd, 1, 10000) < 1 || (pfd.revents & POLLIN) == 0) {
+      // Timed out, or error.
+      // Arrange to sanity check that we're working
+      w_check_my_sock();
       continue;
     }
 

--- a/watchman.h
+++ b/watchman.h
@@ -589,7 +589,7 @@ bool w_reap_children(bool block);
 #define W_LOG_OFF 0
 #define W_LOG_ERR 1
 #define W_LOG_DBG 2
-#define W_LOG_FATAL 3
+#define W_LOG_FATAL -1
 
 #ifndef WATCHMAN_FMT_STRING
 # define WATCHMAN_FMT_STRING(x) x
@@ -828,6 +828,7 @@ json_t *w_root_trigger_list_to_json(w_root_t *root);
 json_t *w_root_watch_list_to_json(void);
 
 bool w_start_listener(const char *socket_path);
+void w_check_my_sock(void);
 char **w_argv_copy_from_json(json_t *arr, int skip);
 
 w_ht_t *w_envp_make_ht(void);

--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -38,6 +38,7 @@ SRCS=\
 	spawn.c \
 	opt.c \
 	cfg.c \
+	checksock.c \
 	fstype.c     \
 	log.c        \
 	json.c       \


### PR DESCRIPTION
Summary: since we're using unix domain sockets, it is possible for a
couple of funky situations to happen:

* Someone can remove the socket file.  Perhaps they are being
  overzealous in fixing some issue, or perhaps the socket gets
  nuked by something like tmpwatch

* It's conceivable that there could be a race condition with multiple
  clients trying to start the service at the same time.

The latter is a bug that we should also try to run down and resolve,
but it is worthwhile to detect and auto remediate if we detect that
the unix socket is broken.

This diff will periodically (every 10 seconds, or each time `poll(2)`
errors out), schedule a thread that will connect and sanity check
that `watchman get-pid` returns our own pid.  If we have any failure
to connect or a mismatch in the result then we'll self terminate.

While working on this I realized that we broke W_LOG_FATAL at some
point; we were just skipping FATAL level messages because the value
was outside the interesting range(!).   That might explain some
of the weird CPU spins we've seen in a couple of weird cases, where
we should have terminated but are still trying hard.

This fixes the value so that it is below the "off" threshold.

Test Plan:

Run this in one window:

`./watchman --logfile=/dev/stdout --foreground -U /tmp/foow`

Then run the same thing in another window.

The first one will output:

```
./watchman --logfile=/dev/stdout --foreground -U /tmp/foow
2015-10-20T13:16:03,838: [listener] Watchman 4.0.0 93e07ce578178c781981960cd7ff0047626f4e19 starting up on wez-mbp
2015-10-20T13:16:03,838: [listener] Using watcher mechanism fsevents
2015-10-20T13:16:03,838: [listener] file limit is 2560 kern.maxfilesperproc=10240
2015-10-20T13:16:03,838: [listener] raised file limit to 10240
2015-10-20T13:16:03,838: [listener] launchd checkin failed: No such process
2015-10-20T13:16:43,853: [sockcheck] remote pid from get-pid (51812) doesn't match my pid (51718)
2015-10-20T13:16:43,854: [sockcheck] Fatal error detected at:
2015-10-20T13:16:43,854: [sockcheck] 0   watchman                            0x00000001045796d0 w_log + 672
2015-10-20T13:16:43,854: [sockcheck] 1   watchman                            0x00000001045790b0 check_my_sock + 432
2015-10-20T13:16:43,854: [sockcheck] 2   libsystem_pthread.dylib             0x00007fff909259b1 _pthread_body + 131
2015-10-20T13:16:43,854: [sockcheck] 3   libsystem_pthread.dylib             0x00007fff9092592e _pthread_body + 0
2015-10-20T13:16:43,854: [sockcheck] 4   libsystem_pthread.dylib             0x00007fff90923385 thread_start + 13
[1]    51718 abort      ./watchman --logfile=/dev/stdout --foreground -U /tmp/foow
```

I also tried removing `/tmp/foow` with a similar result.