### PR TITLE
Flush output for each line

### DIFF
--- a/python/bin/watchman-wait
+++ b/python/bin/watchman-wait
@@ -166,6 +166,7 @@ Perhaps you should use the --pattern option?""" % (path, self.path), file=sys.st
                     for fname in args.fields:
                         out.append(self.formatField(fname, f[fname]))
                 print(args.separator.join(out))
+                sys.stdout.flush()
                 total_events = total_events + 1
                 if args.max_events > 0 and total_events >= args.max_events:
                     sys.exit(0)


### PR DESCRIPTION
When piping to another process, linux will buffer the output. This breaks line-based processing like most people would do with `xargs` for `watchman-wait`.

Fixes #230