### PR TITLE
Allow selecting the watcher for a watch

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,7 @@ watchman_SOURCES = \
 	query/fieldlist.c  \
 	query/since.c      \
 	query/empty.c      \
+	watcher/auto.c     \
 	watcher/fsevents.c \
 	watcher/helper.c   \
 	watcher/inotify.c  \

--- a/cmds/watch.c
+++ b/cmds/watch.c
@@ -314,6 +314,7 @@ static void cmd_watch(struct watchman_client *client, json_t *args)
     set_prop(resp, "error", json_string_nocheck("root was cancelled"));
   } else {
     set_prop(resp, "watch", w_string_to_json(root->root_path));
+    set_prop(resp, "watcher", json_string_nocheck(root->watcher_ops->name));
   }
   add_root_warnings_to_response(resp, root);
   send_and_dispose_response(client, resp);
@@ -361,6 +362,7 @@ static void cmd_watch_project(struct watchman_client *client, json_t *args)
     set_prop(resp, "error", json_string_nocheck("root was cancelled"));
   } else {
     set_prop(resp, "watch", w_string_to_json(root->root_path));
+    set_prop(resp, "watcher", json_string_nocheck(root->watcher_ops->name));
   }
   add_root_warnings_to_response(resp, root);
   if (rel_path_from_watch) {

--- a/main.c
+++ b/main.c
@@ -78,7 +78,6 @@ static void run_service(void)
 
   watchman_watcher_init();
   res = w_start_listener(sock_name);
-  watchman_watcher_dtor();
 
   if (res) {
     exit(0);

--- a/tests/integration/movereadd.php
+++ b/tests/integration/movereadd.php
@@ -37,9 +37,9 @@ class movereaddTestCase extends WatchmanTestCase {
     mkdir("$root/foo/bar");
 
     $since = array('foo/bar');
-    if (PHP_OS == 'SunOS' || phutil_is_windows()) {
-      // This makes me sad, but Solaris reports the parent dir
-      // as changed when we mkdir within it
+    if (in_array($watch['watcher'], array('win32', 'portfs',
+        'kqueue'))) {
+      // the parent dir reflects as changed when we mkdir within it
       array_unshift($since, 'foo');
     }
 

--- a/tests/integration/test_since.py
+++ b/tests/integration/test_since.py
@@ -30,7 +30,7 @@ class TestSince(WatchmanTestCase.WatchmanTestCase):
 
     def test_sinceIssue2(self):
         root = self.mkdtemp()
-        self.watchmanCommand('watch', root)
+        watch = self.watchmanCommand('watch', root)
         self.assertFileList(root, files=[])
 
         foo_dir = os.path.join(root, 'foo')
@@ -53,7 +53,7 @@ class TestSince(WatchmanTestCase.WatchmanTestCase):
 
         # now check the delta for the since
         expected = ['foo/bar', 'foo/bar/222']
-        if os.name == 'nt' or os.uname()[0] == 'SunOS':
+        if watch['watcher'] in ('win32', 'portfs', 'kqueue'):
             # These systems also show the containing dir as modified
             expected.append('foo')
         self.assertFileList(root, cursor='n:foo', files=expected)

--- a/watcher/auto.c
+++ b/watcher/auto.c
@@ -1,0 +1,36 @@
+/* Copyright 2012-present Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 */
+#include "watchman.h"
+
+static struct watchman_ops *default_watcher_ops =
+#if HAVE_FSEVENTS
+   &fsevents_watcher;
+#elif defined(HAVE_PORT_CREATE)
+  // We prefer portfs if you have both portfs and inotify on the assumption
+  // that this is an Illumos based system with both and that the native
+  // mechanism will yield more correct behavior.
+  // https://github.com/facebook/watchman/issues/84
+  &portfs_watcher;
+#elif defined(HAVE_INOTIFY_INIT)
+  &inotify_watcher;
+#elif defined(HAVE_KQUEUE)
+  &kqueue_watcher;
+#elif defined(_WIN32)
+  &win32_watcher;
+#else
+# error you need to assign watcher_ops for this system
+#endif
+
+bool w_watcher_init(w_root_t *root, char **errmsg) {
+  root->watcher_ops = default_watcher_ops;
+
+  if (!root->watcher_ops->root_init(root, errmsg)) {
+    return false;
+  }
+
+  w_log(W_LOG_ERR, "Using watcher mechanism %s\n", root->watcher_ops->name);
+  return true;
+}
+
+/* vim:ts=2:sw=2:et:
+ */

--- a/watcher/auto.c
+++ b/watcher/auto.c
@@ -2,33 +2,97 @@
  * Licensed under the Apache License, Version 2.0 */
 #include "watchman.h"
 
-static struct watchman_ops *default_watcher_ops =
+// These are listed in order of preference in the case that a
+// given system offers multiple choices
+static struct watchman_ops *available_watchers[] = {
 #if HAVE_FSEVENTS
-   &fsevents_watcher;
-#elif defined(HAVE_PORT_CREATE)
+  &fsevents_watcher,
+#endif
+#if defined(HAVE_PORT_CREATE)
   // We prefer portfs if you have both portfs and inotify on the assumption
   // that this is an Illumos based system with both and that the native
   // mechanism will yield more correct behavior.
   // https://github.com/facebook/watchman/issues/84
-  &portfs_watcher;
-#elif defined(HAVE_INOTIFY_INIT)
-  &inotify_watcher;
-#elif defined(HAVE_KQUEUE)
-  &kqueue_watcher;
-#elif defined(_WIN32)
-  &win32_watcher;
-#else
-# error you need to assign watcher_ops for this system
+  &portfs_watcher,
 #endif
+#if defined(HAVE_INOTIFY_INIT)
+  &inotify_watcher,
+#endif
+#if defined(HAVE_KQUEUE)
+  &kqueue_watcher,
+#endif
+#if defined(_WIN32)
+  &win32_watcher,
+#endif
+  NULL
+};
 
 bool w_watcher_init(w_root_t *root, char **errmsg) {
-  root->watcher_ops = default_watcher_ops;
+  const char *watcher_name = cfg_get_string(root, "watcher", "auto");
+  struct watchman_ops *ops = NULL;
+  char *first_err = NULL;
+  int i;
 
-  if (!root->watcher_ops->root_init(root, errmsg)) {
+  root->watcher_ops = NULL;
+
+  if (strcmp(watcher_name, "auto")) {
+    // If they asked for a specific one, let's try to find it
+    for (i = 0; available_watchers[i]; i++) {
+      if (strcmp(available_watchers[i]->name, watcher_name)) {
+        continue;
+      }
+      ops = available_watchers[i];
+
+      if (ops->root_init(root, &first_err)) {
+        root->watcher_ops = ops;
+        goto done;
+      }
+    }
+  }
+
+  // The auto, or fallback behavior
+  for (i = 0; available_watchers[i]; i++) {
+    char *err = NULL;
+
+    if (ops == available_watchers[i]) {
+      // Already tried this one above
+      continue;
+    }
+
+    if (available_watchers[i]->root_init(root, &err)) {
+      root->watcher_ops = available_watchers[i];
+      goto done;
+    }
+
+    if (first_err) {
+      char *tmp = NULL;
+
+      ignore_result(asprintf(&tmp, "%s. %s", first_err, err));
+      free(err);
+      free(first_err);
+      first_err = tmp;
+    } else {
+      first_err = err;
+    }
+  }
+
+  if (!root->watcher_ops) {
+    if (first_err) {
+      *errmsg = first_err;
+    } else {
+      // Unpossible!
+      ignore_result(asprintf(errmsg,
+            "No watchers available on this system!?"));
+    }
     return false;
   }
 
-  w_log(W_LOG_ERR, "Using watcher mechanism %s\n", root->watcher_ops->name);
+done:
+  w_log(W_LOG_ERR, "root %.*s using watcher mechanism %s (%s was requested)\n",
+      root->root_path->len, root->root_path->buf,
+      root->watcher_ops->name,
+      watcher_name);
+  free(first_err);
   return true;
 }
 

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -247,15 +247,14 @@ done:
   return NULL;
 }
 
-static bool fsevents_root_consume_notify(watchman_global_watcher_t watcher,
-    w_root_t *root, struct watchman_pending_collection *coll)
+static bool fsevents_root_consume_notify(w_root_t *root,
+    struct watchman_pending_collection *coll)
 {
   struct watchman_fsevent *head, *evt;
   int n = 0;
   struct timeval now;
   bool recurse;
   struct fsevents_root_state *state = root->watch;
-  unused_parameter(watcher);
 
   pthread_mutex_lock(&state->fse_mtx);
   head = state->fse_head;
@@ -313,18 +312,8 @@ break_out:
   return n > 0;
 }
 
-watchman_global_watcher_t fsevents_global_init(void) {
-  return NULL;
-}
-
-void fsevents_global_dtor(watchman_global_watcher_t watcher) {
-  unused_parameter(watcher);
-}
-
-bool fsevents_root_init(watchman_global_watcher_t watcher, w_root_t *root,
-    char **errmsg) {
+bool fsevents_root_init(w_root_t *root, char **errmsg) {
   struct fsevents_root_state *state;
-  unused_parameter(watcher);
 
   state = calloc(1, sizeof(*state));
   if (!state) {
@@ -347,9 +336,8 @@ bool fsevents_root_init(watchman_global_watcher_t watcher, w_root_t *root,
   return true;
 }
 
-void fsevents_root_dtor(watchman_global_watcher_t watcher, w_root_t *root) {
+void fsevents_root_dtor(w_root_t *root) {
   struct fsevents_root_state *state = root->watch;
-  unused_parameter(watcher);
 
   if (!state) {
     return;
@@ -378,19 +366,15 @@ void fsevents_root_dtor(watchman_global_watcher_t watcher, w_root_t *root) {
   root->watch = NULL;
 }
 
-static void fsevents_root_signal_threads(watchman_global_watcher_t watcher,
-    w_root_t *root) {
+static void fsevents_root_signal_threads(w_root_t *root) {
   struct fsevents_root_state *state = root->watch;
-  unused_parameter(watcher);
 
   write(state->fse_pipe[1], "X", 1);
 }
 
-static bool fsevents_root_start(watchman_global_watcher_t watcher,
-    w_root_t *root) {
+static bool fsevents_root_start(w_root_t *root) {
   int err;
   struct fsevents_root_state *state = root->watch;
-  unused_parameter(watcher);
 
   // Spin up the fsevents processing thread; it owns a ref on the root
   w_root_addref(root);
@@ -418,12 +402,10 @@ static bool fsevents_root_start(watchman_global_watcher_t watcher,
   return false;
 }
 
-static bool fsevents_root_wait_notify(watchman_global_watcher_t watcher,
-    w_root_t *root, int timeoutms) {
+static bool fsevents_root_wait_notify(w_root_t *root, int timeoutms) {
   struct fsevents_root_state *state = root->watch;
   struct timeval now, delta, target;
   struct timespec ts;
-  unused_parameter(watcher);
 
   if (timeoutms == 0 || state->fse_head) {
     return state->fse_head ? true : false;
@@ -442,27 +424,23 @@ static bool fsevents_root_wait_notify(watchman_global_watcher_t watcher,
   return state->fse_head ? true : false;
 }
 
-static bool fsevents_root_start_watch_file(watchman_global_watcher_t watcher,
-      w_root_t *root, struct watchman_file *file) {
-  unused_parameter(watcher);
+static bool fsevents_root_start_watch_file(w_root_t *root,
+    struct watchman_file *file) {
   unused_parameter(root);
   unused_parameter(file);
   return true;
 }
 
-static void fsevents_root_stop_watch_file(watchman_global_watcher_t watcher,
-      w_root_t *root, struct watchman_file *file) {
-  unused_parameter(watcher);
+static void fsevents_root_stop_watch_file(w_root_t *root,
+    struct watchman_file *file) {
   unused_parameter(root);
   unused_parameter(file);
 }
 
 static struct watchman_dir_handle *fsevents_root_start_watch_dir(
-      watchman_global_watcher_t watcher,
       w_root_t *root, struct watchman_dir *dir, struct timeval now,
       const char *path) {
   struct watchman_dir_handle *osdir;
-  unused_parameter(watcher);
 
   osdir = w_dir_open(path);
   if (!osdir) {
@@ -473,16 +451,13 @@ static struct watchman_dir_handle *fsevents_root_start_watch_dir(
   return osdir;
 }
 
-static void fsevents_root_stop_watch_dir(watchman_global_watcher_t watcher,
-      w_root_t *root, struct watchman_dir *dir) {
-  unused_parameter(watcher);
+static void fsevents_root_stop_watch_dir(w_root_t *root,
+    struct watchman_dir *dir) {
   unused_parameter(root);
   unused_parameter(dir);
 }
 
-static void fsevents_file_free(watchman_global_watcher_t watcher,
-    struct watchman_file *file) {
-  unused_parameter(watcher);
+static void fsevents_file_free(struct watchman_file *file) {
   unused_parameter(file);
 }
 
@@ -490,8 +465,6 @@ struct watchman_ops fsevents_watcher = {
   "fsevents",
   WATCHER_HAS_PER_FILE_NOTIFICATIONS|
     WATCHER_COALESCED_RENAME,
-  fsevents_global_init,
-  fsevents_global_dtor,
   fsevents_root_init,
   fsevents_root_start,
   fsevents_root_dtor,

--- a/watcher/inotify.c
+++ b/watcher/inotify.c
@@ -84,14 +84,6 @@ static const struct watchman_hash_funcs move_hash_funcs = {
   del_pending   // del_val
 };
 
-watchman_global_watcher_t inot_global_init(void) {
-  return NULL;
-}
-
-void inot_global_dtor(watchman_global_watcher_t watcher) {
-  unused_parameter(watcher);
-}
-
 static const char *inot_strerror(int err) {
   switch (err) {
     case EMFILE:
@@ -111,10 +103,9 @@ static const char *inot_strerror(int err) {
   }
 }
 
-bool inot_root_init(watchman_global_watcher_t watcher, w_root_t *root,
-    char **errmsg) {
+bool inot_root_init(w_root_t *root, char **errmsg) {
   struct inot_root_state *state;
-  unused_parameter(watcher);
+
 
   state = calloc(1, sizeof(*state));
   if (!state) {
@@ -142,9 +133,9 @@ bool inot_root_init(watchman_global_watcher_t watcher, w_root_t *root,
   return true;
 }
 
-void inot_root_dtor(watchman_global_watcher_t watcher, w_root_t *root) {
+void inot_root_dtor(w_root_t *root) {
   struct inot_root_state *state = root->watch;
-  unused_parameter(watcher);
+
 
   if (!state) {
     return;
@@ -167,42 +158,35 @@ void inot_root_dtor(watchman_global_watcher_t watcher, w_root_t *root) {
   root->watch = NULL;
 }
 
-static void inot_root_signal_threads(watchman_global_watcher_t watcher,
-    w_root_t *root) {
-  unused_parameter(watcher);
+static void inot_root_signal_threads(w_root_t *root) {
   unused_parameter(root);
 }
 
-static bool inot_root_start(watchman_global_watcher_t watcher, w_root_t *root) {
-  unused_parameter(watcher);
+static bool inot_root_start(w_root_t *root) {
   unused_parameter(root);
 
   return true;
 }
 
-static bool inot_root_start_watch_file(watchman_global_watcher_t watcher,
-      w_root_t *root, struct watchman_file *file) {
-  unused_parameter(watcher);
+static bool inot_root_start_watch_file(w_root_t *root,
+    struct watchman_file *file) {
   unused_parameter(root);
   unused_parameter(file);
   return true;
 }
 
-static void inot_root_stop_watch_file(watchman_global_watcher_t watcher,
-      w_root_t *root, struct watchman_file *file) {
-  unused_parameter(watcher);
+static void inot_root_stop_watch_file(w_root_t *root,
+    struct watchman_file *file) {
   unused_parameter(root);
   unused_parameter(file);
 }
 
 static struct watchman_dir_handle *inot_root_start_watch_dir(
-    watchman_global_watcher_t watcher,
     w_root_t *root, struct watchman_dir *dir, struct timeval now,
     const char *path) {
   struct inot_root_state *state = root->watch;
   struct watchman_dir_handle *osdir = NULL;
   int newwd, err;
-  unused_parameter(watcher);
 
   // Carry out our very strict opendir first to ensure that we're not
   // traversing symlinks in the context of this root
@@ -239,10 +223,9 @@ static struct watchman_dir_handle *inot_root_start_watch_dir(
   return osdir;
 }
 
-static void inot_root_stop_watch_dir(watchman_global_watcher_t watcher,
-      w_root_t *root, struct watchman_dir *dir) {
+static void inot_root_stop_watch_dir(w_root_t *root,
+    struct watchman_dir *dir) {
   struct inot_root_state *state = root->watch;
-  unused_parameter(watcher);
   unused_parameter(state);
   unused_parameter(root);
   unused_parameter(dir);
@@ -399,15 +382,14 @@ static void process_inotify_event(
   }
 }
 
-static bool inot_root_consume_notify(watchman_global_watcher_t watcher,
-    w_root_t *root, struct watchman_pending_collection *coll)
+static bool inot_root_consume_notify(w_root_t *root,
+    struct watchman_pending_collection *coll)
 {
   struct inot_root_state *state = root->watch;
   struct inotify_event *ine;
   char *iptr;
   int n;
   struct timeval now;
-  unused_parameter(watcher);
 
   n = read(state->infd, &state->ibuf, sizeof(state->ibuf));
   if (n == -1) {
@@ -457,12 +439,10 @@ static bool inot_root_consume_notify(watchman_global_watcher_t watcher,
   return true;
 }
 
-static bool inot_root_wait_notify(watchman_global_watcher_t watcher,
-    w_root_t *root, int timeoutms) {
+static bool inot_root_wait_notify(w_root_t *root, int timeoutms) {
   struct inot_root_state *state = root->watch;
   int n;
   struct pollfd pfd;
-  unused_parameter(watcher);
 
   pfd.fd = state->infd;
   pfd.events = POLLIN;
@@ -472,17 +452,13 @@ static bool inot_root_wait_notify(watchman_global_watcher_t watcher,
   return n == 1;
 }
 
-static void inot_file_free(watchman_global_watcher_t watcher,
-    struct watchman_file *file) {
-  unused_parameter(watcher);
+static void inot_file_free(struct watchman_file *file) {
   unused_parameter(file);
 }
 
 struct watchman_ops inotify_watcher = {
   "inotify",
   WATCHER_HAS_PER_FILE_NOTIFICATIONS,
-  inot_global_init,
-  inot_global_dtor,
   inot_root_init,
   inot_root_start,
   inot_root_dtor,

--- a/watcher/kqueue.c
+++ b/watcher/kqueue.c
@@ -43,18 +43,8 @@ const struct watchman_hash_funcs name_to_fd_funcs = {
   kqueue_del_key,
 };
 
-watchman_global_watcher_t kqueue_global_init(void) {
-  return NULL;
-}
-
-void kqueue_global_dtor(watchman_global_watcher_t watcher) {
-  unused_parameter(watcher);
-}
-
-bool kqueue_root_init(watchman_global_watcher_t watcher, w_root_t *root,
-    char **errmsg) {
+bool kqueue_root_init(w_root_t *root, char **errmsg) {
   struct kqueue_root_state *state;
-  unused_parameter(watcher);
 
   state = calloc(1, sizeof(*state));
   if (!state) {
@@ -78,9 +68,8 @@ bool kqueue_root_init(watchman_global_watcher_t watcher, w_root_t *root,
   return true;
 }
 
-void kqueue_root_dtor(watchman_global_watcher_t watcher, w_root_t *root) {
+void kqueue_root_dtor(w_root_t *root) {
   struct kqueue_root_state *state = root->watch;
-  unused_parameter(watcher);
 
   if (!state) {
     return;
@@ -96,28 +85,23 @@ void kqueue_root_dtor(watchman_global_watcher_t watcher, w_root_t *root) {
   root->watch = NULL;
 }
 
-static void kqueue_root_signal_threads(watchman_global_watcher_t watcher,
-    w_root_t *root) {
-  unused_parameter(watcher);
+static void kqueue_root_signal_threads(w_root_t *root) {
   unused_parameter(root);
 }
 
-static bool kqueue_root_start(watchman_global_watcher_t watcher,
-    w_root_t *root) {
-  unused_parameter(watcher);
+static bool kqueue_root_start(w_root_t *root) {
   unused_parameter(root);
 
   return true;
 }
 
-static bool kqueue_root_start_watch_file(watchman_global_watcher_t watcher,
+static bool kqueue_root_start_watch_file(
       w_root_t *root, struct watchman_file *file) {
   struct kqueue_root_state *state = root->watch;
   struct kevent k;
   w_ht_val_t fdval;
   int fd;
   w_string_t *full_name;
-  unused_parameter(watcher);
 
   full_name = w_string_path_cat(file->parent->path, file->name);
   pthread_mutex_lock(&state->lock);
@@ -164,15 +148,13 @@ static bool kqueue_root_start_watch_file(watchman_global_watcher_t watcher,
   return true;
 }
 
-static void kqueue_root_stop_watch_file(watchman_global_watcher_t watcher,
+static void kqueue_root_stop_watch_file(
     w_root_t *root, struct watchman_file *file) {
-  unused_parameter(watcher);
   unused_parameter(root);
   unused_parameter(file);
 }
 
 static struct watchman_dir_handle *kqueue_root_start_watch_dir(
-    watchman_global_watcher_t watcher,
     w_root_t *root, struct watchman_dir *dir, struct timeval now,
     const char *path) {
   struct kqueue_root_state *state = root->watch;
@@ -180,7 +162,6 @@ static struct watchman_dir_handle *kqueue_root_start_watch_dir(
   struct stat st, osdirst;
   struct kevent k;
   int newwd;
-  unused_parameter(watcher);
 
   osdir = w_dir_open(path);
   if (!osdir) {
@@ -243,14 +224,13 @@ static struct watchman_dir_handle *kqueue_root_start_watch_dir(
   return osdir;
 }
 
-static void kqueue_root_stop_watch_dir(watchman_global_watcher_t watcher,
+static void kqueue_root_stop_watch_dir(
     w_root_t *root, struct watchman_dir *dir) {
-  unused_parameter(watcher);
   unused_parameter(root);
   unused_parameter(dir);
 }
 
-static bool kqueue_root_consume_notify(watchman_global_watcher_t watcher,
+static bool kqueue_root_consume_notify(
     w_root_t *root, struct watchman_pending_collection *coll)
 {
   struct kqueue_root_state *state = root->watch;
@@ -258,7 +238,6 @@ static bool kqueue_root_consume_notify(watchman_global_watcher_t watcher,
   int i;
   struct timespec ts = { 0, 0 };
   struct timeval now;
-  unused_parameter(watcher);
 
   errno = 0;
   n = kevent(state->kq_fd, NULL, 0,
@@ -323,12 +302,11 @@ static bool kqueue_root_consume_notify(watchman_global_watcher_t watcher,
   return n > 0;
 }
 
-static bool kqueue_root_wait_notify(watchman_global_watcher_t watcher,
+static bool kqueue_root_wait_notify(
     w_root_t *root, int timeoutms) {
   struct kqueue_root_state *state = root->watch;
   int n;
   struct pollfd pfd;
-  unused_parameter(watcher);
 
   pfd.fd = state->kq_fd;
   pfd.events = POLLIN;
@@ -338,17 +316,13 @@ static bool kqueue_root_wait_notify(watchman_global_watcher_t watcher,
   return n == 1;
 }
 
-static void kqueue_file_free(watchman_global_watcher_t watcher,
-    struct watchman_file *file) {
-  unused_parameter(watcher);
+static void kqueue_file_free(struct watchman_file *file) {
   unused_parameter(file);
 }
 
 struct watchman_ops kqueue_watcher = {
   "kqueue",
   0,
-  kqueue_global_init,
-  kqueue_global_dtor,
   kqueue_root_init,
   kqueue_root_start,
   kqueue_root_dtor,

--- a/watcher/portfs.c
+++ b/watcher/portfs.c
@@ -71,18 +71,9 @@ const struct watchman_hash_funcs port_file_funcs = {
   portfs_del_port_file,
 };
 
-watchman_global_watcher_t portfs_global_init(void) {
-  return NULL;
-}
-
-void portfs_global_dtor(watchman_global_watcher_t watcher) {
-  unused_parameter(watcher);
-}
-
-bool portfs_root_init(watchman_global_watcher_t watcher, w_root_t *root,
-    char **errmsg) {
+bool portfs_root_init(w_root_t *root, char **errmsg) {
   struct portfs_root_state *state;
-  unused_parameter(watcher);
+
 
   state = calloc(1, sizeof(*state));
   if (!state) {
@@ -106,9 +97,8 @@ bool portfs_root_init(watchman_global_watcher_t watcher, w_root_t *root,
   return true;
 }
 
-void portfs_root_dtor(watchman_global_watcher_t watcher, w_root_t *root) {
+void portfs_root_dtor(w_root_t *root) {
   struct portfs_root_state *state = root->watch;
-  unused_parameter(watcher);
 
   if (!state) {
     return;
@@ -123,15 +113,11 @@ void portfs_root_dtor(watchman_global_watcher_t watcher, w_root_t *root) {
   root->watch = NULL;
 }
 
-static void portfs_root_signal_threads(watchman_global_watcher_t watcher,
-    w_root_t *root) {
-  unused_parameter(watcher);
+static void portfs_root_signal_threads(w_root_t *root) {
   unused_parameter(root);
 }
 
-static bool portfs_root_start(watchman_global_watcher_t watcher,
-    w_root_t *root) {
-  unused_parameter(watcher);
+static bool portfs_root_start(w_root_t *root) {
   unused_parameter(root);
 
   return true;
@@ -177,13 +163,11 @@ out:
   return success;
 }
 
-static bool portfs_root_start_watch_file(watchman_global_watcher_t watcher,
-    w_root_t *root, struct watchman_file *file) {
+static bool portfs_root_start_watch_file(w_root_t *root,
+    struct watchman_file *file) {
   struct portfs_root_state *state = root->watch;
   w_string_t *name;
   bool success = false;
-
-  unused_parameter(watcher);
 
   name = w_string_path_cat(file->parent->path, file->name);
   if (!name) {
@@ -195,21 +179,18 @@ static bool portfs_root_start_watch_file(watchman_global_watcher_t watcher,
   return success;
 }
 
-static void portfs_root_stop_watch_file(watchman_global_watcher_t watcher,
-      w_root_t *root, struct watchman_file *file) {
-  unused_parameter(watcher);
+static void portfs_root_stop_watch_file(w_root_t *root,
+    struct watchman_file *file) {
   unused_parameter(root);
   unused_parameter(file);
 }
 
 static struct watchman_dir_handle *portfs_root_start_watch_dir(
-    watchman_global_watcher_t watcher,
     w_root_t *root, struct watchman_dir *dir, struct timeval now,
     const char *path) {
   struct portfs_root_state *state = root->watch;
   struct watchman_dir_handle *osdir;
   struct stat st;
-  unused_parameter(watcher);
 
   osdir = w_dir_open(path);
   if (!osdir) {
@@ -234,20 +215,18 @@ static struct watchman_dir_handle *portfs_root_start_watch_dir(
   return osdir;
 }
 
-static void portfs_root_stop_watch_dir(watchman_global_watcher_t watcher,
-      w_root_t *root, struct watchman_dir *dir) {
-  unused_parameter(watcher);
+static void portfs_root_stop_watch_dir(w_root_t *root,
+    struct watchman_dir *dir) {
   unused_parameter(root);
   unused_parameter(dir);
 }
 
-static bool portfs_root_consume_notify(watchman_global_watcher_t watcher,
-    w_root_t *root, struct watchman_pending_collection *coll)
+static bool portfs_root_consume_notify(w_root_t *root,
+    struct watchman_pending_collection *coll)
 {
   struct portfs_root_state *state = root->watch;
   uint_t i, n;
   struct timeval now;
-  unused_parameter(watcher);
 
   errno = 0;
 
@@ -303,12 +282,10 @@ static bool portfs_root_consume_notify(watchman_global_watcher_t watcher,
   return true;
 }
 
-static bool portfs_root_wait_notify(watchman_global_watcher_t watcher,
-    w_root_t *root, int timeoutms) {
+static bool portfs_root_wait_notify(w_root_t *root, int timeoutms) {
   struct portfs_root_state *state = root->watch;
   int n;
   struct pollfd pfd;
-  unused_parameter(watcher);
 
   pfd.fd = state->port_fd;
   pfd.events = POLLIN;
@@ -318,17 +295,13 @@ static bool portfs_root_wait_notify(watchman_global_watcher_t watcher,
   return n == 1;
 }
 
-static void portfs_file_free(watchman_global_watcher_t watcher,
-    struct watchman_file *file) {
-  unused_parameter(watcher);
+static void portfs_file_free(struct watchman_file *file) {
   unused_parameter(file);
 }
 
 struct watchman_ops portfs_watcher = {
   "portfs",
   0,
-  portfs_global_init,
-  portfs_global_dtor,
   portfs_root_init,
   portfs_root_start,
   portfs_root_dtor,

--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -76,6 +76,7 @@ SRCS=\
 	query\intcompare.c  \
 	query\since.c      \
 	query\empty.c      \
+	watcher\auto.c \
 	watcher\win32.c \
 	watcher\helper.c \
 	listener.c   \


### PR DESCRIPTION
These two commits are prep to allow enabling an alternative watcher that will help us work around the apple bug at the root of https://github.com/facebook/watchman/issues/172

The first of these commits is a refactor to allow selecting an alternative watcher implementation from the default, and the second actually wires up the selection to a configuration option.

The configuration can be specified in the watchmanconfig, falling back to the global configuration file.
This will also enable the addition of a polling watcher, as mentioned in https://github.com/facebook/watchman/issues/201