### PR TITLE
Don't crash during error handling

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -203,7 +203,7 @@ Client.prototype.connect = function() {
     try {
       var obj = JSON.parse(stdout.join(''));
       if ('error' in obj) {
-        error = new Error(obj.error);
+        var error = new Error(obj.error);
         error.watchmanResponse = obj;
         self.emit('error', error);
         return;


### PR DESCRIPTION
Before:
```
[9:41:52 AM] <START> Loading bundles layout
[9:41:52 AM] <END>   Loading bundles layout (0ms)

React packager ready.

 ERROR  error is not defined
ReferenceError: error is not defined
    at ChildProcess.<anonymous> (/home/ytec/Desktop/vumc-app/node_modules/react-native/node_modules/sane/node_modules/fb-watchman/index.js:206:15)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:821:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
```

After:
```
[9:42:34 AM] <START> Loading bundles layout
[9:42:34 AM] <END>   Loading bundles layout (1ms)

React packager ready.

 ERROR  A non-recoverable condition has triggered.  Watchman needs your help!
The triggering condition was at timestamp=1452785601: inotify-add-watch(/home/ytec/Desktop/vumc-app/node_modules/eslint/node_modules/escope/node_modules/es6-weak-map/node_modules/es5-ext/test/array/#/@@iterator) -> The user limit on the total number of inotify watches was reached; increase the fs.inotify.max_user_watches sysctl
All requests will continue to fail with this message until you resolve
the underlying problem.  You will find more information on fixing this at
https://facebook.github.io/watchman/docs/troubleshooting.html#poison-inotify-add-watch
```