### PR TITLE
take advantage of FSEventStreamSetExclusionPaths

### DIFF
--- a/watchman_ignore.h
+++ b/watchman_ignore.h
@@ -19,6 +19,10 @@ struct watchman_ignore {
    * entries above.  This is used only on OS X and Windows because
    * we cannot exclude these dirs using the kernel watching APIs */
   art_tree tree;
+  /* On OS X, we need to preserve the order of the ignore list so
+   * that we can exclude things deterministically and fit within
+   * system limits. */
+  w_string_t **dirs_vec;
 };
 
 // Initialize ignore state


### PR DESCRIPTION
Summary: this isn't indexed from the main fsevents docs, but it is a
public API; if you google for it, you will find it listed in changelogs.

The header file documents that it has a limit of 8 items.  From playing
around with this, if we exceed the limit, the function call will fail
with no explanation.

Because of this limit, it is advantageous to list the highest value
ignores in the first 8 entries of the `ignore_dirs` configuration
in `.watchmanconfig`, and we therefore need an ordered list of the
ignores; our current datastructures are unordered maps and that results
in a non-deterministic set of excluded paths on any given attempt to
watch the same dir.

Test Plan: `make integration` succeeds.  I also added some
instrumentation to see what the behavior is; the exact path listed in
the exclusion paths array is delivered to our stream, but any child
paths are ignored.  That's good enough for us.