### PR TITLE
fix off by 1 for time generator

### DIFF
--- a/query/eval.c
+++ b/query/eval.c
@@ -145,7 +145,7 @@ static bool time_generator(
       break;
     }
     if (!ctx->since.is_timestamp &&
-        f->otime.ticks < ctx->since.clock.ticks) {
+        f->otime.ticks <= ctx->since.clock.ticks) {
       break;
     }
 


### PR DESCRIPTION
@int3 noted that he sometimes receives a second run of notifications
that were part of a prior query response.  The second run is strictly
a subset of the earlier query results.

In these cases the oclock of the file results is the same in both queries and equal to the
since parameter in the second query.

This sounds like an off by one and looking a bit harder, the time
generator is terminating its walk if the oclock of the node is <
the since parameter.  It seems like the condition should be <= so
that we don't repeat a notification.

Test Plan:  `make integration` continues to pass with this change