### PR TITLE
Optimize pending list processing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -200,7 +200,9 @@ integration: all py-integration
 tests_art_t_CPPFLAGS = $(THIRDPARTY_CPPFLAGS)
 tests_art_t_LDADD = $(ART_LIB) $(TAP_LIB)
 tests_art_t_SOURCES = \
-	tests/art_test.c
+	tests/art_test.c \
+	tests/log_stub.c \
+	log.c
 
 tests_argv_t_CPPFLAGS = $(THIRDPARTY_CPPFLAGS)
 tests_argv_t_LDADD = $(JSON_LIB) $(TAP_LIB)
@@ -212,6 +214,7 @@ tests_ignore_t_CPPFLAGS = $(THIRDPARTY_CPPFLAGS)
 tests_ignore_t_LDADD = $(ART_LIB) $(TAP_LIB) $(JSON_LIB)
 tests_ignore_t_SOURCES = \
 	tests/ignore_test.c \
+	tests/log_stub.c \
 	watcher/helper.c \
 	hash.c \
 	ht.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -121,6 +121,7 @@ TESTS = \
 		tests/argv.t \
 		tests/bser.t \
 		tests/ignore.t \
+		tests/pending.t \
 		tests/log.t \
 		tests/wildmatch.t
 noinst_PROGRAMS = $(TESTS)
@@ -219,6 +220,23 @@ tests_ignore_t_SOURCES = \
 	hash.c \
 	ht.c \
 	ignore.c \
+	string.c \
+	log.c
+
+tests_pending_t_CPPFLAGS = $(THIRDPARTY_CPPFLAGS)
+tests_pending_t_LDADD = $(ART_LIB) $(TAP_LIB) $(JSON_LIB)
+tests_pending_t_SOURCES = \
+	tests/pending_test.c \
+	tests/log_stub.c \
+	watcher/helper.c \
+	hash.c \
+	ht.c \
+	ignore.c \
+	pending.c \
+	expflags.c \
+	opendir.c \
+	cfg.c \
+	time.c \
 	string.c \
 	log.c
 

--- a/configure.ac
+++ b/configure.ac
@@ -256,6 +256,7 @@ AC_CHECK_HEADERS(CoreServices/CoreServices.h, [
 ])
 AC_CHECK_FUNCS(backtrace backtrace_symbols backtrace_symbols_fd)
 AC_CHECK_FUNCS(sys_siglist)
+AC_CHECK_FUNCS(memmem)
 
 if test -n "$ac_cv_header_sys_statvfs_h"; then
 AC_CHECK_MEMBERS([struct statvfs.f_fstypename,struct statvfs.f_basetype],

--- a/root.c
+++ b/root.c
@@ -498,12 +498,12 @@ bool w_root_process_pending(w_root_t *root,
   }
 
   w_log(W_LOG_DBG, "processing %d events in %s\n",
-      w_ht_size(coll->pending_uniq), root->root_path->buf);
+      w_pending_coll_size(coll), root->root_path->buf);
 
   // Steal the contents
   pending = coll->pending;
   coll->pending = NULL;
-  w_ht_free_entries(coll->pending_uniq);
+  w_pending_coll_drain(coll);
 
   while (pending) {
     p = pending;

--- a/string.c
+++ b/string.c
@@ -348,6 +348,32 @@ bool w_string_startswith_caseless(w_string_t *str, w_string_t *prefix)
   return true;
 }
 
+bool w_string_contains_cstr_len(w_string_t *str, const char *needle,
+                                uint32_t nlen) {
+#if HAVE_MEMMEM
+  return memmem(str->buf, str->len, needle, nlen) != NULL;
+#else
+  // Most likely only for Windows.
+  // Inspired by http://stackoverflow.com/a/24000056/149111
+  const char *haystack = str->buf;
+  uint32_t hlen = str->len;
+  const char *limit;
+
+  if (nlen == 0 || hlen < nlen) {
+    return false;
+  }
+
+  limit = haystack + hlen - nlen + 1;
+  while ((haystack = memchr(haystack, needle[0], limit - haystack)) != NULL) {
+    if (memcmp(haystack, needle, nlen) == 0) {
+      return true;
+    }
+    haystack++;
+  }
+  return false;
+#endif
+}
+
 w_string_t *w_string_canon_path(w_string_t *str)
 {
   int end;

--- a/tests/ignore_test.c
+++ b/tests/ignore_test.c
@@ -3,7 +3,6 @@
 
 #include "watchman.h"
 #include "thirdparty/tap.h"
-#include "thirdparty/libart/src/art.h"
 
 // A list that looks similar to one used in one of our repos
 const char *ignore_dirs[] = {".buckd",
@@ -35,20 +34,6 @@ const char *ignore_dirs[] = {".buckd",
                              "baz/bar/bar/foo/foo"};
 
 const char *ignore_vcs[] = {".hg", ".svn", ".git"};
-
-void w_request_shutdown(void) {}
-
-bool w_should_log_to_clients(int level)
-{
-  unused_parameter(level);
-  return false;
-}
-
-void w_log_to_clients(int level, const char *buf)
-{
-  unused_parameter(level);
-  unused_parameter(buf);
-}
 
 struct test_case {
   const char *path;

--- a/tests/log_stub.c
+++ b/tests/log_stub.c
@@ -1,0 +1,21 @@
+/* Copyright 2016-present Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0. */
+
+#include "watchman.h"
+
+// These are logging stubs to facilitate testing code that pulls in w_log
+// either directly or indirectly.
+
+void w_request_shutdown(void) {}
+
+bool w_should_log_to_clients(int level)
+{
+  unused_parameter(level);
+  return false;
+}
+
+void w_log_to_clients(int level, const char *buf)
+{
+  unused_parameter(level);
+  unused_parameter(buf);
+}

--- a/tests/pending_test.c
+++ b/tests/pending_test.c
@@ -1,0 +1,132 @@
+/* Copyright 2016-present Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0. */
+
+#include "watchman.h"
+#include "thirdparty/tap.h"
+#include "thirdparty/libart/src/art.h"
+
+struct pending_list {
+  struct watchman_pending_fs *pending, *avail, *end;
+};
+
+struct watchman_pending_fs *next_pending(struct pending_list *list) {
+  if (list->avail == list->end) {
+    fail("make list alloc size bigger (used %u entries)",
+         list->avail - list->pending);
+    abort();
+  }
+
+  return list->avail++;
+}
+
+static void build_list(struct pending_list *list, w_string_t *parent_name,
+                       size_t depth, size_t num_files, size_t num_dirs) {
+  size_t i;
+  for (i = 0; i < num_files; i++) {
+    struct watchman_pending_fs *item = next_pending(list);
+    item->path = w_string_make_printf("%.*s/file%d", parent_name->len,
+                                      parent_name->buf, i);
+    item->flags = W_PENDING_VIA_NOTIFY;
+  }
+
+  for (i = 0; i < num_dirs; i++) {
+    struct watchman_pending_fs *item = next_pending(list);
+    item->path = w_string_make_printf("%.*s/dir%d", parent_name->len,
+                                      parent_name->buf, i);
+    item->flags = W_PENDING_RECURSIVE;
+
+    if (depth > 0) {
+      build_list(list, item->path, depth - 1, num_files, num_dirs);
+    }
+  }
+}
+
+size_t process_items(struct watchman_pending_collection *coll) {
+  struct watchman_pending_fs *item;
+  size_t drained = 0;
+  struct stat st;
+
+  while ((item = w_pending_coll_pop(coll)) != NULL) {
+    // To simulate looking at the file, we're just going to stat
+    // ourselves over and over, as the path we put in the list
+    // doesn't exist on the filesystem.  We're measuring hot cache
+    // (best case) stat performance here.
+    w_lstat(__FILE__, &st, true);
+    w_pending_fs_free(item);
+
+    drained++;
+  }
+  return drained;
+}
+
+// Simulate
+static void bench_pending(void) {
+  // These parameters give us 262140 items to track
+  const size_t tree_depth = 7;
+  const size_t num_files_per_dir = 8;
+  const size_t num_dirs_per_dir = 4;
+  w_string_t *root_name = w_string_new("/some/path");
+  struct pending_list list;
+  const size_t alloc_size = 280000;
+
+  list.pending = calloc(alloc_size, sizeof(struct watchman_pending_fs));
+  list.avail = list.pending;
+  list.end = list.pending + alloc_size;
+
+  // Build a list ordered from the root (top) down to the leaves.
+  build_list(&list, root_name, tree_depth, num_files_per_dir, num_dirs_per_dir);
+  diag("built list with %u items", list.avail - list.pending);
+
+  // Benchmark insertion in top-down order.
+  struct timeval start, end;
+  {
+    struct watchman_pending_collection coll;
+    struct watchman_pending_fs *item;
+    size_t drained = 0;
+
+    w_pending_coll_init(&coll);
+
+    gettimeofday(&start, NULL);
+    for (item = list.pending; item < list.avail; item++) {
+      w_pending_coll_add(&coll, item->path, item->now, item->flags);
+    }
+    drained = process_items(&coll);
+
+    gettimeofday(&end, NULL);
+    diag("took %.3fs to insert %u items into pending coll",
+         w_timeval_diff(start, end), drained);
+  }
+
+  // and now in reverse order; this is from the leaves of the filesystem
+  // tree up to the root, or bottom-up.  This simulates the workload of
+  // a recursive delete of a filesystem tree.
+  {
+    struct watchman_pending_collection coll;
+    struct watchman_pending_fs *item;
+    size_t drained = 0;
+
+    w_pending_coll_init(&coll);
+
+    gettimeofday(&start, NULL);
+    for (item = list.avail - 1; item >= list.pending; item--) {
+      w_pending_coll_add(&coll, item->path, item->now, item->flags);
+    }
+
+    drained = process_items(&coll);
+
+    gettimeofday(&end, NULL);
+    diag("took %.3fs to reverse insert %u items into pending coll",
+         w_timeval_diff(start, end), drained);
+  }
+}
+
+int main(int argc, char **argv) {
+  (void)argc;
+  (void)argv;
+
+  plan_tests(1);
+  bench_pending();
+  pass("got here");
+
+  return exit_status();
+}

--- a/thirdparty/libart/src/art.c
+++ b/thirdparty/libart/src/art.c
@@ -151,9 +151,9 @@ static art_node** find_child(art_node *n, unsigned char c) {
             }
             break;
 
-        {
-        __m128i cmp;
         case NODE16:
+        {
+            __m128i cmp;
             p.p2 = (art_node16*)n;
 
             // Compare the key to all 16 stored keys
@@ -960,3 +960,5 @@ int art_iter_prefix(art_tree *t, const unsigned char *key, int key_len, art_call
     }
     return 0;
 }
+
+// vim:ts=4:sw=4:

--- a/thirdparty/libart/src/art.c
+++ b/thirdparty/libart/src/art.c
@@ -371,32 +371,43 @@ art_leaf* art_longest_match(const art_tree *t, const unsigned char *key, int key
 }
 
 // Find the minimum leaf under a node
-static art_leaf* minimum(const art_node *n) {
+static art_leaf *minimum(const art_node *n) {
     int idx;
     union cnode_ptr p = {n};
 
-    // Handle base cases
-    if (!n) return NULL;
-    if (IS_LEAF(n)) return LEAF_RAW(n);
+    while (p.n) {
+        if (IS_LEAF(p.n)) {
+            return LEAF_RAW(p.n);
+        }
 
-    switch (n->type) {
-        case NODE4:
-            return minimum(p.n4->children[0]);
-        case NODE16:
-            return minimum(p.n16->children[0]);
-        case NODE48:
-            idx=0;
-            while (!p.n48->keys[idx]) idx++;
-            idx = p.n48->keys[idx] - 1;
-            return minimum(p.n48->children[idx]);
-        case NODE256:
-            idx=0;
-            while (!p.n256->children[idx]) idx++;
-            return minimum(p.n256->children[idx]);
-        default:
-            abort();
-            return NULL;
+        switch (p.n->type) {
+            case NODE4:
+                p.n = p.n4->children[0];
+                break;
+            case NODE16:
+                p.n = p.n16->children[0];
+                break;
+            case NODE48:
+                idx = 0;
+                while (!p.n48->keys[idx]) {
+                    idx++;
+                }
+                idx = p.n48->keys[idx] - 1;
+                p.n = p.n48->children[idx];
+                break;
+            case NODE256:
+                idx = 0;
+                while (!p.n256->children[idx]) {
+                    idx++;
+                }
+                p.n = p.n256->children[idx];
+                break;
+            default:
+                abort();
+                return NULL;
+        }
     }
+    return NULL;
 }
 
 // Find the maximum leaf under a node
@@ -404,28 +415,39 @@ static art_leaf* maximum(const art_node *n) {
     int idx;
     union cnode_ptr p = {n};
 
-    // Handle base cases
-    if (!n) return NULL;
-    if (IS_LEAF(n)) return LEAF_RAW(n);
+    while (p.n) {
+        if (IS_LEAF(p.n)) {
+            return LEAF_RAW(p.n);
+        }
 
-    switch (n->type) {
-        case NODE4:
-            return maximum(p.n4->children[n->num_children-1]);
-        case NODE16:
-            return maximum(p.n16->children[n->num_children-1]);
-        case NODE48:
-            idx=255;
-            while (!p.n48->keys[idx]) idx--;
-            idx = p.n48->keys[idx] - 1;
-            return maximum(p.n48->children[idx]);
-        case NODE256:
-            idx=255;
-            while (!p.n256->children[idx]) idx--;
-            return maximum(p.n256->children[idx]);
-        default:
-            abort();
-            return NULL;
+        switch (p.n->type) {
+            case NODE4:
+                p.n = p.n4->children[p.n->num_children - 1];
+                break;
+            case NODE16:
+                p.n = p.n16->children[p.n->num_children - 1];
+                break;
+            case NODE48:
+                idx = 255;
+                while (!p.n48->keys[idx]) {
+                    idx--;
+                }
+                idx = p.n48->keys[idx] - 1;
+                p.n = p.n48->children[idx];
+                break;
+            case NODE256:
+                idx = 255;
+                while (!p.n256->children[idx]) {
+                    idx--;
+                }
+                p.n = p.n256->children[idx];
+                break;
+            default:
+                abort();
+                return NULL;
+        }
     }
+    return NULL;
 }
 
 /**

--- a/thirdparty/libart/src/art.c
+++ b/thirdparty/libart/src/art.c
@@ -121,6 +121,8 @@ static void destroy_node(art_node *n) {
  */
 int art_tree_destroy(art_tree *t) {
     destroy_node(t->root);
+    t->root = NULL;
+    t->size = 0;
     return 0;
 }
 

--- a/thirdparty/libart/src/art.h
+++ b/thirdparty/libart/src/art.h
@@ -7,12 +7,7 @@
 extern "C" {
 #endif
 
-#define NODE4   1
-#define NODE16  2
-#define NODE48  3
-#define NODE256 4
-
-#define MAX_PREFIX_LEN 10
+#define ART_MAX_PREFIX_LEN 10
 
 #if defined(__GNUC__) && !defined(__clang__)
 # if __STDC_VERSION__ >= 199901L && 402 == (__GNUC__ * 100 + __GNUC_MINOR__)
@@ -35,7 +30,7 @@ typedef struct {
     uint8_t type;
     uint8_t num_children;
     uint32_t partial_len;
-    unsigned char partial[MAX_PREFIX_LEN];
+    unsigned char partial[ART_MAX_PREFIX_LEN];
 } art_node;
 
 /**
@@ -99,24 +94,10 @@ typedef struct {
 int art_tree_init(art_tree *t);
 
 /**
- * DEPRECATED
- * Initializes an ART tree
- * @return 0 on success.
- */
-#define init_art_tree(...) art_tree_init(__VA_ARGS__)
-
-/**
  * Destroys an ART tree
  * @return 0 on success.
  */
 int art_tree_destroy(art_tree *t);
-
-/**
- * DEPRECATED
- * Initializes an ART tree
- * @return 0 on success.
- */
-#define destroy_art_tree(...) art_tree_destroy(__VA_ARGS__)
 
 /**
  * Returns the size of the ART tree.

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -33,7 +33,7 @@ if ! make integration ; then
     # runtests.py already copied the logs to the artifact store
     exit 1
   fi
-  find /var/tmp/watchmantest* -name log | xargs cat
+  find /var/tmp/watchmantest* -name log | xargs tail -n 2000
   exit 1
 fi
 

--- a/watchman.h
+++ b/watchman.h
@@ -106,6 +106,7 @@ typedef struct watchman_string w_string_t;
 #include "watchman_hash.h"
 #include "watchman_stream.h"
 #include "watchman_ignore.h"
+#include "watchman_log.h"
 
 #include "jansson.h"
 
@@ -117,11 +118,6 @@ typedef struct watchman_string w_string_t;
 #  define HAVE_FSEVENTS 1
 # endif
 #endif
-
-// Helpers for pasting __LINE__ for symbol generation
-#define w_paste2(pre, post)  pre ## post
-#define w_paste1(pre, post)  w_paste2(pre, post)
-#define w_gen_symbol(pre)    w_paste1(pre, __LINE__)
 
 // We make use of constructors to glue together modules
 // without maintaining static lists of things in the build
@@ -618,29 +614,7 @@ void w_start_reaper(void);
 bool w_is_stopping(void);
 extern pthread_t reaper_thread;
 
-#define W_LOG_OFF 0
-#define W_LOG_ERR 1
-#define W_LOG_DBG 2
-#define W_LOG_FATAL -1
-
-#ifndef WATCHMAN_FMT_STRING
-# define WATCHMAN_FMT_STRING(x) x
-#endif
-
-extern int log_level;
-extern char *log_name;
-const char *w_set_thread_name(const char *fmt, ...);
-const char *w_get_thread_name(void);
-void w_setup_signal_handlers(void);
-void w_log(int level, WATCHMAN_FMT_STRING(const char *fmt), ...)
-#ifdef __GNUC__
-  __attribute__((format(printf, 2, 3)))
-#endif
-;
 void w_request_shutdown(void);
-
-bool w_should_log_to_clients(int level);
-void w_log_to_clients(int level, const char *buf);
 
 bool w_is_ignored(w_root_t *root, const char *path, uint32_t pathlen);
 void w_timeoutms_to_abs_timespec(int timeoutms, struct timespec *deadline);

--- a/watchman.h
+++ b/watchman.h
@@ -248,7 +248,7 @@ typedef struct watchman_clock w_clock_t;
 #define W_PENDING_VIA_NOTIFY 2
 #define W_PENDING_CRAWL_ONLY  4
 struct watchman_pending_fs {
-  struct watchman_pending_fs *next;
+  struct watchman_pending_fs *next, *prev;
   w_string_t *path;
   struct timeval now;
   int flags;
@@ -256,10 +256,10 @@ struct watchman_pending_fs {
 
 struct watchman_pending_collection {
   struct watchman_pending_fs *pending;
-  w_ht_t *pending_uniq;
   pthread_mutex_t lock;
   pthread_cond_t cond;
   bool pinged;
+  art_tree tree;
 };
 
 bool w_pending_coll_init(struct watchman_pending_collection *coll);
@@ -650,6 +650,8 @@ w_string_t *w_string_path_cat_cstr_len(w_string_t *parent, const char *rhs,
                                        uint32_t rhs_len);
 bool w_string_startswith(w_string_t *str, w_string_t *prefix);
 bool w_string_startswith_caseless(w_string_t *str, w_string_t *prefix);
+bool w_string_contains_cstr_len(w_string_t *str, const char *needle,
+                                uint32_t nlen);
 w_string_t *w_string_shell_escape(const w_string_t *str);
 w_string_t *w_string_implode(json_t *arr, const char *delim);
 

--- a/watchman_log.h
+++ b/watchman_log.h
@@ -1,0 +1,47 @@
+/* Copyright 2012-present Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 */
+
+#ifndef WATCHMAN_LOG_H
+#define WATCHMAN_LOG_H
+
+// Helpers for pasting __LINE__ for symbol generation
+#define w_paste2(pre, post)  pre ## post
+#define w_paste1(pre, post)  w_paste2(pre, post)
+#define w_gen_symbol(pre)    w_paste1(pre, __LINE__)
+
+#define W_LOG_OFF 0
+#define W_LOG_ERR 1
+#define W_LOG_DBG 2
+#define W_LOG_FATAL -1
+
+#ifndef WATCHMAN_FMT_STRING
+# define WATCHMAN_FMT_STRING(x) x
+#endif
+
+extern int log_level;
+extern char *log_name;
+const char *w_set_thread_name(const char *fmt, ...);
+const char *w_get_thread_name(void);
+void w_setup_signal_handlers(void);
+void w_log(int level, WATCHMAN_FMT_STRING(const char *fmt), ...)
+#ifdef __GNUC__
+  __attribute__((format(printf, 2, 3)))
+#endif
+;
+
+// Similar to assert(), but uses W_LOG_FATAL to log the stack trace
+// before giving up the ghost
+#ifdef NDEBUG
+# define w_assert(e, ...) ((void)0)
+#else
+#define w_assert(e, ...)                                                       \
+  if (!(e)) {                                                                  \
+    w_log(W_LOG_ERR, "%s:%u failed assertion `%s'\n", __FILE__, __LINE__, #e); \
+    w_log(W_LOG_FATAL, __VA_ARGS__);                                           \
+  }
+#endif
+
+bool w_should_log_to_clients(int level);
+void w_log_to_clients(int level, const char *buf);
+
+#endif

--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -96,7 +96,6 @@ SRCS=\
 TEST_SRCS=\
 	thirdparty\tap.c \
 	thirdparty\wildmatch\wildmatch.c \
-	thirdparty\libart\src\art.c \
 	winbuild\asprintf.c \
 	winbuild\time.c \
 	winbuild\pthread.c \
@@ -111,6 +110,7 @@ TEST_DIR_SRCS=\
 	tests\argv.c \
 	tests\bser.c \
 	tests\ignore_test.c \
+	tests\log_stub.c \
 	tests\log.c
 
 OBJS=$(SRCS:.c=.obj)
@@ -118,7 +118,7 @@ TEST_OBJS=$(TEST_SRCS:.c=.obj)
 TEST_DIR_OBJS=$(TEST_DIR_SRCS:.c=.obj)
 DEPS=$(SRCS:.c=.dep) $(TEST_SRCS:.c=.dep) $(TEST_DIR_SRCS:.c=.dep)
 TESTS=tests\argv.exe tests\log.exe tests\bser.exe tests\wildmatch_test.exe \
-			tests\art.exe tests\ignore.exe
+			tests\art.exe tests\ignore.exe tests\pending.exe
 COLLECTDEPS=$(CC) $(CFLAGS) /Zs /showIncludes /EHsc $< | cscript /nologo //E:jscript winbuild\depends.js --stdin
 
 .c.dep:
@@ -203,17 +203,40 @@ tests\argv.exe: tests\argv.obj $(TEST_OBJS)
 	@echo LINK $@
 	$(LINKER) $** $(LIBS)
 
-tests\art.exe: tests\art_test.obj $(TEST_OBJS)
+tests\art.exe: tests\art_test.obj $(TEST_OBJS) log.obj tests\log_stub.obj thirdparty\libart\src\art.obj
 	@echo LINK $@
 	$(LINKER) $** $(LIBS)
 
 tests\ignore.exe: tests\ignore_test.obj $(TEST_OBJS) \
-		log.obj \
 		watcher\helper.obj \
 		hash.obj \
 		ht.obj \
 		ignore.obj \
-		string.obj
+		string.obj \
+		log.obj \
+		tests\log_stub.obj \
+		thirdparty\libart\src\art.obj
+	@echo LINK $@
+	$(LINKER) $** $(LIBS)
+
+tests\pending.exe: tests\pending_test.obj $(TEST_OBJS) \
+		watcher\helper.obj \
+		hash.obj \
+		ht.obj \
+		ignore.obj \
+		pending.obj \
+		expflags.obj \
+		opendir.obj \
+		cfg.obj \
+		time.obj \
+		string.obj \
+		log.obj \
+		tests\log_stub.obj \
+		thirdparty\libart\src\art.obj \
+		winbuild\pathmap.obj \
+		winbuild\stat.obj \
+		winbuild\realpath.obj \
+		winbuild\dir.obj
 	@echo LINK $@
 	$(LINKER) $** $(LIBS)
 


### PR DESCRIPTION
This is a series of diffs to improve our handling of pending list processing.

There are a couple of diffs that are simple refactorings to libart, but there are two that bear special scrutiny:

* `libart: better defined behavior when a full prefix key is encountered`
* `use art to optimize pending list construction`

The former is necessary to avoid being forced to make a copy and NUL-terminate all input strings for both lookup, prefix iteration and insertion.

The latter is really the main component of this pull request.

In the included benchmark we can reduce a bloated pending list full of 260k pending lstat operations down to a dozen or so recursive walks.  This is advantageous because it eliminates a large number of redundant lstat calls and should give us lower latency and higher throughput when processing notifications from the kernel.

That benchmark changes the 2 seconds it takes for 260k lstat calls for todays implementation to a fraction of a second with this more optimal version.

In addition to the individual test plans in these diffs, I run through the mercurial test suite with the tip of this branch:

```
 WATCHMAN_SOCK=/opt/facebook/watchman/var/run/watchman/wez-state/sock ./run-tests.py --blacklist=blacklists/fsmonitor --extra-config="extensions.fsmonitor=" -j 3
```

and observed no new failures vs. the currently deployed watchman.