### PR TITLE
Transition to BSER v2.

### DIFF
--- a/bser.c
+++ b/bser.c
@@ -401,7 +401,7 @@ int w_bser_write_pdu(const uint32_t bser_version,
   }
 
   if (bser_version == 2) {
-    if (bser_int(&ctx, bser_capabilities, data)) {
+    if (dump((const char*) &bser_capabilities, 4, data)) {
       return -1;
     }
   }

--- a/bser.c
+++ b/bser.c
@@ -225,8 +225,20 @@ static int bser_utf8string(const bser_ctx_t *ctx, const char *str, void *data)
 
 static int bser_mixedstring(const bser_ctx_t *ctx, const char *str, void *data)
 {
-  // TODO: Add escaping
-  return bser_generic_string(ctx, str, data, bser_bytestring_hdr);
+  int res, length;
+  char *cpy;
+  if (!(BSER_CAP_DISABLE_UNICODE_FOR_ERRORS & ctx->bser_capabilities) &&
+      !(BSER_CAP_DISABLE_UNICODE & ctx->bser_capabilities)) {
+    length = strlen(str);
+    cpy = malloc(length + 1);
+    memcpy(cpy, str, length + 1);
+    utf8_fix_string(cpy, length);
+    res = bser_utf8string(ctx, str, data);
+    free(cpy);
+  } else {
+    res = bser_bytestring(ctx, str, data);
+  }
+  return res;
 }
 
 static int bser_array(const bser_ctx_t *ctx, const json_t *array, void *data);

--- a/bser.c
+++ b/bser.c
@@ -29,6 +29,11 @@
 #define BSER_NULL      0x0a
 #define BSER_TEMPLATE  0x0b
 #define BSER_SKIP      0x0c
+#define BSER_UTF8STRING 0x0d
+
+// BSER capabilities. Must be powers of 2.
+#define BSER_CAP_DISABLE_UNICODE 0x1
+#define BSER_CAP_DISABLE_UNICODE_FOR_ERRORS 0x2
 
 static const char bser_true = BSER_TRUE;
 static const char bser_false = BSER_FALSE;
@@ -38,6 +43,7 @@ static const char bser_array_hdr = BSER_ARRAY;
 static const char bser_object_hdr = BSER_OBJECT;
 static const char bser_template_hdr = BSER_TEMPLATE;
 static const char bser_skip = BSER_SKIP;
+static const char bser_utf8string_hdr = BSER_UTF8STRING;
 
 static bool is_bser_version_supported(const bser_ctx_t *ctx) {
   return ctx->bser_version == 1 || ctx->bser_version == 2;
@@ -56,8 +62,8 @@ static int bser_real(const bser_ctx_t *ctx, double val, void *data)
   return ctx->dump((char*)&val, sizeof(val), data);
 }
 
-bool bunser_bytestring(const char *buf, json_int_t avail, json_int_t *needed,
-    const char **start, json_int_t *len)
+bool bunser_generic_string(const char *buf, json_int_t avail,
+    json_int_t *needed, const char **start, json_int_t *len)
 {
   json_int_t ineed;
 
@@ -179,7 +185,8 @@ static int bser_int(const bser_ctx_t *ctx, json_int_t val, void *data)
   return ctx->dump(iptr, size, data);
 }
 
-static int bser_bytestring(const bser_ctx_t *ctx, const char *str, void *data)
+static int bser_generic_string(const bser_ctx_t *ctx, const char *str,
+    void *data, const char hdr)
 {
   size_t len = strlen(str);
 
@@ -187,7 +194,7 @@ static int bser_bytestring(const bser_ctx_t *ctx, const char *str, void *data)
     return -1;
   }
 
-  if (ctx->dump(&bser_bytestring_hdr, sizeof(bser_bytestring_hdr), data)) {
+  if (ctx->dump(&hdr, sizeof(hdr), data)) {
     return -1;
   }
 
@@ -200,6 +207,26 @@ static int bser_bytestring(const bser_ctx_t *ctx, const char *str, void *data)
   }
 
   return 0;
+}
+
+static int bser_bytestring(const bser_ctx_t *ctx, const char *str, void *data)
+{
+  return bser_generic_string(ctx, str, data, bser_bytestring_hdr);
+}
+
+static int bser_utf8string(const bser_ctx_t *ctx, const char *str, void *data)
+{
+  if ((ctx->bser_capabilities & BSER_CAP_DISABLE_UNICODE) ||
+      ctx->bser_version == 1) {
+    return bser_bytestring(ctx, str, data);
+  }
+    return bser_generic_string(ctx, str, data, bser_utf8string_hdr);
+}
+
+static int bser_mixedstring(const bser_ctx_t *ctx, const char *str, void *data)
+{
+  // TODO: Add escaping
+  return bser_generic_string(ctx, str, data, bser_bytestring_hdr);
 }
 
 static int bser_array(const bser_ctx_t *ctx, const json_t *array, void *data);
@@ -336,7 +363,7 @@ static int bser_object(const bser_ctx_t *ctx, json_t *obj, void *data)
 int w_bser_dump(const bser_ctx_t* ctx, json_t *json, void *data)
 {
   int type = json_typeof(json);
-
+  w_string_t* wstr;
   if (!is_bser_version_supported(ctx)) {
     return -1;
   }
@@ -353,7 +380,16 @@ int w_bser_dump(const bser_ctx_t* ctx, json_t *json, void *data)
     case JSON_INTEGER:
       return bser_int(ctx, json_integer_value(json), data);
     case JSON_STRING:
-      return bser_bytestring(ctx, json_string_value(json), data);
+      wstr = json_to_w_string(json);
+      switch (wstr->type) {
+        case W_STRING_BYTE:
+          return bser_bytestring(ctx, json_string_value(json), data);
+        case W_STRING_UNICODE:
+          return bser_utf8string(ctx, json_string_value(json), data);
+        case W_STRING_MIXED:
+          return bser_mixedstring(ctx, json_string_value(json), data);
+
+      }
     case JSON_ARRAY:
       return bser_array(ctx, json, data);
     case JSON_OBJECT:
@@ -582,7 +618,7 @@ static json_t *bunser_object(const char *buf, const char *end,
     json_t *item;
 
     // Read key
-    if (!bunser_bytestring(buf, end - buf, &needed, &start, &slen)) {
+    if (!bunser_generic_string(buf, end - buf, &needed, &start, &slen)) {
       *used = total + needed;
       json_decref(objval);
       snprintf(jerr->text, sizeof(jerr->text),
@@ -646,17 +682,19 @@ json_t *bunser(const char *buf, const char *end, json_int_t *needed,
       return json_integer(ival);
 
     case BSER_BYTESTRING:
+    case BSER_UTF8STRING:
     {
       const char *start;
       json_int_t len;
 
-      if (!bunser_bytestring(buf, end - buf, needed, &start, &len)) {
+      if (!bunser_generic_string(buf, end - buf, needed, &start, &len)) {
         snprintf(jerr->text, sizeof(jerr->text),
             "invalid bytestring encoding");
         return NULL;
       }
 
-      return typed_string_len_to_json(start, len, W_STRING_BYTE);
+      return typed_string_len_to_json(start, len,
+          buf[0] == BSER_BYTESTRING? W_STRING_BYTE : W_STRING_UNICODE);
     }
 
     case BSER_REAL:

--- a/checksock.c
+++ b/checksock.c
@@ -32,7 +32,7 @@ static void *check_my_sock(void *unused) {
   w_stm_set_nonblock(client, false);
 
   w_json_buffer_init(&buf);
-  if (!w_ser_write_pdu(is_bser, &buf, client, cmd)) {
+  if (!w_ser_write_pdu(is_bser, 0, &buf, client, cmd)) {
     w_log(W_LOG_FATAL, "Failed to send get-pid PDU: %s\n",
           strerror(errno));
     /* NOTREACHED */

--- a/cmds/reg.c
+++ b/cmds/reg.c
@@ -102,7 +102,8 @@ static struct watchman_command_handler_def *lookup(
   return NULL;
 }
 
-void preprocess_command(json_t *args, enum w_pdu_type output_pdu)
+void preprocess_command(json_t *args, enum w_pdu_type output_pdu,
+    uint32_t output_capabilities)
 {
   char *errmsg = NULL;
   struct watchman_command_handler_def *def;
@@ -130,7 +131,7 @@ void preprocess_command(json_t *args, enum w_pdu_type output_pdu)
     );
 
     w_json_buffer_init(&jr);
-    w_ser_write_pdu(output_pdu, &jr, w_stm_stdout(), err);
+    w_ser_write_pdu(output_pdu, output_capabilities, &jr, w_stm_stdout(), err);
     json_decref(err);
     w_json_buffer_free(&jr);
 

--- a/json.c
+++ b/json.c
@@ -161,20 +161,15 @@ bool w_bser_decode_pdu_info(w_jbuffer_t *jr, w_stm_t stm, uint32_t bser_version,
 {
   json_int_t needed;
   if (bser_version == 2) {
-    while (!bunser_int(jr->buf + jr->rpos, jr->wpos - jr->rpos,
-          &needed, bser_capabilities)) {
-      if (needed == -1) {
-        snprintf(jerr->text, sizeof(jerr->text),
-            "failed to read BSER capabilities");
-        return false;
-      }
+    while (jr->wpos - jr->rpos < 4) {
       if (!fill_buffer(jr, stm)) {
         snprintf(jerr->text, sizeof(jerr->text),
             "unable to fill buffer");
         return false;
       }
     }
-    jr->rpos += (uint32_t)needed;
+    memcpy(bser_capabilities, jr->buf + jr->rpos, 4);
+    jr->rpos += (uint32_t)4;
   }
   while (!bunser_int(jr->buf + jr->rpos, jr->wpos - jr->rpos,
         &needed, len)) {

--- a/json.c
+++ b/json.c
@@ -3,6 +3,7 @@
 
 #include "watchman.h"
 
+W_CAP_REG("bser-v2")
 bool w_json_buffer_init(w_jbuffer_t *jr)
 {
   memset(jr, 0, sizeof(*jr));

--- a/listener.c
+++ b/listener.c
@@ -192,6 +192,7 @@ static void *client_thread(void *ptr)
         goto disconnected;
       } else if (request) {
         client->pdu_type = client->reader.pdu_type;
+        client->capabilities = client->reader.capabilities;
         dispatch_command(client, request, CMD_DAEMON);
         json_decref(request);
       }
@@ -219,8 +220,9 @@ static void *client_thread(void *ptr)
          * Don't bother sending any more messages if the client disconnects,
          * but still free their memory.
          */
-        send_ok = w_ser_write_pdu(client->pdu_type, &client->writer,
-                                  client->stm, response_to_send->json);
+        send_ok = w_ser_write_pdu(client->pdu_type, client->capabilities,
+                                  &client->writer, client->stm,
+                                  response_to_send->json);
         w_stm_set_nonblock(client->stm, true);
       }
 

--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -631,17 +631,15 @@ class Bser2WithFallbackCodec(BserCodec):
 
         capabilities = self.receive()
 
-        # Force the experimental v2 codec to be used. Reactivate fallback
-        # once this codec becomes the default.
-        #if 'error' in capabilities:
-        #  raise Exception('Unsupported BSER version')
+        if 'error' in capabilities:
+            raise Exception('Unsupported BSER version')
 
-        #if capabilities['capabilities']['bser-v2']:
-        self.bser_version = 2
-        self.bser_capabilities = 0
-        #else:
-        #    self.bser_version = 1
-        #    self.bser_capabilities = 0
+        if capabilities['capabilities']['bser-v2']:
+            self.bser_version = 2
+            self.bser_capabilities = 0
+        else:
+            self.bser_version = 1
+            self.bser_capabilities = 0
 
     def _loads(self, response):
         return bser.loads(response)

--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -638,7 +638,7 @@ class Bser2WithFallbackCodec(BserCodec):
 
         #if capabilities['capabilities']['bser-v2']:
         self.bser_version = 2
-        self.bser_capabilities = 1
+        self.bser_capabilities = 0
         #else:
         #    self.bser_version = 1
         #    self.bser_capabilities = 0
@@ -858,13 +858,13 @@ class client(object):
         result = self.recvConn.receive()
         if self._hasprop(result, 'error'):
             error = result['error']
-            if compat.PYTHON3 and isinstance(self.recvConn, BserCodec):
-                error = result['error'].decode('utf-8', 'surrogateescape')
+            if not isinstance(error, compat.UNICODE):
+                error = error.decode('utf-8', 'surrogateescape')
             raise CommandError(error)
 
         if self._hasprop(result, 'log'):
             log = result['log']
-            if compat.PYTHON3 and isinstance(self.recvConn, BserCodec):
+            if not isinstance(log, compat.UNICODE):
                 log = log.decode('utf-8', 'surrogateescape')
             self.logs.append(log)
 

--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -638,7 +638,7 @@ class Bser2WithFallbackCodec(BserCodec):
 
         #if capabilities['capabilities']['bser-v2']:
         self.bser_version = 2
-        self.bser_capabilities = 0
+        self.bser_capabilities = 1
         #else:
         #    self.bser_version = 1
         #    self.bser_capabilities = 0
@@ -656,7 +656,6 @@ class Bser2WithFallbackCodec(BserCodec):
         if hasattr(self, 'bser_version'):
           # Readjust BSER version and capabilities if necessary
           self.bser_version = max(self.bser_version, recv_bser_version)
-          self.capabilities = self.bser_capabilities & recv_bser_capabilities
 
         rlen = len(buf[0])
         while elen > rlen:

--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -631,15 +631,17 @@ class Bser2WithFallbackCodec(BserCodec):
 
         capabilities = self.receive()
 
-        if 'error' in capabilities:
-          raise Exception('Unsupported BSER version')
+        # Force the experimental v2 codec to be used. Reactivate fallback
+        # once this codec becomes the default.
+        #if 'error' in capabilities:
+        #  raise Exception('Unsupported BSER version')
 
-        if capabilities['capabilities']['bser-v2']:
-            self.bser_version = 2
-            self.bser_capabilities = 0
-        else:
-            self.bser_version = 1
-            self.bser_capabilities = 0
+        #if capabilities['capabilities']['bser-v2']:
+        self.bser_version = 2
+        self.bser_capabilities = 0
+        #else:
+        #    self.bser_version = 1
+        #    self.bser_capabilities = 0
 
     def _loads(self, response):
         return bser.loads(response)

--- a/python/pywatchman/bser.c
+++ b/python/pywatchman/bser.c
@@ -278,7 +278,7 @@ static int bser_init(bser_t *bser, uint32_t version, uint32_t capabilities)
 
   // Version 2 also carries an integer indicating the capabilities. The
   // capabilities integer comes before the PDU size.
-#define EMPTY_HEADER_V2 "\x00\x02\x05\x00\x00\x00\x00\x05\x00\x00\x00\x00"
+#define EMPTY_HEADER_V2 "\x00\x02\x00\x00\x00\x00\x05\x00\x00\x00\x00"
   if (version == 2) {
     bser_append(bser, EMPTY_HEADER_V2, sizeof(EMPTY_HEADER_V2)-1);
   } else {
@@ -528,8 +528,8 @@ static PyObject *bser_dumps(PyObject *self, PyObject *args, PyObject *kw)
   } else {
     len = bser.wpos - (sizeof(EMPTY_HEADER_V2) - 1);
     // The BSER capabilities block comes before the PDU length
-    memcpy(bser.buf + 3, &bser_capabilities, sizeof(bser_capabilities));
-    memcpy(bser.buf + 8, &len, sizeof(len));
+    memcpy(bser.buf + 2, &bser_capabilities, sizeof(bser_capabilities));
+    memcpy(bser.buf + 7, &len, sizeof(len));
   }
 
   res = PyBytes_FromStringAndSize(bser.buf, bser.wpos);
@@ -949,7 +949,7 @@ static int pdu_info_helper(PyObject *self, PyObject *args,
   int datalen = 0;
   const char *end;
   uint32_t bser_version;
-  int64_t bser_capabilities = 0; // int64 because bunser_int requires it
+  int32_t bser_capabilities = 0; // int64 because bunser_int requires it
   int64_t expected_len, total_len;
 
   if (!PyArg_ParseTuple(args, "s#", &start, &datalen)) {
@@ -972,9 +972,10 @@ static int pdu_info_helper(PyObject *self, PyObject *args,
   if (bser_version == 2) {
     // Expect an integer telling us what capabilities are supported by the
     // remote server (currently unused).
-    if (!bunser_int(&data, end, &bser_capabilities)) {
+    if (!memcpy(&bser_capabilities, data, 4)) {
       return 0;
     }
+    data += 4;
   }
 
   // Expect an integer telling us how big the rest of the data
@@ -1026,7 +1027,7 @@ static PyObject *bser_loads(PyObject *self, PyObject *args, PyObject *kw)
   const char *value_encoding = NULL;
   const char *value_errors = NULL;
   unser_ctx_t ctx = {1, 0};
-  int64_t bser_capabilities = 0; // int64 because bunser_int requires it
+  int32_t bser_capabilities = 0; // int64 because bunser_int requires it
 
   static char *kw_list[] = {"buf", "mutable", "value_encoding", "value_errors",
                             NULL};
@@ -1064,9 +1065,10 @@ static PyObject *bser_loads(PyObject *self, PyObject *args, PyObject *kw)
   data += 2;
   if (ctx.bser_version == 2) {
     // Expect an integer telling us what BSER capabilities are supported
-    if (!bunser_int(&data, end, &bser_capabilities)) {
-      return NULL;
+    if (!memcpy(&bser_capabilities, data, 4)) {
+      return 0;
     }
+    data += 4;
     ctx.bser_capabilities = (uint32_t) bser_capabilities;
   }
 

--- a/python/pywatchman/bser.c
+++ b/python/pywatchman/bser.c
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BSER_NULL      0x0a
 #define BSER_TEMPLATE  0x0b
 #define BSER_SKIP      0x0c
+#define BSER_UTF8STRING 0x0d
 
 // An immutable object representation of BSER_OBJECT.
 // Rather than build a hash table, key -> value are obtained
@@ -921,6 +922,23 @@ static PyObject *bser_loads_recursive(const char **ptr, const char *end,
         } else {
           return PyBytes_FromStringAndSize(start, (long)len);
         }
+      }
+
+    case BSER_UTF8STRING:
+      {
+        const char *start;
+        int64_t len;
+
+        if (!bunser_bytestring(ptr, end, &start, &len)) {
+          return NULL;
+        }
+
+        if (len > LONG_MAX) {
+          PyErr_Format(PyExc_ValueError, "string too long for python");
+          return NULL;
+        }
+
+        return PyUnicode_Decode(start, (long)len, "utf-8", "strict");
       }
 
     case BSER_ARRAY:

--- a/python/pywatchman/pybser.py
+++ b/python/pywatchman/pybser.py
@@ -54,6 +54,7 @@ BSER_FALSE = b'\x09'
 BSER_NULL = b'\x0a'
 BSER_TEMPLATE = b'\x0b'
 BSER_SKIP = b'\x0c'
+BSER_UTF8STRING = b'\x0d'
 
 if compat.PYTHON3:
     STRING_TYPES = (str, bytes)
@@ -313,12 +314,18 @@ class Bunser(object):
         str_val = struct.unpack_from(tobytes(str_len) + b's', buf, pos)[0]
         return (str_val.decode('utf-8'), pos + str_len)
 
-    def unser_string(self, buf, pos):
+    def unser_bytestring(self, buf, pos):
         str_len, pos = self.unser_int(buf, pos + 1)
         str_val = struct.unpack_from(tobytes(str_len) + b's', buf, pos)[0]
         if self.value_encoding is not None:
             str_val = str_val.decode(self.value_encoding, self.value_errors)
             # str_len stays the same because that's the length in bytes
+        return (str_val, pos + str_len)
+
+    def unser_utf8string(self, buf, pos):
+        str_len, pos = self.unser_int(buf, pos + 1)
+        str_val = struct.unpack_from(tobytes(str_len) + b's', buf, pos)[0]
+        str_val = str_val.decode('utf-8')
         return (str_val, pos + str_len)
 
     def unser_array(self, buf, pos):
@@ -404,7 +411,9 @@ class Bunser(object):
         elif val_type == BSER_NULL:
             return (None, pos + 1)
         elif val_type == BSER_BYTESTRING:
-            return self.unser_string(buf, pos)
+            return self.unser_bytestring(buf, pos)
+        elif val_type == BSER_UTF8STRING:
+            return self.unser_utf8string(buf, pos)
         elif val_type == BSER_ARRAY:
             return self.unser_array(buf, pos)
         elif val_type == BSER_OBJECT:

--- a/python/pywatchman/pybser.py
+++ b/python/pywatchman/pybser.py
@@ -69,7 +69,7 @@ else:
 # our overall length.  To make things simpler, we'll use an
 # int32 for the header
 EMPTY_HEADER = b"\x00\x01\x05\x00\x00\x00\x00"
-EMPTY_HEADER_V2 = b"\x00\x02\x05\x00\x00\x00\x00\x05\x00\x00\x00\x00"
+EMPTY_HEADER_V2 = b"\x00\x02\x00\x00\x00\x00\x05\x00\x00\x00\x00"
 
 def _int_size(x):
     """Return the smallest size int that can store the value"""
@@ -240,8 +240,8 @@ def dumps(obj, version=1, capabilities=0):
         struct.pack_into(b'=i', bser_buf.buf, 3, obj_len)
     else:
         obj_len = bser_buf.wpos - len(EMPTY_HEADER_V2)
-        struct.pack_into(b'=i', bser_buf.buf, 3, capabilities)
-        struct.pack_into(b'=i', bser_buf.buf, 8, obj_len)
+        struct.pack_into(b'=i', bser_buf.buf, 2, capabilities)
+        struct.pack_into(b'=i', bser_buf.buf, 7, obj_len)
     return bser_buf.buf.raw[:bser_buf.wpos]
 
 # This is a quack-alike with the bserObjectType in bser.c
@@ -422,9 +422,11 @@ def pdu_info(buf):
         bser_capabilities = 0
         expected_len, pos2 = Bunser.unser_int(buf, 2)
     elif buf[0:2] == EMPTY_HEADER_V2[0:2]:
+        if len(buf) < 8:
+            raise ValueError('Invalid BSER header')
         bser_version = 2
-        bser_capabilities, pos1 = Bunser.unser_int(buf, 2)
-        expected_len, pos2 = Bunser.unser_int(buf, pos1)
+        bser_capabilities = struct.unpack_from("I", buf, 2)[0]
+        expected_len, pos2 = Bunser.unser_int(buf, 6)
     else:
         raise ValueError('Invalid BSER header')
 
@@ -462,8 +464,8 @@ def loads(buf, mutable=True, value_encoding=None, value_errors=None):
         bser_capabilities = 0
         expected_len, pos2 = Bunser.unser_int(buf, 2)
     else: # bser_version == 2
-        bser_capabilities, pos1 = Bunser.unser_int(buf, 2)
-        expected_len, pos2 = Bunser.unser_int(buf, pos1)
+        bser_capabilities = struct.unpack_from("I", buf, 2)
+        expected_len, pos2 = Bunser.unser_int(buf, 6)
 
     if len(buf) != expected_len + pos2:
         raise ValueError('bser data len != header len')

--- a/tests/integration/WatchmanInstance.py
+++ b/tests/integration/WatchmanInstance.py
@@ -148,7 +148,7 @@ class _Instance(object):
 
         if self.debug_watchman:
             print('Watchman instance PID:' + str(self.proc.pid))
-            raw_input('Press enter to continue...')
+            input('Press enter to continue...')
 
         # wait for it to come up
         deadline = time.time() + self.start_timeout

--- a/tests/integration/WatchmanTestCase.py
+++ b/tests/integration/WatchmanTestCase.py
@@ -160,7 +160,8 @@ class WatchmanTestCase(unittest.TestCase):
     def decodeBSERUTF8(self, s, surrogateescape=False):
         if pywatchman.compat.PYTHON3 and \
                 (self.encoding == 'experimental-bser-v2' or \
-                 self.encoding == 'bser'):
+                 self.encoding == 'bser') and \
+                 not isinstance(s, pywatchman.compat.UNICODE):
             if surrogateescape:
                 errors = 'surrogateescape'
             else:

--- a/thirdparty/jansson/jansson.h
+++ b/thirdparty/jansson/jansson.h
@@ -14,7 +14,7 @@
 
 #include <jansson_config.h>
 #include "watchman_string.h" // Needed for w_string_t
-
+#include "utf.h"
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/thirdparty/jansson/utf.c
+++ b/thirdparty/jansson/utf.c
@@ -188,3 +188,34 @@ int utf8_check_string(const char *string, int length)
 
     return 1;
 }
+
+void utf8_fix_string(char *string, int length)
+{
+    int i, j;
+
+    if(length == -1)
+        length = strlen(string);
+
+    for(i = 0; i < length; i++)
+    {
+        int count = utf8_check_first(string[i]);
+        if(count == 0) {
+            string[i] = '?';
+        }
+        else if(count > 1)
+        {
+            if(i + count > length) {
+                for (j = i; j < length; j++) {
+                    string[j] = '?';
+                }
+            }
+
+            if(!utf8_check_full(&string[i], count, NULL)) {
+                for (j = i; j < i + count; j++) {
+                    string[j] = '?';
+                }
+            }
+            i += count - 1;
+        }
+    }
+}

--- a/thirdparty/jansson/utf.h
+++ b/thirdparty/jansson/utf.h
@@ -35,5 +35,6 @@ int utf8_check_full(const char *buffer, int size, int32_t *codepoint);
 const char *utf8_iterate(const char *buffer, int32_t *codepoint);
 
 int utf8_check_string(const char *string, int length);
+void utf8_fix_string(char *string, int length);
 
 #endif

--- a/watchman.h
+++ b/watchman.h
@@ -538,6 +538,7 @@ struct watchman_json_buffer {
   uint32_t allocd;
   uint32_t rpos, wpos;
   enum w_pdu_type pdu_type;
+  uint32_t capabilities;
 };
 
 typedef struct bser_ctx {
@@ -553,12 +554,13 @@ void w_json_buffer_free(w_jbuffer_t *jr);
 json_t *w_json_buffer_next(w_jbuffer_t *jr, w_stm_t stm, json_error_t *jerr);
 bool w_json_buffer_passthru(w_jbuffer_t *jr,
     enum w_pdu_type output_pdu,
+    uint32_t output_capabilities,
     w_jbuffer_t *output_pdu_buf,
     w_stm_t stm);
 bool w_json_buffer_write(w_jbuffer_t *jr, w_stm_t stm, json_t *json, int flags);
 bool w_json_buffer_write_bser(uint32_t bser_version, uint32_t bser_capabilities,
     w_jbuffer_t *jr, w_stm_t stm, json_t *json);
-bool w_ser_write_pdu(enum w_pdu_type pdu_type,
+bool w_ser_write_pdu(enum w_pdu_type pdu_type, uint32_t capabilities,
     w_jbuffer_t *jr, w_stm_t stm, json_t *json);
 
 #define BSER_MAGIC "\x00\x01"
@@ -594,6 +596,7 @@ struct watchman_client {
   bool client_mode;
   bool client_is_owner;
   enum w_pdu_type pdu_type;
+  uint32_t capabilities;
 
   // The command currently being processed by dispatch_command
   json_t *current_command;

--- a/watchman_cmd.h
+++ b/watchman_cmd.h
@@ -31,7 +31,8 @@ struct watchman_command_handler_def {
 // argument list
 bool w_cmd_realpath_root(json_t *args, char **errmsg);
 
-void preprocess_command(json_t *args, enum w_pdu_type output_pdu);
+void preprocess_command(json_t *args, enum w_pdu_type output_pdu,
+                        uint32_t output_capabilities);
 bool dispatch_command(struct watchman_client *client, json_t *args, int mode);
 bool try_client_mode_command(json_t *cmd, bool pretty);
 void w_register_command(struct watchman_command_handler_def *defs);


### PR DESCRIPTION
As per https://github.com/facebook/watchman/wiki/Better-Unicode-handling-plan.

- Added tests specific to BSER v1 (to make sure things don't break during the transition).
- Renamed `STRING` to `BYTESTRING`.
- Added context type for switching BSER versions.
- Added BSER version switching logic to server.
- Added BSER v2 as a capability testable with the `version` command.
- Added logic for negotiating up to BSER v2 if both client and server support it.