### PR TITLE
pywatchman: add immutable version of data results

### DIFF
--- a/python/pywatchman/bser.c
+++ b/python/pywatchman/bser.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2013, Facebook, Inc.
+Copyright (c) 2013-2015, Facebook, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,138 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BSER_TEMPLATE  0x0b
 #define BSER_SKIP      0x0c
 
-static PyObject *bser_loads_recursive(const char **ptr, const char *end);
+// An immutable object representation of BSER_OBJECT.
+// Rather than build a hash table, key -> value are obtained
+// by walking the list of keys to determine the offset into
+// the values array.  The assumption is that the number of
+// array elements will be typically small (~6 for the top
+// level query result and typically 3-5 for the file entries)
+// so that the time overhead for this is small compared to
+// using a proper hash table.  Even with this simplistic
+// approach, this is still faster for the mercurial use case
+// as it helps to eliminate creating N other objects to
+// represent the stat information in the hgwatchman extension
+typedef struct {
+  PyObject_HEAD
+  PyObject *keys;   // tuple of field names
+  PyObject *values; // tuple of values
+} bserObject;
+
+static Py_ssize_t bserobj_tuple_length(PyObject *o) {
+  bserObject *obj = (bserObject*)o;
+
+  return PySequence_Length(obj->keys);
+}
+
+static PyObject *bserobj_tuple_item(PyObject *o, Py_ssize_t i) {
+  bserObject *obj = (bserObject*)o;
+
+  return PySequence_GetItem(obj->values, i);
+}
+
+static PySequenceMethods bserobj_sq = {
+  bserobj_tuple_length,      /* sq_length */
+  0,                         /* sq_concat */
+  0,                         /* sq_repeat */
+  bserobj_tuple_item,        /* sq_item */
+  0,                         /* sq_ass_item */
+  0,                         /* sq_contains */
+  0,                         /* sq_inplace_concat */
+  0                          /* sq_inplace_repeat */
+};
+
+static void bserobj_dealloc(PyObject *o) {
+  bserObject *obj = (bserObject*)o;
+
+  Py_CLEAR(obj->keys);
+  Py_CLEAR(obj->values);
+  PyObject_Del(o);
+}
+
+static PyObject *bserobj_getattrro(PyObject *o, PyObject *name) {
+  bserObject *obj = (bserObject*)o;
+  Py_ssize_t i, n;
+  const char *namestr;
+
+  if (PyIndex_Check(name)) {
+    i = PyNumber_AsSsize_t(name, PyExc_IndexError);
+    if (i == -1 && PyErr_Occurred()) {
+      return NULL;
+    }
+    return PySequence_GetItem(obj->values, i);
+  }
+
+  // hack^Wfeature to allow mercurial to use "st_size" to reference "size"
+  namestr = PyString_AsString(name);
+  if (!strncmp(namestr, "st_", 3)) {
+    namestr += 3;
+  }
+
+  n = PyTuple_GET_SIZE(obj->keys);
+  for (i = 0; i < n; i++) {
+    const char *item_name = NULL;
+    PyObject *key = PyTuple_GET_ITEM(obj->keys, i);
+
+    item_name = PyString_AsString(key);
+    if (!strcmp(item_name, namestr)) {
+      return PySequence_GetItem(obj->values, i);
+    }
+  }
+  PyErr_Format(PyExc_AttributeError,
+              "bserobject has no attribute '%.400s'", namestr);
+  return NULL;
+}
+
+static PyMappingMethods bserobj_map = {
+  bserobj_tuple_length,     /* mp_length */
+  bserobj_getattrro,        /* mp_subscript */
+  0                         /* mp_ass_subscript */
+};
+
+PyTypeObject bserObjectType = {
+  PyVarObject_HEAD_INIT(NULL, 0)
+  "bserobj_tuple",           /* tp_name */
+  sizeof(bserObject),        /* tp_basicsize */
+  0,                         /* tp_itemsize */
+  bserobj_dealloc,           /* tp_dealloc */
+  0,                         /* tp_print */
+  0,                         /* tp_getattr */
+  0,                         /* tp_setattr */
+  0,                         /* tp_compare */
+  0,                         /* tp_repr */
+  0,                         /* tp_as_number */
+  &bserobj_sq,               /* tp_as_sequence */
+  &bserobj_map,              /* tp_as_mapping */
+  0,                         /* tp_hash  */
+  0,                         /* tp_call */
+  0,                         /* tp_str */
+  bserobj_getattrro,         /* tp_getattro */
+  0,                         /* tp_setattro */
+  0,                         /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT,        /* tp_flags */
+  "bserobj tuple",           /* tp_doc */
+  0,                         /* tp_traverse */
+  0,                         /* tp_clear */
+  0,                         /* tp_richcompare */
+  0,                         /* tp_weaklistoffset */
+  0,                         /* tp_iter */
+  0,                         /* tp_iternext */
+  0,                         /* tp_methods */
+  0,                         /* tp_members */
+  0,                         /* tp_getset */
+  0,                         /* tp_base */
+  0,                         /* tp_dict */
+  0,                         /* tp_descr_get */
+  0,                         /* tp_descr_set */
+  0,                         /* tp_dictoffset */
+  0,                         /* tp_init */
+  0,                         /* tp_alloc */
+  0,                         /* tp_new */
+};
+
+
+static PyObject *bser_loads_recursive(const char **ptr, const char *end,
+    int mutable);
 
 static const char bser_true = BSER_TRUE;
 static const char bser_false = BSER_FALSE;
@@ -61,8 +192,6 @@ static const char bser_null = BSER_NULL;
 static const char bser_string_hdr = BSER_STRING;
 static const char bser_array_hdr = BSER_ARRAY;
 static const char bser_object_hdr = BSER_OBJECT;
-static const char bser_template_hdr = BSER_TEMPLATE;
-static const char bser_skip = BSER_SKIP;
 
 static inline uint32_t next_power_2(uint32_t n)
 {
@@ -430,7 +559,7 @@ static int bunser_string(const char **ptr, const char *end,
   return 1;
 }
 
-static PyObject *bunser_array(const char **ptr, const char *end)
+static PyObject *bunser_array(const char **ptr, const char *end, int mutable)
 {
   const char *buf = *ptr;
   int64_t nitems, i;
@@ -448,28 +577,38 @@ static PyObject *bunser_array(const char **ptr, const char *end)
     return NULL;
   }
 
-  res = PyList_New((Py_ssize_t)nitems);
+  if (mutable) {
+    res = PyList_New((Py_ssize_t)nitems);
+  } else {
+    res = PyTuple_New((Py_ssize_t)nitems);
+  }
 
   for (i = 0; i < nitems; i++) {
-    PyObject *ele = bser_loads_recursive(ptr, end);
+    PyObject *ele = bser_loads_recursive(ptr, end, mutable);
 
     if (!ele) {
       Py_DECREF(res);
       return NULL;
     }
 
-    PyList_SET_ITEM(res, i, ele);
+    if (mutable) {
+      PyList_SET_ITEM(res, i, ele);
+    } else {
+      PyTuple_SET_ITEM(res, i, ele);
+    }
     // DECREF(ele) not required as SET_ITEM steals the ref
   }
 
   return res;
 }
 
-static PyObject *bunser_object(const char **ptr, const char *end)
+static PyObject *bunser_object(const char **ptr, const char *end,
+    int mutable)
 {
   const char *buf = *ptr;
   int64_t nitems, i;
   PyObject *res;
+  bserObject *obj;
 
   // skip array header
   buf++;
@@ -478,7 +617,14 @@ static PyObject *bunser_object(const char **ptr, const char *end)
   }
   *ptr = buf;
 
-  res = PyDict_New();
+  if (mutable) {
+    res = PyDict_New();
+  } else {
+    obj = PyObject_New(bserObject, &bserObjectType);
+    obj->keys = PyTuple_New((Py_ssize_t)nitems);
+    obj->values = PyTuple_New((Py_ssize_t)nitems);
+    res = (PyObject*)obj;
+  }
 
   for (i = 0; i < nitems; i++) {
     const char *keystr;
@@ -503,7 +649,7 @@ static PyObject *bunser_object(const char **ptr, const char *end)
       return NULL;
     }
 
-    ele = bser_loads_recursive(ptr, end);
+    ele = bser_loads_recursive(ptr, end, mutable);
 
     if (!ele) {
       Py_DECREF(key);
@@ -511,15 +657,22 @@ static PyObject *bunser_object(const char **ptr, const char *end)
       return NULL;
     }
 
-    PyDict_SetItem(res, key, ele);
-    Py_DECREF(key);
-    Py_DECREF(ele);
+    if (mutable) {
+      PyDict_SetItem(res, key, ele);
+      Py_DECREF(key);
+      Py_DECREF(ele);
+    } else {
+      /* PyTuple_SET_ITEM steals ele, key */
+      PyTuple_SET_ITEM(obj->values, i, ele);
+      PyTuple_SET_ITEM(obj->keys, i, key);
+    }
   }
 
   return res;
 }
 
-static PyObject *bunser_template(const char **ptr, const char *end)
+static PyObject *bunser_template(const char **ptr, const char *end,
+    int mutable)
 {
   const char *buf = *ptr;
   int64_t nitems, i;
@@ -537,12 +690,12 @@ static PyObject *bunser_template(const char **ptr, const char *end)
   *ptr = buf;
 
   // Load template keys
-  keys = bunser_array(ptr, end);
+  keys = bunser_array(ptr, end, mutable);
   if (!keys) {
     return NULL;
   }
 
-  numkeys = PyList_GET_SIZE(keys);
+  numkeys = PySequence_Length(keys);
 
   // Load number of array elements
   if (!bunser_int(ptr, end, &nitems)) {
@@ -563,10 +716,21 @@ static PyObject *bunser_template(const char **ptr, const char *end)
   }
 
   for (i = 0; i < nitems; i++) {
-    PyObject *obj;
+    PyObject *dict = NULL;
+    bserObject *obj = NULL;
 
-    obj = PyDict_New();
-    if (!obj) {
+    if (mutable) {
+      dict = PyDict_New();
+    } else {
+      obj = PyObject_New(bserObject, &bserObjectType);
+      if (obj) {
+        obj->keys = keys;
+        Py_INCREF(obj->keys);
+        obj->values = PyTuple_New(numkeys);
+      }
+      dict = (PyObject*)obj;
+    }
+    if (!dict) {
 fail:
       Py_DECREF(keys);
       Py_DECREF(arrval);
@@ -579,21 +743,27 @@ fail:
 
       if (**ptr == BSER_SKIP) {
         *ptr = *ptr + 1;
-        continue;
+        ele = Py_None;
+        Py_INCREF(ele);
+      } else {
+        ele = bser_loads_recursive(ptr, end, mutable);
       }
-
-      key = PyList_GET_ITEM(keys, keyidx);
-      ele = bser_loads_recursive(ptr, end);
 
       if (!ele) {
         goto fail;
       }
 
-      PyDict_SetItem(obj, key, ele);
-      Py_DECREF(ele);
+      if (mutable) {
+        key = PyList_GET_ITEM(keys, keyidx);
+        PyDict_SetItem(dict, key, ele);
+        Py_DECREF(ele);
+      } else {
+        PyTuple_SET_ITEM(obj->values, keyidx, ele);
+        // DECREF(ele) not required as SET_ITEM steals the ref
+      }
     }
 
-    PyList_SET_ITEM(arrval, i, obj);
+    PyList_SET_ITEM(arrval, i, dict);
     // DECREF(obj) not required as SET_ITEM steals the ref
   }
 
@@ -602,7 +772,8 @@ fail:
   return arrval;
 }
 
-static PyObject *bser_loads_recursive(const char **ptr, const char *end)
+static PyObject *bser_loads_recursive(const char **ptr, const char *end,
+    int mutable)
 {
   const char *buf = *ptr;
 
@@ -663,13 +834,13 @@ static PyObject *bser_loads_recursive(const char **ptr, const char *end)
       }
 
     case BSER_ARRAY:
-      return bunser_array(ptr, end);
+      return bunser_array(ptr, end, mutable);
 
     case BSER_OBJECT:
-      return bunser_object(ptr, end);
+      return bunser_object(ptr, end, mutable);
 
     case BSER_TEMPLATE:
-      return bunser_template(ptr, end);
+      return bunser_template(ptr, end, mutable);
 
     default:
       PyErr_Format(PyExc_ValueError, "unhandled bser opcode 0x%02x", buf[0]);
@@ -725,10 +896,16 @@ static PyObject *bser_loads(PyObject *self, PyObject *args)
   int datalen = 0;
   const char *end;
   int64_t expected_len;
+  int mutable = 1;
+  PyObject *mutable_obj = NULL;
 
-  if (!PyArg_ParseTuple(args, "s#", &data, &datalen)) {
+  if (!PyArg_ParseTuple(args, "s#|O:loads", &data, &datalen, &mutable_obj)) {
     return NULL;
   }
+  if (mutable_obj) {
+    mutable = PyObject_IsTrue(mutable_obj) > 0 ? 1 : 0;
+  }
+
   end = data + datalen;
 
   // Validate the header and length
@@ -751,7 +928,7 @@ static PyObject *bser_loads(PyObject *self, PyObject *args)
     return NULL;
   }
 
-  return bser_loads_recursive(&data, end);
+  return bser_loads_recursive(&data, end, mutable);
 }
 
 static PyMethodDef bser_methods[] = {
@@ -764,6 +941,7 @@ static PyMethodDef bser_methods[] = {
 PyMODINIT_FUNC initbser(void)
 {
   (void)Py_InitModule("bser", bser_methods);
+  PyType_Ready(&bserObjectType);
 }
 
 /* vim:ts=2:sw=2:et:

--- a/python/pywatchman/pybser.py
+++ b/python/pywatchman/pybser.py
@@ -213,45 +213,106 @@ def _bunser_string(buf, pos):
     return (str_val, pos + str_len)
 
 
-def _bunser_array(buf, pos):
+def _bunser_array(buf, pos, mutable=True):
     arr_len, pos = _bunser_int(buf, pos + 1)
     arr = []
     for i in range(arr_len):
-        arr_item, pos = _bser_loads_recursive(buf, pos)
+        arr_item, pos = _bser_loads_recursive(buf, pos, mutable)
         arr.append(arr_item)
+
+    if not mutable:
+      arr = tuple(arr)
+
     return arr, pos
 
 
-def _bunser_object(buf, pos):
+# This is a quack-alike with the bserObjectType in bser.c
+# It provides by getattr accessors and getitem for both index
+# and name.
+class _BunserDict(object):
+    __slots__ = ('_keys', '_values')
+
+    def __init__(self, keys, values):
+        self._keys = keys
+        self._values = values
+
+    def __getattr__(self, name):
+        try:
+            return self._values[self._keys.index(name)]
+        except ValueError as ex:
+            raise AttributeError('_BunserDict has no attribute %s' % name)
+
+    def __getitem__(self, key):
+        if isinstance(key, (int, long)):
+            return self._values[key]
+        elif key.startswith('st_'):
+            # hack^Wfeature to allow mercurial to use "st_size" to
+            # reference "size"
+            key = key[3:]
+        try:
+            return self._values[self._keys.index(key)]
+        except ValueError as ex:
+            raise KeyError('_BunserDict has no key %s' % key)
+
+    def __len__(self):
+        return len(self._keys)
+
+def _bunser_object(buf, pos, mutable=True):
     obj_len, pos = _bunser_int(buf, pos + 1)
-    obj = {}
+    if mutable:
+        obj = {}
+    else:
+        keys = []
+        vals = []
+
     for i in range(obj_len):
         key, pos = _bunser_string(buf, pos)
-        val, pos = _bser_loads_recursive(buf, pos)
-        obj[key] = val
+        val, pos = _bser_loads_recursive(buf, pos, mutable)
+        if mutable:
+            obj[key] = val
+        else:
+            keys.append(key)
+            vals.append(val)
+
+    if not mutable:
+        obj = _BunserDict(keys, vals)
+
     return obj, pos
 
 
-def _bunser_template(buf, pos):
+def _bunser_template(buf, pos, mutable=True):
     if buf[pos + 1] != BSER_ARRAY:
         raise RuntimeError('Expect ARRAY to follow TEMPLATE')
     keys, pos = _bunser_array(buf, pos + 1)
     nitems, pos = _bunser_int(buf, pos)
     arr = []
     for i in range(nitems):
-        obj = {}
+        if mutable:
+            obj = {}
+        else:
+            vals = []
+
         for keyidx in range(len(keys)):
             if buf[pos] == BSER_SKIP:
                 pos += 1
-                continue
-            key = keys[keyidx]
-            ele, pos = _bser_loads_recursive(buf, pos)
-            obj[key] = ele
+                ele = None
+            else:
+                ele, pos = _bser_loads_recursive(buf, pos, mutable)
+
+            if mutable:
+                key = keys[keyidx]
+                obj[key] = ele
+            else:
+                vals.append(ele)
+
+        if not mutable:
+            obj = _BunserDict(keys, vals)
+
         arr.append(obj)
     return arr, pos
 
 
-def _bser_loads_recursive(buf, pos):
+def _bser_loads_recursive(buf, pos, mutable=True):
     val_type = buf[pos]
     if (val_type == BSER_INT8 or val_type == BSER_INT16 or
         val_type == BSER_INT32 or val_type == BSER_INT64):
@@ -268,11 +329,11 @@ def _bser_loads_recursive(buf, pos):
     elif val_type == BSER_STRING:
         return _bunser_string(buf, pos)
     elif val_type == BSER_ARRAY:
-        return _bunser_array(buf, pos)
+        return _bunser_array(buf, pos, mutable)
     elif val_type == BSER_OBJECT:
-        return _bunser_object(buf, pos)
+        return _bunser_object(buf, pos, mutable)
     elif val_type == BSER_TEMPLATE:
-        return _bunser_template(buf, pos)
+        return _bunser_template(buf, pos, mutable)
     else:
         raise RuntimeError('unhandled bser opcode 0x%02x' % (val_type,))
 
@@ -284,10 +345,10 @@ def pdu_len(buf):
     return expected_len + pos
 
 
-def loads(buf):
+def loads(buf, mutable=True):
     if buf[0:2] != EMPTY_HEADER[0:2]:
         raise RuntimeError('Invalid BSER header')
     expected_len, pos = _bunser_int(buf, 2)
     if len(buf) != expected_len + pos:
         raise RuntimeError('bser data len != header len')
-    return _bser_loads_recursive(buf, pos)[0]
+    return _bser_loads_recursive(buf, pos, mutable)[0]

--- a/python/setup.py
+++ b/python/setup.py
@@ -22,7 +22,11 @@ setup(
     license = 'Apache License (2.0)',
     packages = ['pywatchman'],
     ext_modules = [
-        Extension('pywatchman.bser', sources = ['pywatchman/bser.c'])
+        Extension('pywatchman.bser', sources = ['pywatchman/bser.c']
+        #    ,
+        #    extra_compile_args=['-O0', '-g'],
+        #    extra_link_args=['-g']
+        )
     ],
     platforms = 'Platform Independent',
     classifiers = [

--- a/python/tests/tests.py
+++ b/python/tests/tests.py
@@ -38,10 +38,10 @@ class TestBSERDump(unittest.TestCase):
         else:
             return super(TestBSERDump, self).id()
 
-    def roundtrip(self, val):
+    def roundtrip(self, val, mutable=True):
         enc = self.bser_mod.dumps(val)
         print "# %s  -->  %s" % (val, enc.encode('hex'))
-        dec = self.bser_mod.loads(enc)
+        dec = self.bser_mod.loads(enc, mutable)
         self.assertEquals(val, dec)
 
     def munged(self, val, munged):
@@ -82,9 +82,22 @@ class TestBSERDump(unittest.TestCase):
 
     def test_tuple(self):
         self.munged((1, 2, 3), [1, 2, 3])
+        self.roundtrip((1, 2, 3), mutable=False)
 
     def test_dict(self):
         self.roundtrip({"hello": "there"})
+        obj = self.bser_mod.loads(self.bser_mod.dumps({"hello": "there"}), False)
+        self.assertEquals(1, len(obj))
+        self.assertEquals('there', obj.hello)
+        self.assertEquals('there', obj['hello'])
+        self.assertEquals('there', obj[0])
+        hello, = obj  # sequence/list assignment
+        self.assertEquals('there', hello)
+
+    def assertItemAttributes(self, dictish, attrish):
+        self.assertEquals(len(dictish), len(attrish))
+        for k, v in dictish.iteritems():
+            self.assertEquals(v, getattr(attrish, k))
 
     def test_template(self):
         # since we can't generate the template bser output, here's a
@@ -98,9 +111,13 @@ class TestBSERDump(unittest.TestCase):
         exp = [
             {"name": "fred", "age": 20},
             {"name": "pete", "age": 30},
-            {"age": 25}
+            {"name": None, "age": 25}
         ]
         self.assertEquals(exp, dec)
+        res = self.bser_mod.loads(templ, False)
+
+        for i in range(0, len(exp)):
+            self.assertItemAttributes(exp[i], res[i])
 
     def test_pdu_len(self):
         enc = self.bser_mod.dumps(1)


### PR DESCRIPTION
This adds an alternative object representation for decoded bser
values.   The new representation is immutable and can have its
properties accessed via either the mapping protocol or as attributes.

The goal is to eliminate an intermediate representation in mercurial
and just return the bser values directly in place of stat-like
objects that are manufactured by the hgwatchman extension.

This can save several seconds of runtime in hgwatchman if we adjust it
to process fresh_instance result sets with very large trees.

`bser.loads` has been augmented with an optional `mutable` flag that
defaults to `True`.   When `True` we return the same dicts and lists
of dicts that we've always done.  When `False` we return our immutable
object representation.

pybser has been updated to respect this flag also.

Test Plan: `make integration`.  I also built a debug cpython with ASAN
to verify the reference counting.