### PR TITLE
Improve diagnostics and behavior when the root lock is held for a long time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,7 @@ watchman_SOURCES = \
 	stream.c        \
 	stream_stdout.c \
 	stream_unix.c   \
+	timedlock.c     \
 	cmds/find.c     \
 	cmds/info.c     \
 	cmds/log.c      \

--- a/cmds/debug.c
+++ b/cmds/debug.c
@@ -23,7 +23,7 @@ static void cmd_debug_recrawl(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(root);
+  w_root_lock(root, "debug-recrawl");
   w_root_schedule_recrawl(root, "debug-recrawl");
   w_root_unlock(root);
 
@@ -54,7 +54,7 @@ static void cmd_debug_show_cursors(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(root);
+  w_root_lock(root, "debug-show-cursors");
   cursors = json_object_of_size(w_ht_size(root->cursors));
   if (w_ht_first(root->cursors, &i)) do {
     w_string_t *name = w_ht_val_ptr(i.key);
@@ -93,7 +93,7 @@ static void cmd_debug_ageout(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(root);
+  w_root_lock(root, "debug-ageout");
   w_root_perform_age_out(root, min_age);
   w_root_unlock(root);
 

--- a/cmds/info.c
+++ b/cmds/info.c
@@ -138,7 +138,7 @@ static void cmd_get_config(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(root);
+  w_root_lock(root, "cmd_get_config");
   {
     config = root->config_file;
     if (config) {

--- a/cmds/state.c
+++ b/cmds/state.c
@@ -101,7 +101,7 @@ static void cmd_state_enter(struct watchman_client *client, json_t *args) {
   w_root_addref(assertion->root);
   w_string_addref(assertion->name);
 
-  w_root_lock(root);
+  w_root_lock(root, "state-enter");
   {
     // If the state is already asserted, we can't re-assert it
     if (!root->asserted_states) {
@@ -194,7 +194,7 @@ static void leave_state(struct watchman_client *client,
   w_root_t *root = assertion->root;
 
   if (!clockbuf) {
-    w_root_lock(root);
+    w_root_lock(root, "state-leave");
     clock_id_string(root->number, root->ticks, buf, sizeof(buf));
     w_root_unlock(root);
 
@@ -237,7 +237,7 @@ static void leave_state(struct watchman_client *client,
   pthread_mutex_unlock(&w_client_lock);
 
   // Now remove the state
-  w_root_lock(root);
+  w_root_lock(root, "state-leave");
   w_ht_del(root->asserted_states, w_ht_ptr_val(assertion->name));
   w_root_unlock(root);
 
@@ -294,7 +294,7 @@ static void cmd_state_leave(struct watchman_client *client, json_t *args) {
   }
 
   // Confirm that this client owns this state
-  w_root_lock(root);
+  w_root_lock(root, "state-leave");
   {
     assertion = root->asserted_states ?
           w_ht_val_ptr(w_ht_get(root->asserted_states,

--- a/cmds/subscribe.c
+++ b/cmds/subscribe.c
@@ -68,6 +68,10 @@ static json_t *build_subscription_results(
   // Subscriptions never need to sync explicitly; we are only dispatched
   // at settle points which are by definition sync'd to the present time
   sub->query->sync_timeout = 0;
+  // We're called by the io thread, so there's little chance that the root
+  // could be legitimately blocked by something else.  That means that we
+  // can use a short lock_timeout
+  sub->query->lock_timeout = 10;
   if (!w_query_execute(sub->query, root, &res, subscription_generator, sub)) {
     w_log(W_LOG_ERR, "error running subscription %s query: %s",
         sub->name->buf, res.errmsg);

--- a/cmds/trigger.c
+++ b/cmds/trigger.c
@@ -32,7 +32,7 @@ static void cmd_trigger_delete(struct watchman_client *client, json_t *args)
   }
   tname = w_string_new(name);
 
-  w_root_lock(root);
+  w_root_lock(root, "trigger-del");
   res = w_ht_del(root->commands, w_ht_ptr_val(tname));
   w_root_unlock(root);
 
@@ -65,7 +65,7 @@ static void cmd_trigger_list(struct watchman_client *client, json_t *args)
   }
 
   resp = make_response();
-  w_root_lock(root);
+  w_root_lock(root, "trigger-list");
   arr = w_root_trigger_list_to_json(root);
   w_root_unlock(root);
 
@@ -350,7 +350,7 @@ static void cmd_trigger(struct watchman_client *client, json_t *args)
   resp = make_response();
   set_prop(resp, "triggerid", w_string_to_json(cmd->triggername));
 
-  w_root_lock(root);
+  w_root_lock(root, "trigger-add");
 
   old = w_ht_val_ptr(w_ht_get(root->commands,
           w_ht_ptr_val(cmd->triggername)));

--- a/cmds/watch.c
+++ b/cmds/watch.c
@@ -66,7 +66,7 @@ static void cmd_clock(struct watchman_client *client, json_t *args)
   }
 
   resp = make_response();
-  w_root_lock(root);
+  w_root_lock(root, "clock");
   annotate_with_clock(root, resp);
   w_root_unlock(root);
 
@@ -307,7 +307,7 @@ static void cmd_watch(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(root);
+  w_root_lock(root, "watch");
   if (root->failure_reason) {
     set_prop(resp, "error", w_string_to_json(root->failure_reason));
   } else if (root->cancelled) {
@@ -355,7 +355,7 @@ static void cmd_watch_project(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(root);
+  w_root_lock(root, "watch-project");
   if (root->failure_reason) {
     set_prop(resp, "error", w_string_to_json(root->failure_reason));
   } else if (root->cancelled) {

--- a/query/eval.c
+++ b/query/eval.c
@@ -403,7 +403,7 @@ bool w_query_execute(
    */
 
   // Lock the root and begin generation
-  w_root_lock(root);
+  w_root_lock(root, "w_query_execute");
   res->root_number = root->number;
   res->ticks = root->ticks;
 

--- a/query/eval.c
+++ b/query/eval.c
@@ -403,7 +403,13 @@ bool w_query_execute(
    */
 
   // Lock the root and begin generation
-  w_root_lock(root, "w_query_execute");
+  if (!w_root_lock_with_timeout(root, "w_query_execute", query->lock_timeout)) {
+    ignore_result(asprintf(&res->errmsg, "couldn't acquire root lock within "
+                                         "lock_timeout of %dms. root is "
+                                         "currently busy (%s)\n",
+                           query->lock_timeout, root->lock_reason));
+    return false;
+  }
   res->root_number = root->number;
   res->ticks = root->ticks;
 

--- a/query/parse.c
+++ b/query/parse.c
@@ -258,6 +258,26 @@ static bool parse_sync(w_query *res, json_t *query)
   return true;
 }
 
+static bool parse_lock_timeout(w_query *res, json_t *query)
+{
+  int value = DEFAULT_QUERY_SYNC_MS;
+
+  if (query &&
+      json_unpack(query, "{s?:i*}", "lock_timeout", &value) != 0) {
+    res->errmsg = strdup("lock_timeout must be an integer value >= 0");
+    return false;
+  }
+
+  if (value < 0) {
+    res->errmsg = strdup("lock_timeout must be an integer value >= 0");
+    return false;
+  }
+
+  res->lock_timeout = value;
+  return true;
+}
+
+
 static bool parse_empty_on_fresh_instance(w_query *res, json_t *query)
 {
   int value = 0;
@@ -287,6 +307,10 @@ w_query *w_query_parse(w_root_t *root, json_t *query, char **errmsg)
   res->case_sensitive = root->case_sensitive;
 
   if (!parse_sync(res, query)) {
+    goto error;
+  }
+
+  if (!parse_lock_timeout(res, query)) {
     goto error;
   }
 

--- a/spawn.c
+++ b/spawn.c
@@ -58,7 +58,7 @@ void w_mark_dead(pid_t pid)
       root->root_path->len, root->root_path->buf, (int)pid);
 
   /* now walk the cmds and try to find our match */
-  w_root_lock(root);
+  w_root_lock(root, "mark_dead");
 
   /* walk the list of triggers, and run their rules */
   if (w_ht_first(root->commands, &iter)) do {

--- a/timedlock.c
+++ b/timedlock.c
@@ -1,0 +1,39 @@
+/* Copyright 2016-present Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 */
+
+#include "watchman.h"
+
+#ifdef __APPLE__
+// We get to emulate this function because Darwin doesn't implement it
+
+int pthread_mutex_timedlock(pthread_mutex_t *m, const struct timespec *deadline_ts) {
+  int result;
+  struct timeval now, deadline;
+  int usec = 1;
+
+  w_timespec_to_timeval(*deadline_ts, &deadline);
+
+  while (true) {
+    gettimeofday(&now, NULL);
+    if (w_timeval_compare(now, deadline) >= 0) {
+      return ETIMEDOUT;
+    }
+
+    result = pthread_mutex_trylock(m);
+    if (result != EBUSY) {
+      return result;
+    }
+
+    // Exponential backoff on the sleep period
+    usec = MIN(usec * 2, 1024);
+    if (now.tv_sec == deadline.tv_sec) {
+      // Cap the sleep if we are close to the deadline
+      usec = MIN(usec, deadline.tv_usec - now.tv_usec);
+    }
+    usleep(usec);
+  }
+}
+#endif
+
+/* vim:ts=2:sw=2:et:
+ */

--- a/watcher/win32.c
+++ b/watcher/win32.c
@@ -146,7 +146,7 @@ static void *readchanges_thread(void *arg) {
     w_log(W_LOG_ERR,
         "ReadDirectoryChangesW: failed, cancel watch. %s\n",
         win32_strerror(err));
-    w_root_lock(root);
+    w_root_lock(root, "w_root_cancel");
     w_root_cancel(root);
     w_root_unlock(root);
     goto out;
@@ -169,7 +169,7 @@ static void *readchanges_thread(void *arg) {
         w_log(W_LOG_ERR,
             "ReadDirectoryChangesW: failed, cancel watch. %s\n",
             win32_strerror(err));
-        w_root_lock(root);
+        w_root_lock(root, "w_root_cancel");
         w_root_cancel(root);
         w_root_unlock(root);
         break;
@@ -206,7 +206,7 @@ static void *readchanges_thread(void *arg) {
         } else {
           w_log(W_LOG_ERR, "Cancelling watch for %s\n",
               root->root_path->buf);
-          w_root_lock(root);
+          w_root_lock(root, "w_root_cancel");
           w_root_cancel(root);
           w_root_unlock(root);
           break;

--- a/watchman.h
+++ b/watchman.h
@@ -430,6 +430,7 @@ struct watchman_root {
 
   /* our locking granularity is per-root */
   pthread_mutex_t lock;
+  const char *lock_reason;
   pthread_t notify_thread;
   pthread_t io_thread;
 
@@ -685,7 +686,7 @@ void w_root_mark_file_changed(w_root_t *root, struct watchman_file *file,
 
 bool w_root_sync_to_now(w_root_t *root, int timeoutms);
 
-void w_root_lock(w_root_t *root);
+void w_root_lock(w_root_t *root, const char *purpose);
 void w_root_unlock(w_root_t *root);
 
 /* Bob Jenkins' lookup3.c hash function */

--- a/watchman.h
+++ b/watchman.h
@@ -815,6 +815,12 @@ static inline void w_timeval_to_timespec(
   ts->tv_nsec = a.tv_usec * WATCHMAN_NSEC_IN_USEC;
 }
 
+static inline void w_timespec_to_timeval(
+    const struct timespec ts, struct timeval *tv) {
+  tv->tv_sec = ts.tv_sec;
+  tv->tv_usec = ts.tv_nsec / WATCHMAN_NSEC_IN_USEC;
+}
+
 static inline double w_timeval_diff(struct timeval start, struct timeval end)
 {
   double s = start.tv_sec + ((double)start.tv_usec)/WATCHMAN_USEC_IN_SEC;
@@ -990,6 +996,10 @@ struct flag_map {
 };
 void w_expand_flags(const struct flag_map *fmap, uint32_t flags,
     char *buf, size_t len);
+
+#ifdef __APPLE__
+int pthread_mutex_timedlock(pthread_mutex_t *m, const struct timespec *ts);
+#endif
 
 #ifdef __cplusplus
 }

--- a/watchman.h
+++ b/watchman.h
@@ -687,6 +687,7 @@ void w_root_mark_file_changed(w_root_t *root, struct watchman_file *file,
 bool w_root_sync_to_now(w_root_t *root, int timeoutms);
 
 void w_root_lock(w_root_t *root, const char *purpose);
+bool w_root_lock_with_timeout(w_root_t *root, const char *purpose, int timeoutms);
 void w_root_unlock(w_root_t *root);
 
 /* Bob Jenkins' lookup3.c hash function */

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -63,6 +63,7 @@ struct w_query {
   size_t nsuffixes;
 
   uint32_t sync_timeout;
+  uint32_t lock_timeout;
 
   bool empty_on_fresh_instance;
 

--- a/website/_docs/cmd.query.markdown
+++ b/website/_docs/cmd.query.markdown
@@ -130,3 +130,27 @@ expressed in milliseconds:
 You may specify `0` as the value if you do not wish for the query to create
 a cookie and synchronize; the query will be evaluated over the present view
 of the tree, which may lag behind the present state of the filesystem.
+
+### Lock timeout
+
+*Since 4.6.*
+
+By default queries will wait for up to 60 seconds to acquire a lock to inspect
+the view of the filesystem tree.  In practice, this timeout should never be hit
+(it is indicative of an environmental or load related issue).  However, in some
+situations it is important to ensure that the query attempt times out sooner
+than this.  You may use the `lock_timeout` field to control this behavior.
+`lock_timeout` must be an integer value expressed in milliseconds:
+
+```json
+["query", "/path/to/root", {
+  "expression": ["exists"],
+  "fields": ["name"],
+  "lock_timeout": 60000,
+  "sync_timeout": 60000
+}]
+```
+
+Prior to version 4.6, the `lock_timeout` could not be configured and had an
+effective value of infinity.
+


### PR DESCRIPTION
We can now annotate the root with the reason that the lock is held, and use an alternative locking function that allows specifying a timeout.

Between these and #220 we should be able to understand a bit more about the issue that @int3 has been tracking.