### PR TITLE
listener: allow writing to socket for entities with access

### DIFF
--- a/cfg.c
+++ b/cfg.c
@@ -251,7 +251,7 @@ double cfg_get_double(w_root_t *root, const char *name, double defval) {
 
 #define MAKE_GET_PERM(PROP, SUFFIX) \
   static mode_t get_ ## PROP ## _perm(const char *name, json_t *val, \
-                                      bool execute_bits) { \
+                                      bool write_bits, bool execute_bits) { \
     mode_t ret = 0; \
     json_t *perm = json_object_get(val, #PROP); \
     if (perm) { \
@@ -261,6 +261,9 @@ double cfg_get_double(w_root_t *root, const char *name, double defval) {
       } \
       if (json_is_true(perm)) { \
         ret |= S_IR ## SUFFIX; \
+        if (write_bits) { \
+          ret |= S_IW ## SUFFIX; \
+        } \
         if (execute_bits) { \
           ret |= S_IX ## SUFFIX; \
         } \
@@ -276,7 +279,8 @@ MAKE_GET_PERM(others, OTH)
  * This function expects the config to be an object containing the keys 'group'
  * and 'others', each a bool.
  */
-mode_t cfg_get_perms(w_root_t *root, const char *name, bool execute_bits) {
+mode_t cfg_get_perms(w_root_t *root, const char *name, bool write_bits,
+                     bool execute_bits) {
   json_t *val = cfg_get_json(root, name);
   mode_t ret = S_IRUSR | S_IWUSR;
   if (execute_bits) {
@@ -288,8 +292,8 @@ mode_t cfg_get_perms(w_root_t *root, const char *name, bool execute_bits) {
       w_log(W_LOG_FATAL, "Expected config value %s to be an object\n", name);
     }
 
-    ret |= get_group_perm(name, val, execute_bits);
-    ret |= get_others_perm(name, val, execute_bits);
+    ret |= get_group_perm(name, val, write_bits, execute_bits);
+    ret |= get_others_perm(name, val, write_bits, execute_bits);
   }
 
   return ret;

--- a/listener.c
+++ b/listener.c
@@ -320,7 +320,9 @@ static void wakeme(int signo)
 static int get_listener_socket(const char *path)
 {
   struct sockaddr_un un;
-  mode_t perms = cfg_get_perms(NULL, "sock_access", false);
+  mode_t perms = cfg_get_perms(NULL, "sock_access",
+                               true /* write bits */,
+                               false /* execute bits */);
 
 #ifdef __APPLE__
   listener_fd = w_get_listener_socket_from_launchd();

--- a/main.c
+++ b/main.c
@@ -486,8 +486,11 @@ static void compute_file_name(char **strp,
       uid_t euid = geteuid();
       // TODO: also allow a gid to be specified here
       const char *sock_group_name = cfg_get_string(NULL, "sock_group", NULL);
-      // S_ISGID is set so that files inside this directory inherit permissions
-      mode_t dir_perms = cfg_get_perms(NULL, "sock_access", true) | S_ISGID;
+      // S_ISGID is set so that files inside this directory inherit the group
+      // name
+      mode_t dir_perms = cfg_get_perms(NULL, "sock_access",
+                                       false /* write bits */,
+                                       true /* execute bits */) | S_ISGID;
 
       dirp = opendir(state_dir);
       if (!dirp) {

--- a/tests/integration/test_sock_perms.py
+++ b/tests/integration/test_sock_perms.py
@@ -127,7 +127,7 @@ class TestSockPerms(unittest.TestCase):
         instance.stop()
 
         self.assertFileMode(instance.user_dir, 0o750 | stat.S_ISGID)
-        self.assertFileMode(instance.sock_file, 0o640)
+        self.assertFileMode(instance.sock_file, 0o660)
 
     def test_custom_sock_access_others(self):
         instance = self._new_instance({'sock_access': {'group': True,
@@ -136,7 +136,7 @@ class TestSockPerms(unittest.TestCase):
         instance.stop()
 
         self.assertFileMode(instance.user_dir, 0o755 | stat.S_ISGID)
-        self.assertFileMode(instance.sock_file, 0o644)
+        self.assertFileMode(instance.sock_file, 0o666)
 
     def test_sock_access_upgrade(self):
         instance = self._new_instance({'sock_access': {'group': True,
@@ -147,7 +147,7 @@ class TestSockPerms(unittest.TestCase):
         instance.stop()
 
         self.assertFileMode(instance.user_dir, 0o755 | stat.S_ISGID)
-        self.assertFileMode(instance.sock_file, 0o644)
+        self.assertFileMode(instance.sock_file, 0o666)
 
     def test_sock_access_downgrade(self):
         instance = self._new_instance({'sock_access': {'group': True}})
@@ -157,7 +157,7 @@ class TestSockPerms(unittest.TestCase):
         instance.stop()
 
         self.assertFileMode(instance.user_dir, 0o750 | stat.S_ISGID)
-        self.assertFileMode(instance.sock_file, 0o640)
+        self.assertFileMode(instance.sock_file, 0o660)
 
     def test_sock_access_group_change(self):
         gid = self._get_custom_gid()

--- a/watchman.h
+++ b/watchman.h
@@ -950,7 +950,8 @@ json_int_t cfg_get_int(w_root_t *root, const char *name,
     json_int_t defval);
 bool cfg_get_bool(w_root_t *root, const char *name, bool defval);
 double cfg_get_double(w_root_t *root, const char *name, double defval);
-mode_t cfg_get_perms(w_root_t *root, const char *name, bool execute_bits);
+mode_t cfg_get_perms(w_root_t *root, const char *name, bool write_bits,
+                     bool execute_bits);
 const char *cfg_get_trouble_url(void);
 json_t *cfg_compute_root_files(bool *enforcing);
 


### PR DESCRIPTION
Without this, on Linux you can't connect to the socket.