### PR TITLE
Add concept of session owner, restrict command execution

### DIFF
--- a/cmds/debug.c
+++ b/cmds/debug.c
@@ -128,5 +128,18 @@ static void cmd_debug_poison(struct watchman_client *client, json_t *args)
 }
 W_CMD_REG("debug-poison", cmd_debug_poison, CMD_DAEMON, w_cmd_realpath_root)
 
+static void cmd_debug_drop_privs(struct watchman_client *client, json_t *args)
+{
+  json_t *resp;
+
+  unused_parameter(args);
+  client->client_is_owner = false;
+
+  resp = make_response();
+  set_prop(resp, "owner", json_boolean(client->client_is_owner));
+  send_and_dispose_response(client, resp);
+}
+W_CMD_REG("debug-drop-privs", cmd_debug_drop_privs, CMD_DAEMON, NULL);
+
 /* vim:ts=2:sw=2:et:
  */

--- a/cmds/find.c
+++ b/cmds/find.c
@@ -63,7 +63,8 @@ static void cmd_find(struct watchman_client *client, json_t *args)
   send_and_dispose_response(client, response);
   w_root_delref(root);
 }
-W_CMD_REG("find", cmd_find, CMD_DAEMON, w_cmd_realpath_root)
+W_CMD_REG("find", cmd_find, CMD_DAEMON | CMD_ALLOW_ANY_USER,
+          w_cmd_realpath_root)
 
 /* vim:ts=2:sw=2:et:
  */

--- a/cmds/info.c
+++ b/cmds/info.c
@@ -79,7 +79,8 @@ static void cmd_version(struct watchman_client *client, json_t *args)
 
   send_and_dispose_response(client, resp);
 }
-W_CMD_REG("version", cmd_version, CMD_DAEMON|CMD_CLIENT, NULL)
+W_CMD_REG("version", cmd_version, CMD_DAEMON | CMD_CLIENT | CMD_ALLOW_ANY_USER,
+          NULL)
 
 /* list-capabilities */
 static void cmd_list_capabilities(struct watchman_client *client,
@@ -91,7 +92,7 @@ static void cmd_list_capabilities(struct watchman_client *client,
   send_and_dispose_response(client, resp);
 }
 W_CMD_REG("list-capabilities", cmd_list_capabilities,
-    CMD_DAEMON|CMD_CLIENT, NULL)
+          CMD_DAEMON | CMD_CLIENT | CMD_ALLOW_ANY_USER, NULL)
 
 /* get-sockname */
 static void cmd_get_sockname(struct watchman_client *client, json_t *args)
@@ -104,7 +105,8 @@ static void cmd_get_sockname(struct watchman_client *client, json_t *args)
 
   send_and_dispose_response(client, resp);
 }
-W_CMD_REG("get-sockname", cmd_get_sockname, CMD_DAEMON|CMD_CLIENT, NULL)
+W_CMD_REG("get-sockname", cmd_get_sockname,
+          CMD_DAEMON | CMD_CLIENT | CMD_ALLOW_ANY_USER, NULL)
 
 static void cmd_get_config(struct watchman_client *client, json_t *args)
 {

--- a/cmds/query.c
+++ b/cmds/query.c
@@ -74,7 +74,8 @@ static void cmd_query(struct watchman_client *client, json_t *args)
   send_and_dispose_response(client, response);
   w_root_delref(root);
 }
-W_CMD_REG("query", cmd_query, CMD_DAEMON|CMD_CLIENT, w_cmd_realpath_root)
+W_CMD_REG("query", cmd_query, CMD_DAEMON | CMD_CLIENT | CMD_ALLOW_ANY_USER,
+          w_cmd_realpath_root)
 
 /* vim:ts=2:sw=2:et:
  */

--- a/cmds/reg.c
+++ b/cmds/reg.c
@@ -154,6 +154,12 @@ bool dispatch_command(struct watchman_client *client, json_t *args, int mode)
     return false;
   }
 
+  if (!client->client_is_owner && (def->flags & CMD_ALLOW_ANY_USER) == 0) {
+    send_error_response(client, "you must be the process owner to execute '%s'",
+                        def->name);
+    return false;
+  }
+
   w_log(W_LOG_DBG, "dispatch_command: %s\n", def->name);
   def->func(client, args);
   w_log(W_LOG_DBG, "dispatch_command: %s (completed)\n", def->name);

--- a/cmds/since.c
+++ b/cmds/since.c
@@ -72,7 +72,8 @@ static void cmd_since(struct watchman_client *client, json_t *args)
   send_and_dispose_response(client, response);
   w_root_delref(root);
 }
-W_CMD_REG("since", cmd_since, CMD_DAEMON, w_cmd_realpath_root)
+W_CMD_REG("since", cmd_since, CMD_DAEMON | CMD_ALLOW_ANY_USER,
+          w_cmd_realpath_root)
 
 /* vim:ts=2:sw=2:et:
  */

--- a/cmds/subscribe.c
+++ b/cmds/subscribe.c
@@ -214,7 +214,8 @@ static void cmd_unsubscribe(struct watchman_client *clientbase, json_t *args)
   send_and_dispose_response(&client->client, resp);
   w_root_delref(root);
 }
-W_CMD_REG("unsubscribe", cmd_unsubscribe, CMD_DAEMON, w_cmd_realpath_root)
+W_CMD_REG("unsubscribe", cmd_unsubscribe, CMD_DAEMON | CMD_ALLOW_ANY_USER,
+          w_cmd_realpath_root)
 
 /* subscribe /root subname {query}
  * Subscribes the client connection to the specified root. */
@@ -335,7 +336,8 @@ static void cmd_subscribe(struct watchman_client *clientbase, json_t *args)
 done:
   w_root_delref(root);
 }
-W_CMD_REG("subscribe", cmd_subscribe, CMD_DAEMON, w_cmd_realpath_root)
+W_CMD_REG("subscribe", cmd_subscribe, CMD_DAEMON | CMD_ALLOW_ANY_USER,
+          w_cmd_realpath_root)
 
 /* vim:ts=2:sw=2:et:
  */

--- a/cmds/watch.c
+++ b/cmds/watch.c
@@ -73,7 +73,8 @@ static void cmd_clock(struct watchman_client *client, json_t *args)
   send_and_dispose_response(client, resp);
   w_root_delref(root);
 }
-W_CMD_REG("clock", cmd_clock, CMD_DAEMON, w_cmd_realpath_root)
+W_CMD_REG("clock", cmd_clock, CMD_DAEMON | CMD_ALLOW_ANY_USER,
+          w_cmd_realpath_root)
 
 /* watch-del /root
  * Stops watching the specified root */
@@ -129,7 +130,7 @@ static void cmd_watch_list(struct watchman_client *client, json_t *args)
   set_prop(resp, "roots", root_paths);
   send_and_dispose_response(client, resp);
 }
-W_CMD_REG("watch-list", cmd_watch_list, CMD_DAEMON, NULL)
+W_CMD_REG("watch-list", cmd_watch_list, CMD_DAEMON | CMD_ALLOW_ANY_USER, NULL)
 
 // For each directory component in candidate_dir to the root of the filesystem,
 // look for root_file.  If root_file is present, update relpath to reflect the
@@ -321,7 +322,8 @@ static void cmd_watch(struct watchman_client *client, json_t *args)
   w_root_unlock(root);
   w_root_delref(root);
 }
-W_CMD_REG("watch", cmd_watch, CMD_DAEMON, w_cmd_realpath_root)
+W_CMD_REG("watch", cmd_watch, CMD_DAEMON | CMD_ALLOW_ANY_USER,
+          w_cmd_realpath_root)
 
 static void cmd_watch_project(struct watchman_client *client, json_t *args)
 {
@@ -374,7 +376,8 @@ static void cmd_watch_project(struct watchman_client *client, json_t *args)
   w_root_delref(root);
   free(dir_to_watch);
 }
-W_CMD_REG("watch-project", cmd_watch_project, CMD_DAEMON, w_cmd_realpath_root)
+W_CMD_REG("watch-project", cmd_watch_project, CMD_DAEMON | CMD_ALLOW_ANY_USER,
+          w_cmd_realpath_root)
 
 /* vim:ts=2:sw=2:et:
  */

--- a/configure.ac
+++ b/configure.ac
@@ -236,6 +236,7 @@ AC_SEARCH_LIBS([pthread_create], [pthread])
 AC_SEARCH_LIBS([socket], [socket])
 
 AC_CHECK_HEADERS(sys/types.h inttypes.h locale.h port.h sys/inotify.h sys/event.h)
+AC_CHECK_HEADERS(sys/ucred.h sys/socket.h)
 AC_CHECK_FUNCS(mkostemp kqueue port_create inotify_init strtoll localeconv statfs)
 AC_CHECK_FUNCS(accept4 inotify_init1 getattrlistbulk openat fdopendir)
 AC_CHECK_HEADERS(sys/vfs.h sys/param.h sys/mount.h sys/statfs.h sys/statvfs.h, [], [],

--- a/listener.c
+++ b/listener.c
@@ -120,7 +120,7 @@ static void client_delete(struct watchman_client *client)
 
 void w_request_shutdown(void) {
   stopping = true;
-  // Knock listener thread out of poll/accept
+// Knock listener thread out of poll/accept
 #ifndef _WIN32
   pthread_kill(listener_thread, SIGUSR1);
   pthread_kill(reaper_thread, SIGUSR1);
@@ -142,6 +142,8 @@ static void *client_thread(void *ptr)
 
   w_stm_set_nonblock(client->stm, true);
   w_set_thread_name("client:stm=%p", client->stm);
+
+  client->client_is_owner = w_stm_peer_is_owner(client->stm);
 
   w_stm_get_events(client->stm, &pfd[0].evt);
   pfd[1].evt = client->ping;

--- a/stream.c
+++ b/stream.c
@@ -73,3 +73,14 @@ bool w_stm_shutdown(w_stm_t stm) {
   }
   return stm->ops->op_shutdown(stm);
 }
+
+bool w_stm_peer_is_owner(w_stm_t stm) {
+  if (!stm || stm->handle == NULL || stm->ops == NULL) {
+    errno = EBADF;
+    return false;
+  }
+  if (!stm->ops->op_peer_is_owner) {
+    return false;
+  }
+  return stm->ops->op_peer_is_owner(stm);
+}

--- a/stream_stdout.c
+++ b/stream_stdout.c
@@ -53,7 +53,8 @@ static struct watchman_stream_ops stdio_ops = {
   stdio_get_events,
   stdio_set_nonb,
   stdio_rewind,
-  stdio_shutdown
+  stdio_shutdown,
+  NULL
 };
 
 static struct watchman_stream stm_stdout = {

--- a/stream_win.c
+++ b/stream_win.c
@@ -527,6 +527,12 @@ static bool win_shutdown(w_stm_t stm) {
   return true;
 }
 
+static bool win_peer_is_owner(w_stm_t stm) {
+  unused_parameter(stm);
+  // TODO: implement this for Windows
+  return true;
+}
+
 static struct watchman_stream_ops win_ops = {
   win_close,
   win_read,
@@ -534,7 +540,8 @@ static struct watchman_stream_ops win_ops = {
   win_get_events,
   win_set_nonb,
   win_rewind,
-  win_shutdown
+  win_shutdown,
+  win_peer_is_owner
 };
 
 w_evt_t w_event_make(void) {

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,0 +1,34 @@
+# vim:ts=4:sw=4:et:
+# Copyright 2016-present Facebook, Inc.
+# Licensed under the Apache License, Version 2.0
+import WatchmanTestCase
+import pywatchman
+
+class TestAuth(WatchmanTestCase.WatchmanTestCase):
+    def requiresPersistentSession(self):
+        return True
+
+    def test_dropPriv(self):
+        root = self.mkdtemp()
+        self.touchRelative(root, '111')
+
+        self.watchmanCommand('watch', root)
+
+        # pretend we are not the owner
+        self.watchmanCommand('debug-drop-privs')
+
+        # Should be able to watch something that is already watched
+        self.watchmanCommand('watch', root)
+
+        # can't make a new watch
+        altroot = self.mkdtemp()
+        with self.assertRaises(pywatchman.WatchmanError):
+            self.watchmanCommand('watch', altroot)
+
+        # Should not be able to delete a watch
+        with self.assertRaises(pywatchman.WatchmanError):
+            self.watchmanCommand('watch-del', root)
+
+        # or register a trigger
+        with self.assertRaises(pywatchman.WatchmanError):
+            self.watchmanCommand('trigger', root, 'trig', '*.js', '--', 'false')

--- a/watchman.h
+++ b/watchman.h
@@ -571,6 +571,7 @@ struct watchman_client {
   int log_level;
   w_jbuffer_t reader, writer;
   bool client_mode;
+  bool client_is_owner;
   enum w_pdu_type pdu_type;
 
   struct watchman_client_response *head, *tail;

--- a/watchman_cmd.h
+++ b/watchman_cmd.h
@@ -18,6 +18,7 @@ typedef bool (*watchman_cli_cmd_validate_func)(
 #define CMD_DAEMON 1
 #define CMD_CLIENT 2
 #define CMD_POISON_IMMUNE 4
+#define CMD_ALLOW_ANY_USER 8
 struct watchman_command_handler_def {
   const char *name;
   watchman_command_func func;

--- a/watchman_stream.h
+++ b/watchman_stream.h
@@ -24,6 +24,7 @@ struct watchman_stream_ops {
   void (*op_set_nonblock)(w_stm_t stm, bool nonb);
   bool (*op_rewind)(w_stm_t stm);
   bool (*op_shutdown)(w_stm_t stm);
+  bool (*op_peer_is_owner)(w_stm_t stm);
 };
 
 struct watchman_stream {
@@ -58,6 +59,7 @@ void w_stm_get_events(w_stm_t stm, w_evt_t *readable);
 void w_stm_set_nonblock(w_stm_t stm, bool nonb);
 bool w_stm_rewind(w_stm_t stm);
 bool w_stm_shutdown(w_stm_t stm);
+bool w_stm_peer_is_owner(w_stm_t stm);
 
 w_stm_t w_stm_stdout(void);
 w_stm_t w_stm_stdin(void);


### PR DESCRIPTION
Refs: https://github.com/facebook/watchman/issues/222

This adds an interface to our stream layer that allows us to check
whether the peer matches the owner of our process.  We do not
currently implement this for Windows.

We record this flag in the client structure.

The command dispatcher will by default refuse to allow any commands to
run if the peer is not the owner.

A command can be registered with the `CMD_ALLOW_ANY_USER` to whitelist
that command from this blanket dispatcher check.

The model we're using to decide what is white listed is this:

* If you are not the owner, you can inspect any of the current
  state in the watchman instance.
* You may not change that state; initiating new watches, deleting
  watches or registering triggers are prohibited

`watch` and `watch-project` are white listed because they are an
important part of initializing a client; well behaved clients will
issue `watch-project` to resolve the watched path and directory
offset they should use for their session.

For that reason, we add a check for client==owner when we resolve a
root; if the `auto_create` flag is true and you are not the owner,
we turn the flag off.  We'll also expand the error message to provide
more context.

Test Plan: included a test case, but also manually:

```
$ sudo watchman -U /opt/facebook/watchman/var/run/watchman/wez-state/sock --no-spawn watch list
{
    "version": "4.5.0",
    "error": "unable to resolve root list: path \"list\" must be absolute (this may be because you are not the process owner)"
}
$ sudo watchman -U /opt/facebook/watchman/var/run/watchman/wez-state/sock --no-spawn watch-list
{
    "version": "4.5.0",
    "roots": [
        "/Users/wez/fbsource",
        "/Users/wez/fb/watchman"
    ]
}
$ sudo watchman -U /opt/facebook/watchman/var/run/watchman/wez-state/sock --no-spawn watch-del /Users/wez/fbsource
{
    "version": "4.5.0",
    "error": "you must be the process owner to execute 'watch-del'"
}
$ sudo watchman -U /opt/facebook/watchman/var/run/watchman/wez-state/sock --no-spawn watch /Users/wez/fbsource
{
    "version": "4.5.0",
    "watch": "/Users/wez/fbsource",
    "watcher": "fsevents"
}
```