### PR TITLE
watchman: improve handling of case insensitive filenames

### DIFF
--- a/opendir.c
+++ b/opendir.c
@@ -47,143 +47,293 @@ struct watchman_dir_handle {
   struct watchman_dir_ent ent;
 };
 
-/* Opens a directory, strictly prohibiting opening any symlinks
- * in any component of the path on systems that make this
- * reasonable and easy to do.
- * We do this by opening / and then walking down the tree one
- * directory component at a time.
- * We prefer to do this rather than using realpath() and comparing
- * names for two reasons:
- * 1. We should be slightly less prone to TOCTOU issues if an element
- *    of the path is changed to a symlink in the middle of our examination
- * 2. We can terminate as soon as we discover a symlink this way, whereas
- *    realpath() would walk all the way down before it could come back to
- *    us and allow us to detect the issue.
+#ifdef _WIN32
+static const char *w_basename(const char *path) {
+  const char *last = path + strlen(path) - 1;
+  while (last >= path) {
+    if (*last == '/' || *last == '\\') {
+      return last + 1;
+    }
+    --last;
+  }
+  return NULL;
+}
+#endif
+
+static bool is_basename_canonical_case(const char *path) {
+#ifdef __APPLE__
+  struct attrlist attrlist;
+  struct {
+    uint32_t len;
+    attrreference_t ref;
+    char canonical_name[WATCHMAN_NAME_MAX];
+  } vomit;
+  char *name;
+  const char *base = strrchr(path, '/') + 1;
+
+  memset(&attrlist, 0, sizeof(attrlist));
+  attrlist.bitmapcount = ATTR_BIT_MAP_COUNT;
+  attrlist.commonattr = ATTR_CMN_NAME;
+
+  if (getattrlist(path, &attrlist, &vomit,
+        sizeof(vomit), FSOPT_NOFOLLOW) == -1) {
+    w_log(W_LOG_ERR, "getattrlist(%s) failed: %s\n",
+        path, strerror(errno));
+    return false;
+  }
+
+  name = ((char*)&vomit.ref) + vomit.ref.attr_dataoffset;
+  return strcmp(name, base) == 0;
+#elif defined(_WIN32)
+  WCHAR long_buf[WATCHMAN_NAME_MAX];
+  WCHAR *wpath = w_utf8_to_win_unc(path, -1);
+  DWORD err;
+  char *canon;
+  bool result;
+  const char *path_base;
+  const char *canon_base;
+
+  DWORD long_len = GetLongPathNameW(wpath, long_buf,
+                      sizeof(long_buf)/sizeof(long_buf[0]));
+  err = GetLastError();
+  free(wpath);
+
+  if (long_len == 0 && err == ERROR_FILE_NOT_FOUND) {
+    // signal to caller that the file has disappeared -- the caller will read
+    // errno and do error handling
+    errno = map_win32_err(err);
+    return false;
+  }
+
+  if (long_len == 0) {
+    w_log(W_LOG_ERR, "Failed to canon(%s): %s\n", path, win32_strerror(err));
+    return false;
+  }
+
+  if (long_len > sizeof(long_buf)-1) {
+    w_log(W_LOG_FATAL, "GetLongPathNameW needs %lu chars\n", long_len);
+  }
+
+  canon = w_win_unc_to_utf8(long_buf, long_len, NULL);
+  if (!canon) {
+    return false;
+  }
+
+  path_base = w_basename(path);
+  canon_base = w_basename(canon);
+  if (!path_base || !canon_base) {
+    result = false;
+  } else {
+    result = strcmp(path_base, canon_base) == 0;
+    if (!result) {
+      w_log(W_LOG_ERR,
+            "is_basename_canonical_case(%s): basename=%s != canonical "
+            "%s basename of %s\n",
+            path, path_base, canon, canon_base);
+    }
+  }
+  free(canon);
+
+  return result;
+#else
+  unused_parameter(path);
+  return true;
+#endif
+}
+
+/* Extract the canonical path of an open file descriptor and store
+ * it into the provided buffer.
+ * Unlike w_realpath, which will return an allocated buffer of the correct
+ * size, this will indicate EOVERFLOW if the buffer is too small.
+ * For our purposes this is fine: if the canonical name is larger than
+ * the input buffer it means that it does not match the path that we
+ * wanted to open; we don't care what the actual canonical path really is.
  */
-static int open_dir_as_fd_no_symlinks(const char *path, int flags) {
-#ifdef HAVE_OPENAT
-  char *pathcopy;
-  int fd = -1;
-  int err;
-  char *elem, *next;
+static int realpath_fd(int fd, char *canon, size_t canon_size) {
+#if defined(F_GETPATH)
+  unused_parameter(canon_size);
+  return fcntl(fd, F_GETPATH, canon);
+#elif defined(__linux__)
+  char procpath[1024];
+  int len;
 
-  if (path[0] != '/') {
-    errno = EINVAL;
+  snprintf(procpath, sizeof(procpath), "/proc/%d/fd/%d", getpid(), fd);
+  len = readlink(procpath, canon, canon_size);
+  if (len > 0) {
+    canon[len] = 0;
+    return 0;
+  }
+  if (errno == ENOENT) {
+    // procfs is likely not mounted, let caller fall back to realpath()
+    errno = ENOSYS;
+  }
+  return -1;
+#elif defined(_WIN32)
+  HANDLE h = (HANDLE)_get_osfhandle(fd);
+  WCHAR final_buf[WATCHMAN_NAME_MAX];
+  DWORD len, err;
+  DWORD nchars = sizeof(final_buf) / sizeof(WCHAR);
+
+  if (h == INVALID_HANDLE_VALUE) {
     return -1;
   }
 
-  if (strlen(path) == 1) {
-    // They want to open "/"
-    return open(path, O_NOFOLLOW | flags);
+  len = GetFinalPathNameByHandleW(h, final_buf, nchars, FILE_NAME_NORMALIZED);
+  err = GetLastError();
+  if (len >= nchars) {
+    errno = EOVERFLOW;
+    return -1;
+  }
+  if (len > 0) {
+    uint32_t utf_len;
+    char *utf8 = w_win_unc_to_utf8(final_buf, len, &utf_len);
+    if (!utf8) {
+      return -1;
+    }
+
+    if (utf_len + 1 > canon_size) {
+      free(utf8);
+      errno = EOVERFLOW;
+      return -1;
+    }
+
+    memcpy(canon, utf8, utf_len + 1);
+    free(utf8);
+    return 0;
   }
 
-  pathcopy = strdup(path);
-  if (!pathcopy) {
+  errno = map_win32_err(err);
+  return -1;
+#else
+  unused_parameter(canon);
+  unused_parameter(canon_size);
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+
+/* Opens a file or directory, strictly prohibiting opening any symlinks
+ * in any component of the path, and strictly matching the canonical
+ * case of the file for case insensitive filesystems.
+ */
+static int open_strict(const char *path, int flags) {
+  int fd;
+  char canon[WATCHMAN_NAME_MAX];
+  int err = 0;
+  char *pathcopy = NULL;
+
+  if (strlen(path) >= sizeof(canon)) {
+    w_log(W_LOG_ERR, "open_strict(%s): path is larger than WATCHMAN_NAME_MAX\n",
+          path);
+    errno = EOVERFLOW;
     return -1;
   }
 
-  // "/" really shouldn't be a symlink, so we shouldn't need to use NOFOLLOW
-  // here, but we do so anyway for consistency with how we open the
-  // intermediate descriptors in the loop below.
-  fd = open("/", O_NOFOLLOW | O_CLOEXEC);
+  fd = open(path, flags);
   if (fd == -1) {
+    return -1;
+  }
+
+  if (realpath_fd(fd, canon, sizeof(canon)) == 0) {
+    if (strcmp(canon, path) == 0) {
+      return fd;
+    }
+
+    w_log(W_LOG_DBG, "open_strict(%s): doesn't match canon path %s\n",
+        path, canon);
+    close(fd);
+    errno = ENOENT;
+    return -1;
+  }
+
+  if (errno != ENOSYS) {
     err = errno;
-    free(pathcopy);
+    w_log(W_LOG_ERR, "open_strict(%s): realpath_fd failed: %s\n", path,
+          strerror(err));
+    close(fd);
     errno = err;
     return -1;
   }
 
-  // "/foo/bar" means that elem -> "foo/bar"
-  elem = pathcopy + 1;
-  while (elem) {
-    int next_fd;
-
-    // if elem -> "foo/bar" we want:
-    // elem -> "foo", next -> "bar"
-    // if there is no slash, say if elem -> "bar":
-    // elem -> "bar", next -> NULL
-    next = strchr(elem, '/');
-    if (next) {
-      *next = 0;
-      next++;
-    }
-
-    // Ensure that we're CLOEXEC on all intermediate components of
-    // path, but use the flags the caller passed to us when we reach
-    // the leaf of the tree
-    next_fd = openat(fd, elem, (next ? O_CLOEXEC : flags)|O_NOFOLLOW);
-    if (next_fd == -1) {
-      err = errno;
-      close(fd);
-      free(pathcopy);
-      errno = err;
-      return -1;
-    }
-
-    // walk down to next level
-    elem = next;
+  // Fall back to realpath
+  pathcopy = w_realpath(path);
+  if (!pathcopy) {
+    err = errno;
+    w_log(W_LOG_ERR, "open_strict(%s): realpath failed: %s\n", path,
+          strerror(err));
     close(fd);
-    fd = next_fd;
+    errno = err;
+    return -1;
   }
 
-  // This was the final component in the path
+  if (strcmp(pathcopy, path)) {
+    // Doesn't match canonical case or the path we were expecting
+    w_log(W_LOG_ERR, "open_strict(%s): canonical path is %s\n",
+        path, pathcopy);
+    free(pathcopy);
+    close(fd);
+    errno = ENOENT;
+    return -1;
+  }
   free(pathcopy);
   return fd;
-#else
-  return open(path, flags);
-#endif
 }
 
 // Like lstat, but strict about symlinks in any path component
-int w_lstat(const char *path, struct stat *st) {
-#ifdef HAVE_OPENAT
-  char *pathcopy = strdup(path);
-  char *slash;
-  int dir_fd, res, err;
+int w_lstat(const char *path, struct stat *st, bool case_sensitive) {
+  char *parent, *slash;
+  int fd = -1;
+  int err, res = -1;
 
-  if (!pathcopy) {
+  parent = strdup(path);
+  if (!parent) {
     return -1;
   }
 
-  slash = strrchr(pathcopy, '/');
-  if (!slash) {
-    free(pathcopy);
-    errno = EINVAL;
-    return -1;
+  slash = strrchr(parent, '/');
+  if (slash) {
+    *slash = '\0';
   }
-
-  *slash = '\0';
-  dir_fd = open_dir_as_fd_no_symlinks(pathcopy, O_NOFOLLOW|O_CLOEXEC);
-  if (dir_fd == -1) {
-    free(pathcopy);
-    errno = ENOTDIR;
-    return -1;
+  fd = open_strict(parent, O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC );
+  if (fd == -1) {
+    err = errno;
+    goto out;
   }
 
   errno = 0;
-  res = fstatat(dir_fd, slash + 1, st, AT_SYMLINK_NOFOLLOW);
+#ifdef HAVE_OPENAT
+  res = fstatat(fd, slash + 1, st, AT_SYMLINK_NOFOLLOW);
   err = errno;
+#else
+  res = lstat(path, st);
+  err = errno;
+#endif
 
-  free(pathcopy);
-  close(dir_fd);
+  if (res == 0 && !case_sensitive && !is_basename_canonical_case(path)) {
+    res = -1;
+    err = ENOENT;
+  }
 
+out:
+  if (fd != -1) {
+    close(fd);
+  }
+  free(parent);
   errno = err;
   return res;
-#else
-  return lstat(path, st);  // tadaa!
-#endif
 }
 
 /* Opens a directory making sure it's not a symlink */
-DIR *opendir_nofollow(const char *path)
+static DIR *opendir_nofollow(const char *path)
 {
-#ifdef _WIN32
-  return win_opendir(path, 1 /* no follow */);
-#else
-  int fd = open_dir_as_fd_no_symlinks(path, O_NOFOLLOW | O_CLOEXEC);
+  int fd = open_strict(path, O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
   if (fd == -1) {
     return NULL;
   }
+#ifdef _WIN32
+  close(fd);
+  return win_opendir(path, 1 /* no follow */);
+#else
 # if !defined(HAVE_FDOPENDIR) || defined(__APPLE__)
   /* fdopendir doesn't work on earlier versions OS X, and we don't
    * use this function since 10.10, as we prefer to use getattrlistbulk
@@ -211,8 +361,7 @@ struct watchman_dir_handle *w_dir_open(const char *path) {
   if (cfg_get_bool(NULL, "_use_bulkstat", true)) {
     struct stat st;
 
-    dir->fd = open_dir_as_fd_no_symlinks(path,
-                  O_NOFOLLOW | O_CLOEXEC | O_RDONLY);
+    dir->fd = open_strict(path, O_NOFOLLOW | O_CLOEXEC | O_RDONLY);
     if (dir->fd == -1) {
       err = errno;
       free(dir);

--- a/watchman.h
+++ b/watchman.h
@@ -292,8 +292,6 @@ struct watchman_dir {
   w_string_t *path;
   /* files contained in this dir (keyed by file->name) */
   w_ht_t *files;
-  /* files contained in this dir (keyed by lc(file->name)) */
-  w_ht_t *lc_files;
   /* child dirs contained in this dir (keyed by dir->path) */
   w_ht_t *dirs;
 };
@@ -968,9 +966,8 @@ void handle_open_errno(w_root_t *root, struct watchman_dir *dir,
     struct timeval now, const char *syscall, int err,
     const char *reason);
 void stop_watching_dir(w_root_t *root, struct watchman_dir *dir);
-DIR *opendir_nofollow(const char *path);
 uint32_t u32_strlen(const char *str);
-int w_lstat(const char *path, struct stat *st);
+int w_lstat(const char *path, struct stat *st, bool case_sensitive);
 
 extern struct watchman_ops fsevents_watcher;
 extern struct watchman_ops kqueue_watcher;

--- a/winbuild/config.h
+++ b/winbuild/config.h
@@ -51,7 +51,7 @@ static inline long __sync_add_and_fetch(volatile long *target, long add) {
 }
 
 const char *win32_strerror(DWORD err);
-char *w_win_unc_to_utf8(WCHAR *wpath, int pathlen);
+char *w_win_unc_to_utf8(WCHAR *wpath, int pathlen, uint32_t *outlen);
 WCHAR *w_utf8_to_win_unc(const char *path, int pathlen);
 int map_win32_err(DWORD err);
 int map_winsock_err(void);
@@ -78,6 +78,7 @@ char *realpath(const char *filename, char *target);
 
 #define O_DIRECTORY _O_OBTAIN_DIR
 #define O_CLOEXEC _O_NOINHERIT
+#define O_NOFOLLOW 0 /* clowny, but there's no translation */
 
 typedef DWORD pid_t;
 

--- a/winbuild/pathmap.c
+++ b/winbuild/pathmap.c
@@ -16,7 +16,7 @@
 #define UNC_PREFIX L"UNC"
 #define UNC_PREFIX_LEN 3
 
-char *w_win_unc_to_utf8(WCHAR *wpath, int pathlen) {
+char *w_win_unc_to_utf8(WCHAR *wpath, int pathlen, uint32_t *outlen) {
   int len, res;
   char *buf;
   bool is_unc = false;
@@ -66,6 +66,9 @@ char *w_win_unc_to_utf8(WCHAR *wpath, int pathlen) {
   }
 
   buf[res] = 0;
+  if (outlen) {
+    *outlen = res;
+  }
   return buf;
 }
 

--- a/winbuild/realpath.c
+++ b/winbuild/realpath.c
@@ -74,7 +74,7 @@ char *realpath(const char *filename, char *target) {
     return NULL;
   }
 
-  utf8 = w_win_unc_to_utf8(final_bufptr, len);
+  utf8 = w_win_unc_to_utf8(final_bufptr, len, NULL);
   if (final_bufptr != final_buf) {
     free(final_bufptr);
   }


### PR DESCRIPTION
TL;DR:

1. Halved memory requirements for case insensitive filesystem trees
2. Halved crawl time on mac
3. Handle directory case-only-renames more reliably
4. Disable symlink re-checking (7edcb2110ee0c9121f9b7013dd4ec819407e1afc) because it is too costly in our largest repo when not using a sparse checkout

Copy-n-paste from the commit summary:

    Summary: we hit an issue where a directory rename that changed only the
    case of the dir name got us confused.  It had a bad interaction with
    the recently added symlink sanity checking code; the problem manifested
    as watchman relatively busily ping-ponging between thinking that `DIR/a`
    and `dir/a` existed.

    The heart of this issue is similar to the one that we solved with
    symlinks; at any point, any path component could have changed case, but
    on a case insensitive filesystem we can't ask the system to operate in
    case sensitive mode for a given operation.

    The resolution is similar to our resolution of the symlink issue; as we
    walk down from the root, not only do we check for symlinks, but we now
    also check the canonical case of the path component.  If what we want
    to open doesn't match the canonical case, we report ENOENT.

    This gives us a pretty decent case-sensitive stat operation (modulo
    TOCTOU, but it's no worse than our existing symlink checking).

    In our stat_path/crawler code, we check for ENOENT/ENOTDIR on case
    insensitive filesystems and use that as a signal to look in the parent
    of the item that we tried to examine.

    This serves two purposes:

    1. It allows us to discover the new canonical name by walking the dir
       contents.
    2. We can garbage collect any other similarly case-changed items in that
       dir.

    A nice side effect of this is that we can remove the relatively complex
    lc_files hash stuff; our core data structures can all be case sensitive
    and we can leave the insensitive matching to the query engine.  This
    means that we can halve the memory used to build our filesystem tree
    representation on Mac (nice!) but does make it a bit more expensive to
    crawl the filesystem.

    So, looking at perf; implementing things strictly as described above
    adds 50% to the initial crawl time for one of our large repos (so 150%
    total time vs. prior implementation).

    The original intent of the code that walks down from the root was to
    avoid going out to am expensive remote filesystem if a symlink change
    surprised us.  Since that type of change is not common, and because
    we're happy to now perform case sensitive compares on the path vs. the
    canonical path, we can switch to using a system-dependent means for
    obtaining the canonical path from an opened file descriptor.

    This switch takes us from a negative perf impact to a positive perf
    impact; 50% of the prior implementation for crawling this same large
    repo.