### PR TITLE
WIP: fix up named pipes on windows

### DIFF
--- a/arcanist/__phutil_library_map__.php
+++ b/arcanist/__phutil_library_map__.php
@@ -27,11 +27,14 @@ phutil_register_library_map(array(
   array(
     'execx' => 'lib/WatchmanInstance.php',
     'w_find_subdata_containing_file' => 'lib/WatchmanTestCase.php',
+    'w_is_file_in_file_list' => 'lib/WatchmanTestCase.php',
     'w_is_same_file_list' => 'lib/WatchmanTestCase.php',
     'w_is_same_filename' => 'lib/WatchmanTestCase.php',
     'w_normalize_file_list' => 'lib/WatchmanTestCase.php',
     'w_normalize_filename' => 'lib/WatchmanTestCase.php',
     'w_rmdir_recursive' => 'lib/WatchmanDirectoryFixture.php',
+    'w_rmdir_recursive_inner' => 'lib/WatchmanDirectoryFixture.php',
+    'w_unlink' => 'lib/WatchmanTestCase.php',
   ),
   'xmap' =>
   array(

--- a/cmds/reg.c
+++ b/cmds/reg.c
@@ -149,7 +149,9 @@ bool dispatch_command(struct watchman_client *client, json_t *args, int mode)
     return false;
   }
 
+  w_log(W_LOG_DBG, "dispatch_command: %s\n", def->name);
   def->func(client, args);
+  w_log(W_LOG_DBG, "dispatch_command: %s (completed)\n", def->name);
   return true;
 }
 

--- a/root.c
+++ b/root.c
@@ -1974,6 +1974,7 @@ void w_root_delref(w_root_t *root)
 
   w_log(W_LOG_DBG, "root: final ref on %s\n",
       root->root_path->buf);
+  w_cancel_subscriptions_for_root(root);
 
   w_root_teardown(root);
 

--- a/runtests.py
+++ b/runtests.py
@@ -368,6 +368,11 @@ while not results_queue.empty():
 print('Ran %d, failed %d, skipped %d, concurrency %d' % (
     tests_run, tests_failed, tests_skipped, args.concurrency))
 
+if 'APPVEYOR' in os.environ:
+    shutil.copytree(temp_dir, 'logs')
+    subprocess.call(['7z', 'a', 'logs.zip', 'logs'])
+    subprocess.call(['appveyor', 'PushArtifact', 'logs.zip'])
+
 if tests_failed or (tests_run == 0):
     if args.keep_if_fail:
         args.keep = True

--- a/tests/integration/WatchmanInstance.py
+++ b/tests/integration/WatchmanInstance.py
@@ -9,6 +9,8 @@ import pywatchman
 import time
 import threading
 import uuid
+import traceback
+import sys
 
 tls = threading.local()
 
@@ -29,6 +31,7 @@ class Instance(object):
         self.base_dir = tempfile.mkdtemp(prefix='inst')
         self.cfg_file = os.path.join(self.base_dir, "config.json")
         self.log_file_name = os.path.join(self.base_dir, "log")
+        self.pid = None
         if os.name == 'nt':
             self.sock_file = '\\\\.\\pipe\\watchman-test-%s' % uuid.uuid4().hex
         else:
@@ -76,8 +79,9 @@ class Instance(object):
                 self.pid = client.query('get-pid')['pid']
                 break
             except Exception as e:
-                last_err = e
+                t, val, tb = sys.exc_info()
+                last_err = ''.join(traceback.format_exception(t, val, tb))
                 time.sleep(0.1)
 
-        if not self.pid:
-            raise last_err
+        if self.pid is None:
+            raise Exception(last_err)

--- a/tests/integration/age.php
+++ b/tests/integration/age.php
@@ -41,7 +41,7 @@ class ageOutTestCase extends WatchmanTestCase {
     $this->assertTrue(array_key_exists('n:foo', $cursors['cursors']));
 
     unlink("$root/a/file.txt");
-    rmdir("$root/a");
+    w_rmdir_recursive("$root/a");
 
     $this->assertFileList($root, array('b.txt'));
 
@@ -85,10 +85,9 @@ class ageOutTestCase extends WatchmanTestCase {
         touch("$root/dir/$i");
       }
       for ($i = 0; $i < 100; $i++) {
-        unlink("$root/stress-$i");
-        unlink("$root/dir/$i");
+        w_rmdir_recursive("$root/stress-$i");
       }
-      rmdir("$root/dir");
+      w_rmdir_recursive("$root/dir");
       $this->assertFileList($root, array('b.txt', 'c.txt'));
       $this->watchmanCommand('debug-ageout', $root, 0);
       $this->assertFileList($root, array('b.txt', 'c.txt'));

--- a/tests/integration/movereadd.php
+++ b/tests/integration/movereadd.php
@@ -53,11 +53,11 @@ class movereaddTestCase extends WatchmanTestCase {
     );
 
     $this->watchmanCommand('log', 'debug', 'XXX: rmdir foo/bar');
-    rmdir("$root/foo/bar");
+    w_rmdir_recursive("$root/foo/bar");
     $this->watchmanCommand('log', 'debug', 'XXX: unlink foo/222');
     unlink("$root/foo/222");
     $this->watchmanCommand('log', 'debug', 'XXX: rmdir foo');
-    rmdir("$root/foo");
+    w_rmdir_recursive("$root/foo");
 
     $this->assertFileListUsingSince($root, 'n:foo',
       array(

--- a/tests/integration/test_age_watch.py
+++ b/tests/integration/test_age_watch.py
@@ -19,6 +19,26 @@ class TestAgeOutWatch(WatchmanTestCase.WatchmanTestCase):
             }))
         return root
 
+    def listContains(self, superset, subset):
+        superset = self.normFileList(superset)
+        for x in self.normFileList(subset):
+            if x not in superset:
+                return False
+        return True
+
+    def listNotContains(self, superset, subset):
+        superset = self.normFileList(superset)
+        for x in self.normFileList(subset):
+            if x in superset:
+                return False
+        return True
+
+    def assertListNotContains(self, superset, subset):
+        if self.listNotContains(superset, subset):
+            return
+        self.assertTrue(
+            False, "superset: %s should not contain any of the elements of %s" % (superset, subset))
+
     def test_watchReap(self):
         root = self.makeRootAndConfig()
         self.watchmanCommand('watch', root)
@@ -32,7 +52,7 @@ class TestAgeOutWatch(WatchmanTestCase.WatchmanTestCase):
         time.sleep(2)
 
         watch_list = self.watchmanCommand('watch-list')
-        self.assertEqual(self.normFileList(watch_list['roots']), [root])
+        self.assertTrue(self.listContains(watch_list['roots'], [root]))
 
         self.watchmanCommand('trigger-del', root, 't')
 
@@ -46,11 +66,11 @@ class TestAgeOutWatch(WatchmanTestCase.WatchmanTestCase):
         else:
             expected = self.normFileList([root])
 
-        self.waitFor(lambda: self.normFileList(
-            self.watchmanCommand('watch-list')['roots']) == expected)
+        self.waitFor(lambda: self.listContains(
+            self.watchmanCommand('watch-list')['roots'], expected))
 
         watch_list = self.watchmanCommand('watch-list')
-        self.assertEqual(self.normFileList(watch_list['roots']), expected)
+        self.assertTrue(self.listContains(watch_list['roots'], expected))
 
         if self.transport != 'cli':
             # let's verify that we can safely reap two roots at once without
@@ -60,11 +80,14 @@ class TestAgeOutWatch(WatchmanTestCase.WatchmanTestCase):
             self.assertFileList(second, ['.watchmanconfig'])
 
             # and unsubscribe from root and allow it to be reaped
-            self.watchmanCommand('unsubscribe', root, 's')
+            unsub = self.watchmanCommand('unsubscribe', root, 's')
+            self.assertTrue(unsub['deleted'], 'deleted subscription %s' % unsub)
+            expected.append(self.normPath(second))
 
         # and now we should be ready to reap
-        self.waitFor(lambda: len(
-            self.watchmanCommand('watch-list')['roots']) == 0)
+        self.waitFor(lambda: self.listNotContains(
+            self.watchmanCommand('watch-list')['roots'], expected))
 
-        self.assertEqual(
-            self.watchmanCommand('watch-list')['roots'], [])
+        self.assertListNotContains(
+            self.watchmanCommand('watch-list')['roots'], expected)
+

--- a/watchman.h
+++ b/watchman.h
@@ -749,6 +749,7 @@ void w_run_subscription_rules(
     struct watchman_client *client,
     struct watchman_client_subscription *sub,
     w_root_t *root);
+void w_cancel_subscriptions_for_root(w_root_t *root);
 
 void w_match_results_free(uint32_t num_matches,
     struct watchman_rule_match *matches);

--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -168,7 +168,7 @@ py-build:
 	cd python && python ./setup.py clean build_py -c -d . build_ext -i
 
 py-integration: py-build
-	python runtests.py
+	python -u runtests.py
 
 # helper for suspending/resuming a target process
 susres.exe: winbuild\susres.c

--- a/winbuild/errmap.c
+++ b/winbuild/errmap.c
@@ -19,6 +19,8 @@ int map_win32_err(DWORD err) {
     case ERROR_SUCCESS: return 0;
     case ERROR_ALREADY_EXISTS: return EEXIST;
     case ERROR_TIMEOUT: return ETIMEDOUT;
+    case WAIT_TIMEOUT: return ETIMEDOUT;
+    case WAIT_IO_COMPLETION: return EINTR;
     case ERROR_INVALID_FUNCTION: return ENOSYS;
     case ERROR_PATH_NOT_FOUND: return ENOTDIR;
     case ERROR_FILE_NOT_FOUND: return ENOENT;


### PR DESCRIPTION
[don't bother reviewing this yet if you get tagged by the bot]

Summary: Our windows builds have been failing since the python
subscription tests were committed.  This is because we've had
a lurking problem with named pipes since Windows support went in.

This diff tackles this on both the pywatchman client and on the
server side.

* pywatchman: use ctypes to invoke native win32 APIs for working
  with pipes.  All our reads and writes are now overlapped (async)
  IOs that are waited for explicitly.  This avoids unbounded
  wait time in cases where either the client or the server is
  out of sync with the other in the watchman protocol

* runtests.py: fix a threading/waiting problem that would cause
  the harness to hang forever if we encountered an error very
  early in the harness initialization.

* stream_win.c: Treat WAIT_IO_COMPLETION as equivalent to EINTR
  and pay closer attention to when we set and reset our synchronization
  event.

* stream_win.c: For subscriptions, we may elect to queue a number
  of unilateral PDUs in quick succession, and the writes for those
  PDUs may only partially complete.  Fixup our handling of partial
  writes and re-queue the remainder.