### PR TITLE
Make pywatchman run on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
       - php5-cli
       - python2.7
+      - python3.4
 #      - ruby
 #      - rubygems
 #      - valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
     packages:
       - php5-cli
       - python2.7
-      - python3.4
 #      - ruby
 #      - rubygems
 #      - valgrind

--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -37,7 +37,7 @@ import time
 # so fall back to a pure Python implementation.
 try:
     import bser
-except ImportError, e:
+except ImportError:
     import pybser as bser
 
 import capabilities

--- a/python/pywatchman/pybser.py
+++ b/python/pywatchman/pybser.py
@@ -29,6 +29,7 @@
 import collections
 import ctypes
 import struct
+import sys
 
 BSER_ARRAY = '\x00'
 BSER_OBJECT = '\x01'
@@ -49,6 +50,9 @@ BSER_SKIP = '\x0c'
 # int32 for the header
 EMPTY_HEADER = "\x00\x01\x05\x00\x00\x00\x00"
 
+# Python 3 conditional for supporting Python 2's int/long types
+if sys.version_info > (3,):
+    long = int
 
 def _int_size(x):
     """Return the smallest size int that can store the value"""
@@ -58,7 +62,7 @@ def _int_size(x):
         return 2
     elif -0x80000000 <= x <= 0x7FFFFFFF:
         return 4
-    elif -0x8000000000000000L <= x <= 0x7FFFFFFFFFFFFFFFL:
+    elif long(-0x8000000000000000) <= x <= long(0x7FFFFFFFFFFFFFFF):
         return 8
     else:
         raise RuntimeError('Cannot represent value: ' + str(x))


### PR DESCRIPTION
Python 3 doesn't support the long character (L), int and long types have been merged in Python 3. "except Exception, e" has been removed in Python 3.

It is impossible to test pywatchman with Python 3.4 with TravisCI, since Python 3.4 is not natively supported on TravisCI's Ubuntu 12.04.5, but this a separate issue all together.