### PR TITLE
pybser: allow st_size in __getattr__

### DIFF
--- a/python/pywatchman/pybser.py
+++ b/python/pywatchman/pybser.py
@@ -239,10 +239,7 @@ class _BunserDict(object):
         self._values = values
 
     def __getattr__(self, name):
-        try:
-            return self._values[self._keys.index(name)]
-        except ValueError as ex:
-            raise AttributeError('_BunserDict has no attribute %s' % name)
+        return self.__getitem__(name)
 
     def __getitem__(self, key):
         if isinstance(key, (int, long)):


### PR DESCRIPTION
Fixes `AttributeError: _BunserDict has no attribute st_size` when bser.c is not
compiled. Traceback:

    File "hg/mercurial/dirstate.py", line 1101, in status
      ((size != st.st_size and size != st.st_size & _rangemask)
    File "hgwatchman/hgwatchman/pywatchman/pybser.py", line 245, in __getattr__
      raise AttributeError('_BunserDict has no attribute %s' % name)