### PR TITLE
fix exponential time complexity during deep tree delete on case insensitive filesystems

### DIFF
--- a/watchman.h
+++ b/watchman.h
@@ -293,6 +293,9 @@ struct watchman_dir {
   w_ht_t *files;
   /* child dirs contained in this dir (keyed by dir->path) */
   w_ht_t *dirs;
+  // If we think this dir was deleted, we'll avoid recursing
+  // to its children when processing deletes
+  bool exists;
 };
 
 struct watchman_ops {


### PR DESCRIPTION
Summary: we've seen this crop up a couple of times, but not enough
that it warranted digging in.  While testing the new ART-based
optimizations for the pending tree, I found this pretty easy to
reproduce.

The steps in the Test Plan cause the tree to be recursively removed and
then recreated.

The problem is that we can recursively call either `w_root_mark_deleted`
to walk down the tree, or in a couple of cases `stat_path` to look up
the tree.  In the delete case this can cause some wasted and repetitive
walking up and down the tree.

This diff adds a simple `exists` field to the `dir` structure that we
can use to indicate whether we have processed a delete on the dir or
not.  This defaults to true and is used to gate recursion in
`w_root_mark_deleted` (and is set there on the first time through), and
is cleared in `stat_path` when we have observed the directory as
existing.

This flag is also used to gate the upwards recursion into `stat_path`
that occurs in the case of a canonical path miss, and in another case
where we need to observe an mtime update on a parent dir.  Both of these
cases should really be adding to the pending list anyway, so I've fixed
those in this diff too.

Test Plan:
In a mercurial checkout of a big repo:

`hg sparse -X foooid`

(where foooid is a deep tree with many tens of thousands of files)

followed by:

`hg sparse --reset`

Before this change, I would observe watchman spinning away in the
activity monitor.  Instruments and a process sample showed that we were
sticking in the functions listed above.

After this change, this behavior is resolved.