### PR TITLE
inotify: don't unconditionally set the recursive flag

### DIFF
--- a/watcher/inotify.c
+++ b/watcher/inotify.c
@@ -366,8 +366,7 @@ static void process_inotify_event(
 
       w_log(W_LOG_DBG, "add_pending for inotify mask=%x %.*s\n",
           ine->mask, name->len, name->buf);
-      w_pending_coll_add(coll, name, now,
-          W_PENDING_RECURSIVE|W_PENDING_VIA_NOTIFY);
+      w_pending_coll_add(coll, name, now, W_PENDING_VIA_NOTIFY);
 
       w_string_delref(name);
 


### PR DESCRIPTION
Summary: durham noticed that calls to `clock` were taking 6 seconds to
return during some rebase profiling with hgwatchman.  Looking deeper,
we're doing a lot of recursive walking.  I don't recall why we were
setting recursive to true here, but turning it off seems to have no
negative side effects; the watchman integration tests pass, as do
the mercurial tests.

Test plan: ran hgwatchman + hg tests, `make integration` passes,
corrected the slow rebase behavior.  Let's see what Travis CI makes of
it.