### PR TITLE
add site-specific spawn command

### DIFF
--- a/main.c
+++ b/main.c
@@ -932,6 +932,18 @@ const char *get_sock_name(void)
   return sock_name;
 }
 
+static void spawn_watchman(void) {
+#ifdef USE_GIMLI
+  spawn_via_gimli();
+#elif defined(__APPLE__)
+  spawn_via_launchd();
+#elif defined(_WIN32)
+  spawn_win32();
+#else
+  daemonize();
+#endif
+}
+
 int main(int argc, char **argv)
 {
   bool ran;
@@ -956,15 +968,7 @@ int main(int argc, char **argv)
         ran = try_client_mode_command(cmd, !no_pretty);
       }
     } else {
-#ifdef USE_GIMLI
-      spawn_via_gimli();
-#elif defined(__APPLE__)
-      spawn_via_launchd();
-#elif defined(_WIN32)
-      spawn_win32();
-#else
-      daemonize();
-#endif
+      spawn_watchman();
       ran = try_command(cmd, 10);
     }
   }

--- a/tests/integration/WatchmanInstance.py
+++ b/tests/integration/WatchmanInstance.py
@@ -113,6 +113,23 @@ class _Instance(object):
             self.proc = None
         self.cli_log_file.close()
 
+    def commandViaCLI(self, cmd):
+        '''a very bare bones helper to test the site spawner functionality'''
+        args = [
+            'watchman',
+            '--log-level=2',
+        ]
+        args.extend(self.get_state_args())
+        args.extend(cmd)
+        env = os.environ.copy()
+        env["WATCHMAN_CONFIG_FILE"] = self.cfg_file
+        proc = subprocess.Popen(args,
+                                     env=env,
+                                     stdin=None,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
+        return proc.communicate()
+
     def start(self):
         args = [
             'watchman',

--- a/tests/integration/site_spawn.py
+++ b/tests/integration/site_spawn.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# This is a simple script that spawns a watchman process in the background
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+# no unicode literals
+import os
+import sys
+import subprocess
+args = sys.argv[1:]
+args.insert(0, 'watchman')
+args.insert(1, '--foreground')
+subprocess.Popen(args)

--- a/tests/integration/site_spawn_fail.py
+++ b/tests/integration/site_spawn_fail.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# This is a simple script that fails to spawn a process in the background
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+# no unicode literals
+import sys
+print('failed to start')
+sys.exit(1)

--- a/tests/integration/test_site_spawn.py
+++ b/tests/integration/test_site_spawn.py
@@ -1,0 +1,48 @@
+# vim:ts=4:sw=4:et:
+# Copyright 2016-present Facebook, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+# no unicode literals
+import json
+import os
+import tempfile
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import WatchmanInstance
+
+@unittest.skipIf(os.name == 'nt', "not supported on windows")
+class TestSiteSpawn(unittest.TestCase):
+    def test_failingSpawner(self):
+      config = {
+          'spawn_watchman_service': os.path.join(os.path.dirname(__file__), 'site_spawn_fail.py')
+      }
+
+      inst = WatchmanInstance.Instance(config=config)
+      stdout, stderr = inst.commandViaCLI(['version'])
+
+      self.assertEqual(b'', stdout)
+      self.assertRegexpMatches(stderr.decode('ascii'),
+            'site_spawn_fail.py: exited with status 1')
+      with open(inst.log_file_name, 'r') as f:
+          self.assertEqual('failed to start\n', f.read())
+
+    def test_spawner(self):
+      config = {
+          'spawn_watchman_service': os.path.join(os.path.dirname(__file__), 'site_spawn.py')
+      }
+
+      inst = WatchmanInstance.Instance(config=config)
+      stdout, stderr = inst.commandViaCLI(['version'])
+
+      parsed = json.loads(stdout.decode('ascii'))
+      self.assertTrue('version' in parsed)
+
+      # Shut down that process, as we have no automatic way to deal with it
+      inst.commandViaCLI(['--no-spawn', '--no-local', 'shutdown-server'])


### PR DESCRIPTION
    Summary: in some situations, the system administrator may desire to have
    control over the context in which the watchman service is started.

    For example, if may be desirable to force the service to spawn a
    system service that was automatically created for the current user
    rather than just having watchman fork off a child.

    For this situation we now provide a `spawn_watchman_service`
    configuration key that is available in `/etc/watchman.json`.
    If this string is set, when the watchman CLI decides that it is
    appropriate to spawn the watchman service, rather than using the
    default spawning action, it will instead invoke `spawn_watchman_service`
    and forward all daemon appropriate watchman arguments to it.

    The value of `spawn_watchman_service` will be used as `argv[0]` when
    launching the spawner, so it must either be the full path to the
    spawning program, or be something that posix_spawn is able to resolve
    from the PATH of the current process.

    If the spawner returns with a non-zero exit status, the watchman command
    that invoked it will fail and report the problem to the user.

    The stdout and stderr of the spawner program are redirected to the
    watchman log file.
