### PR TITLE
add our own pidfile handling

### DIFF
--- a/arcanist/lib/WatchmanInstance.php
+++ b/arcanist/lib/WatchmanInstance.php
@@ -202,7 +202,7 @@ class WatchmanInstance {
 
   function start() {
     $cmd = "%s --foreground --sockname=%s --logfile=%s " .
-            "--statefile=%s.state --log-level=2";
+            "--statefile=%s.state --log-level=2 --pidfile=%s.pid";
     if ($this->valgrind) {
       $cmd = "valgrind --tool=memcheck " .
         "--log-file=$this->vg_log " .
@@ -224,7 +224,7 @@ class WatchmanInstance {
 
     $cmd = sprintf($cmd, $this->repo_root . '/watchman',
       $this->getFullSockName(), $this->logfile,
-                    $this->logfile);
+      $this->logfile, $this->logfile);
 
     $pipes = array();
     $this->proc = proc_open($cmd, array(

--- a/tests/integration/WatchmanInstance.py
+++ b/tests/integration/WatchmanInstance.py
@@ -41,6 +41,7 @@ class InitWithFilesMixin(object):
         self.cfg_file = os.path.join(self.base_dir, "config.json")
         self.log_file_name = os.path.join(self.base_dir, "log")
         self.cli_log_file_name = os.path.join(self.base_dir, 'cli-log')
+        self.pid_file = os.path.join(self.base_dir, "pid")
         if os.name == 'nt':
             self.sock_file = '\\\\.\\pipe\\watchman-test-%s' % uuid.uuid4().hex
         else:
@@ -52,6 +53,7 @@ class InitWithFilesMixin(object):
             '--sockname={0}'.format(self.sock_file),
             '--logfile={0}'.format(self.log_file_name),
             '--statefile={0}'.format(self.state_file),
+            '--pidfile={0}'.format(self.pid_file),
         ]
 
 class InitWithDirMixin(object):


### PR DESCRIPTION
Summary: we've dodged the need to do this for ourselves thus far,
because we've relied on launchd and gimli to manage it for us.

When not using either of these, there is potential for multiple
CLI process to want to attempt to bring up the watchman server
at the same time.  This is partially successful: two watchman servers
start up, fight over the socket, start to crawl the saved watches
from the state.

If they don't exhaust the inotify resources on the machine, about a
minute later, one of them will realize that it doesn't own the socket
any more and will terminate.

Adding a pid file and locking it prevents us from wasting resources in
this scenario, so that's what we're doing.

Test Plan: `make integration` continues to run (I added appropriate
pidfile flags to the instances that we spawn).

Running `./watchman` on my mac correctly updates the launchd command
line; running `ps -ef` afterwards shows the appropriate `--pidfile`
argument.

Running `./watchman --foreground` while another watchman is running in
the background exits immediately with no output.  The error message
about the pidfile shows up in the watchman log:

```
2016-06-14T08:06:17,131: [2057699328] Failed to lock pidfile /path/to/wez-state/pid: process 60717 owns it: Resource temporarily unavailable
```