### PR TITLE
add basic support for spawning from inetd-style supervisors

### DIFF
--- a/watchman.h
+++ b/watchman.h
@@ -874,6 +874,7 @@ json_t *w_root_watch_list_to_json(void);
 #ifdef __APPLE__
 int w_get_listener_socket_from_launchd(void);
 #endif
+bool w_listener_prep_inetd(void);
 bool w_start_listener(const char *socket_path);
 void w_check_my_sock(void);
 char **w_argv_copy_from_json(json_t *arr, int skip);


### PR DESCRIPTION
Summary: this allows defining a per-user service using systemd without
requiring that we integrate explicitly against the systemd libraries.

Test Plan: define socket and service units that look like this:

```
[Unit]
Description=Watchman socket for user %i

[Socket]
ListenStream=/var/facebook/watchman/%i-state/sock
Accept=false
SocketMode=0664
SocketUser=%i
SocketGroup=othergroup

[Install]
WantedBy=sockets.target
```

```
[Unit]
Description=Watchman for user %i
After=remote-fs.target
Conflicts=shutdown.target

[Service]
ExecStart=/usr/local/bin/watchman --foreground --inetd
ExecStop=pkill -u %i -x watchman
Restart=on-failure
User=%i
Group=users
StandardInput=socket
StandardOutput=syslog
SyslogIdentifier=watchman-%i

[Install]
WantedBy=multi-user.target
```

Then run:

```
sudo systemctl enable watchman@wez.sock
sudo systemctl enable watchman@wez.service
```

to instantiate it for my own user.  This causes systemd to listen on my
socket path and spawn watchman on my behalf.

Running `watchman version` causes the process list to look something
like this:

```
[wez@dev5744]~% ps -ef | grep watchman
wez      1081616       1 97 15:15 ?        00:00:07 /usr/local/bin/watchman --foreground --inetd
```

Running `watchman shutdown-server` will stop the process but keep things alive in systemd:

```
% sudo systemctl --full |grep watchman
  system-watchman.slice                                                                     loaded active active    system-watchman.slice
  watchman@wez.socket                                                                       loaded active listening Watchman socket for user wez
```

Running watchman version again causes it to run via systemd as above