### PR TITLE
Use more reliably present poll.h

### DIFF
--- a/watchman.h
+++ b/watchman.h
@@ -55,7 +55,7 @@ extern "C" {
 # define O_CLOEXEC 0
 #endif
 #ifndef _WIN32
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/wait.h>
 #endif
 #ifdef HAVE_PCRE_H


### PR DESCRIPTION
Void Linux currently has a blanket replacement in place: `sed -i 's,sys/poll.h,poll.h,g' *.[ch]`.

Since that line was written (at version 3.3.0), it seems `sys/poll.h` now only gets referenced from `watchman.h`.

That said, `poll.h` is present on more systems, even if it only contains the line `#include <sys/poll.h>`.

Unless this is not true for a watchman supported platform, this change should work. If this breaks your build, I can add a configure check.