### PR TITLE
speculative fix for some fishy state-leave behavior

### DIFF
--- a/listener-user.c
+++ b/listener-user.c
@@ -133,6 +133,7 @@ void derived_client_dtor(struct watchman_client *ptr) {
 
   /* cancel subscriptions */
   w_ht_free(client->subscriptions);
+  client->subscriptions = NULL;
 
   w_client_vacate_states(client);
 }

--- a/listener.c
+++ b/listener.c
@@ -155,7 +155,7 @@ static void *client_thread(void *ptr)
   bool send_ok = true;
 
   w_stm_set_nonblock(client->stm, true);
-  w_set_thread_name("client:stm=%p", client->stm);
+  w_set_thread_name("client=%p:stm=%p", client, client->stm);
 
   client->client_is_owner = w_stm_peer_is_owner(client->stm);
 
@@ -232,6 +232,7 @@ static void *client_thread(void *ptr)
   }
 
 disconected:
+  w_set_thread_name("NOT_CONN:client=%p:stm=%p", client, client->stm);
   // Remove the client from the map before we tear it down, as this makes
   // it easier to flush out pending writes on windows without worrying
   // about w_log_to_clients contending for the write buffers


### PR DESCRIPTION
Summary: This has been hard to nail down, but we've seen some weird
crashes every so often where we see events like this in the log:

```
2016-06-10T21:34:06,035: [client:stm=0x63c5c0] implicitly vacating state hg.update on /data/users/wez/FOO due to client disconnect
2016-06-10T21:34:24,367: [client:stm=0x63c5c0] send_error_response: ["state-leave", "/data/users/wez/FOO", {"name": "hg.update", "metadata": {"rev": "hash1 hash2", "distance": 123, "status": "ok", "partial": false}}] failed: state hg.update is not asserted
```

this doesn't make sense because the the first line happens 20 seconds
before the second, but can't possibly run before the latter.

I haven't found a way to reproduce this even intermittently, let alone
reliably, so this diff adds some belt and suspenders stuff around the
cleanup of this so that we can hopefully get a better read on this
if/when it happens in the future.

Test Plan: make integration + CI