### PR TITLE
travis: restore dumping error logs on test failure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,7 +125,7 @@ py-tests:
 	$(PYTHON) $(TESTNAME)
 
 py-integration:
-	$(PYTHON) runtests.py
+	$(PYTHON) runtests.py --keep-if-fail
 
 py-clean:
 	-cd python && $(PYTHON) ./setup.py clean --all

--- a/root.c
+++ b/root.c
@@ -1805,6 +1805,7 @@ static void io_thread(w_root_t *root)
       }
       w_root_lock(root);
       gettimeofday(&start, NULL);
+      root->ticks++;
       w_pending_coll_add(&root->pending, root->root_path, start, 0);
       while (w_root_process_pending(root, &pending, true)) {
         ;

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -15,11 +15,12 @@ make clean
 make
 set +e
 rm -rf /tmp/watchman*
+rm -rf /var/tmp/watchmantest*
 TMPDIR=/var/tmp
 TMP=/var/tmp
 export TMPDIR TMP
 if ! make integration ; then
-  cat /tmp/watchman*
+  find /var/tmp/watchmantest* -name log | xargs cat
   exit 1
 fi
 


### PR DESCRIPTION
Trying to understand a test failure on Travis and noticed that our logs
aren't where they used to be