### PR TITLE
Support for symbolic link target handling

### DIFF
--- a/query/fieldlist.c
+++ b/query/fieldlist.c
@@ -8,6 +8,12 @@ static json_t *make_name(struct watchman_rule_match *match)
   return w_string_to_json(match->relname);
 }
 
+static json_t *make_symlink(struct watchman_rule_match *match)
+{
+  return (match->file->symlink_target) ?
+    w_string_to_json(match->file->symlink_target) : json_null();
+}
+
 static json_t *make_exists(struct watchman_rule_match *match)
 {
   return json_boolean(match->file->exists);
@@ -120,6 +126,7 @@ static struct w_query_field_renderer {
   json_t *(*make)(struct watchman_rule_match *match);
 } field_defs[] = {
   { "name", make_name },
+  { "symlink_target", make_symlink },
   { "exists", make_exists },
   { "size", make_size },
   { "mode", make_mode },

--- a/root.c
+++ b/root.c
@@ -902,6 +902,7 @@ static void stat_path(w_root_t *root,
 
     memcpy(&file->stat, &st, sizeof(file->stat));
 
+#ifndef _WIN32
     // check for symbolic link
     if (S_ISLNK(st.mode)) {
       char link_target_path[WATCHMAN_NAME_MAX];
@@ -928,6 +929,7 @@ static void stat_path(w_root_t *root,
       w_string_delref(file->symlink_target);
       file->symlink_target = NULL;
     }
+#endif
 
     if (S_ISDIR(st.mode)) {
       if (dir_ent == NULL) {

--- a/root.c
+++ b/root.c
@@ -903,6 +903,11 @@ static void stat_path(w_root_t *root,
     memcpy(&file->stat, &st, sizeof(file->stat));
 
 #ifndef _WIN32
+    if (file->symlink_target) {
+      w_string_delref(file->symlink_target);
+      file->symlink_target = NULL;
+    }
+
     // check for symbolic link
     if (S_ISLNK(st.mode)) {
       char link_target_path[WATCHMAN_NAME_MAX];
@@ -912,22 +917,9 @@ static void stat_path(w_root_t *root,
       if (tlen < 0 || tlen >= WATCHMAN_NAME_MAX) {
         w_log(W_LOG_ERR,
             "readlink(%s) errno=%d tlen=%d\n", path, errno, (int)tlen);
-
-        // not a proper symbolic link. NULL out symlink_target
-        if (file->symlink_target) {
-          w_string_delref(file->symlink_target);
-          file->symlink_target = NULL;
-        }
       } else {
-        if (file->symlink_target) {
-          w_string_delref(file->symlink_target);
-        }
-
         file->symlink_target = w_string_new_len(link_target_path, tlen);
       }
-    } else if (file->symlink_target) {
-      w_string_delref(file->symlink_target);
-      file->symlink_target = NULL;
     }
 #endif
 

--- a/tests/integration/test_symlink.py
+++ b/tests/integration/test_symlink.py
@@ -6,8 +6,10 @@ import tempfile
 import os
 import os.path
 import sys
-import unittest
-
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 class TestSymlink(WatchmanTestCase.WatchmanTestCase):
 

--- a/tests/integration/test_symlink.py
+++ b/tests/integration/test_symlink.py
@@ -1,0 +1,137 @@
+# vim:ts=4:sw=4:et:
+# Copyright 2016-present Facebook, Inc.
+# Licensed under the Apache License, Version 2.0
+import WatchmanTestCase
+import tempfile
+import os
+import os.path
+import sys
+import unittest
+
+
+class TestSymlink(WatchmanTestCase.WatchmanTestCase):
+
+    # test to see that valid symbolic link
+    # updates are picked up by the symlink_target field
+    @unittest.skipIf(os.name == 'nt', 'win')
+    def test_symlink(self):
+        root = self.mkdtemp()
+        self.touchRelative(root, '222')
+        self.touchRelative(root, '333')
+        os.symlink(os.path.join(root, '222'), os.path.join(root, '111'))
+
+        self.watchmanCommand('watch', root)
+        self.assertFileList(root, ['111', '222', '333'])
+
+        expr = {
+            "expression": ["name", "111"],
+            "fields": ["name", "symlink_target"]
+        }
+
+        res1 = self.watchmanCommand('query', root, expr)
+
+        files1 = res1['files']
+        self.assertTrue(files1 and os.path.basename(files1[0]['symlink_target']) == '222')
+
+        os.unlink(os.path.join(root, '111'))
+        os.symlink(os.path.join(root, '333'), os.path.join(root, '111'))
+
+        res2 = self.watchmanCommand('query', root, expr)
+        files2 = res2['files']
+        #print files2
+        self.assertTrue(files2 and os.path.basename(files2[0]['symlink_target']) == '333')
+
+    # test to see that invalid symbolic link
+    # updates are picked up by the symlink_target field
+    @unittest.skipIf(sys.platform == 'darwin' or os.name == 'nt', 'mac os or win')
+    def test_invalidSymlink(self):
+        root = self.mkdtemp()
+        os.symlink(os.path.join(root, '222'), os.path.join(root, '111'))
+
+        self.watchmanCommand('watch', root)
+        self.assertFileList(root, ['111' ])
+
+        expr = {
+            "expression": ["name", "111"],
+            "fields": ["name", "symlink_target"]
+        }
+
+        res1 = self.watchmanCommand('query', root, expr)
+
+        files1 = res1['files']
+        self.assertTrue(files1 and os.path.basename(files1[0]['symlink_target']) == '222')
+
+        os.unlink(os.path.join(root, '111'))
+        os.symlink(os.path.join(root, '333'), os.path.join(root, '111'))
+
+        res2 = self.watchmanCommand('query', root, expr)
+        files2 = res2['files']
+        #print files2
+        self.assertTrue(files2 and os.path.basename(files2[0]['symlink_target']) == '333')
+
+    # test to see that symbolic link deletes work
+    @unittest.skipIf(os.name == 'nt', 'win')
+    def test_delSymlink(self):
+        root = self.mkdtemp()
+        self.touchRelative(root, '222')
+        os.symlink(os.path.join(root, '222'), os.path.join(root, '111'))
+
+        self.watchmanCommand('watch', root)
+        self.assertFileList(root, ['111', '222' ])
+
+        # Create a cursor for this state
+        self.watchmanCommand('since', root, 'n:foo')
+
+        os.unlink(os.path.join(root, '111'))
+
+        expr = {
+            "fields": ["name", "symlink_target"],
+            "since" : 'n:foo',
+        }
+
+        res = self.watchmanCommand('query', root, expr)
+        files = res['files']
+        #print files
+        self.assertTrue(files and files[0]['name']  == '111'
+            and os.path.basename(files[0]['symlink_target']) == '222')
+
+    # test to see that when a symbolic link is changed to a file,
+    # the symlink target is updated correctly
+    @unittest.skipIf(os.name == 'nt', 'win')
+    def test_symlinkToFileDir(self):
+        root = self.mkdtemp()
+        self.touchRelative(root, '222')
+        os.symlink(os.path.join(root, '222'), os.path.join(root, '111'))
+
+        self.watchmanCommand('watch', root)
+        self.assertFileList(root, ['111', '222'])
+
+        expr = {
+            "expression": ["name", "111"],
+            "fields": ["name", "symlink_target", "type"]
+        }
+
+        res1 = self.watchmanCommand('query', root, expr)
+
+        files1 = res1['files']
+        #print files1
+        self.assertTrue(files1 and os.path.basename(files1[0]['symlink_target']) == '222'
+                and files1[0]['type'] == 'l')
+
+        os.unlink(os.path.join(root, '111'))
+        self.touchRelative(root, '111')
+
+        res2 = self.watchmanCommand('query', root, expr)
+        files2 = res2['files']
+        #print files2
+        self.assertTrue(files2 and ('symlink_target' not in files2[0] or files2[0]['symlink_target'] is None)
+                and files2[0]['type'] == 'f')
+
+        os.unlink(os.path.join(root, '111'))
+        os.mkdir(os.path.join(root, '111'))
+
+        res3 = self.watchmanCommand('query', root, expr)
+        files3 = res3['files']
+        #print files3
+        self.assertTrue(files3 and ('symlink_target' not in files3[0] or files3[0]['symlink_target'] is None)
+                and files3[0]['type'] == 'd')

--- a/tests/integration/test_symlink.py
+++ b/tests/integration/test_symlink.py
@@ -31,13 +31,13 @@ class TestSymlink(WatchmanTestCase.WatchmanTestCase):
         }
 
         res = self.watchmanCommand('query', root, expr)
-        self.assertEqual(os.path.basename(res['files'][0]['symlink_target']), '222')
+        self.assertEqualUTF8Strings('222', os.path.basename(res['files'][0]['symlink_target']))
 
         os.unlink(os.path.join(root, '111'))
         os.symlink(os.path.join(root, '333'), os.path.join(root, '111'))
 
         res = self.watchmanCommand('query', root, expr)
-        self.assertEqual(os.path.basename(res['files'][0]['symlink_target']), '333')
+        self.assertEqualUTF8Strings('333', os.path.basename(res['files'][0]['symlink_target']))
 
     # test to see that invalid symbolic link
     # updates are picked up by the symlink_target field
@@ -56,13 +56,13 @@ class TestSymlink(WatchmanTestCase.WatchmanTestCase):
         }
 
         res = self.watchmanCommand('query', root, expr)
-        self.assertEqual(os.path.basename(res['files'][0]['symlink_target']), '222')
+        self.assertEqualUTF8Strings('222', os.path.basename(res['files'][0]['symlink_target']))
 
         os.unlink(os.path.join(root, '111'))
         os.symlink(os.path.join(root, '333'), os.path.join(root, '111'))
 
         res = self.watchmanCommand('query', root, expr)
-        self.assertEqual(os.path.basename(res['files'][0]['symlink_target']), '333')
+        self.assertEqualUTF8Strings('333', os.path.basename(res['files'][0]['symlink_target']))
 
     # test to see that symbolic link deletes work
     @unittest.skipIf(os.name == 'nt', 'win')
@@ -85,8 +85,8 @@ class TestSymlink(WatchmanTestCase.WatchmanTestCase):
         }
 
         res = self.watchmanCommand('query', root, expr)
-        self.assertEqual(res['files'][0]['name'], '111')
-        self.assertEqual(os.path.basename(res['files'][0]['symlink_target']), '222')
+        self.assertEqualUTF8Strings('111', res['files'][0]['name'])
+        self.assertEqualUTF8Strings('222', os.path.basename(res['files'][0]['symlink_target']))
 
     # test to see that when a symbolic link is changed to a file,
     # the symlink target is updated correctly
@@ -106,19 +106,19 @@ class TestSymlink(WatchmanTestCase.WatchmanTestCase):
 
         res = self.watchmanCommand('query', root, expr)
 
-        self.assertEqual(os.path.basename(res['files'][0]['symlink_target']), '222')
-        self.assertEqual(res['files'][0]['type'], 'l')
+        self.assertEqualUTF8Strings('222', os.path.basename(res['files'][0]['symlink_target']))
+        self.assertEqualUTF8Strings('l', res['files'][0]['type'])
 
         os.unlink(os.path.join(root, '111'))
         self.touchRelative(root, '111')
 
         res = self.watchmanCommand('query', root, expr)
         self.assertTrue(res['files'] and ('symlink_target' not in res['files'][0] or res['files'][0]['symlink_target'] is None))
-        self.assertEqual(res['files'][0]['type'], 'f')
+        self.assertEqualUTF8Strings('f', res['files'][0]['type'])
 
         os.unlink(os.path.join(root, '111'))
         os.mkdir(os.path.join(root, '111'))
 
         res = self.watchmanCommand('query', root, expr)
         self.assertTrue(res['files'] and ('symlink_target' not in res['files'][0] or res['files'][0]['symlink_target'] is None))
-        self.assertEqual(res['files'][0]['type'], 'd')
+        self.assertEqualUTF8Strings('d', res['files'][0]['type'])

--- a/watchman.h
+++ b/watchman.h
@@ -401,6 +401,10 @@ struct watchman_file {
   /* cache stat results so we can tell if an entry
    * changed */
   struct watchman_stat stat;
+
+  /* the symbolic link target of this file.
+   * Can be NULL if not a symlink, or we failed to read the target */
+  w_string_t *symlink_target;
 };
 
 #define WATCHMAN_COOKIE_PREFIX ".watchman-cookie-"


### PR DESCRIPTION
Summary: Add a field for symlink_target in watchman file.
Add a query field to return the symlink_target for the file.

When symbolic link changes, update the target metadata.

Test Plan: Added tests for symlink. Some of these tests are
not run on Darwin and NT, because of platform specific behavior.

1. test for basic symlink targets.
2. invalid symlinks.
3. deletion of symlinks.
4. transition of symlink to regular file or directory

Reviewers: wez

Subscribers:

Tasks:

Blame Revision: