### PR TITLE
poison when the system hits the number-of-files limits

### DIFF
--- a/root.c
+++ b/root.c
@@ -1074,6 +1074,10 @@ void handle_open_errno(w_root_t *root, struct watchman_dir *dir,
   } else if (err == EACCES || err == EPERM) {
     log_warning = true;
     transient = false;
+  } else if (err == ENFILE || err == EMFILE) {
+    set_poison_state(root, dir->path, now, syscall, err,
+        strerror(err));
+    return;
   } else {
     log_warning = true;
     transient = true;


### PR DESCRIPTION
If the watchman process itself runs out of files, or if the system
file table is full, we will have missed some notifications and have
no way to self-remediate, so let's poison ourselves.

There isn't a great way to test this in CI :-/