### PR TITLE
Guard against receiving data after the socket was closed.

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -118,7 +118,9 @@ Client.prototype.connect = function() {
       self.emit('error', err);
     });
     self.socket.on('data', function(buf) {
-      self.bunser.append(buf);
+      if (self.bunser) {
+        self.bunser.append(buf);
+      }
     });
     self.socket.on('end', function() {
       self.socket = null;


### PR DESCRIPTION
I'm using this implicitly on www and it throws every time. For some reason I'm receiving data after the socket was closed (wtf?). Logging the buffer gives me this: `<Buffer 00 01 04 48 01 01 03 07 02 03 07 76 65 72 73 69 6f 6e 02 03 05 34 2e 31 2e 30 02 03 05 63 6c 6f 63 6b 02 03 1c 63 3a 31 34 35 32 35 34 36 33 31 34 3a ... >`

Is this a reasonable guard?

@wez @amasad 