### PR TITLE
Resync from fsevents journal on UserDropped

### DIFF
--- a/tests/integration/test_fsevents_resync.py
+++ b/tests/integration/test_fsevents_resync.py
@@ -1,0 +1,57 @@
+# vim:ts=4:sw=4:et:
+# Copyright 2016-present Facebook, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+# no unicode literals
+
+import WatchmanTestCase
+import json
+import tempfile
+import os
+import os.path
+import sys
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+@unittest.skipIf(sys.platform != 'darwin', 'N/A unless macOS')
+class TestFSEventsResync(WatchmanTestCase.WatchmanTestCase):
+
+    def test_resync(self):
+        root = self.mkdtemp()
+        with open(os.path.join(root, '.watchmanconfig'), 'w') as f:
+            f.write(json.dumps({
+                'fsevents_try_resync': True
+            }))
+
+        self.watchmanCommand('watch', root)
+        self.touchRelative(root, '111')
+        self.assertFileList(root, ['.watchmanconfig', '111'])
+
+        res = self.watchmanCommand('query', root, {
+            'fields': ['name']})
+        self.assertTrue(res['is_fresh_instance'])
+        clock = res['clock']
+
+        dropinfo = self.watchmanCommand('debug-fsevents-inject-drop', root)
+        self.assertTrue('last_good' in dropinfo, dropinfo)
+
+        # We expect to see the results of these two filesystem operations
+        # on our next query, and not see evidence of a recrawl
+        os.unlink(os.path.join(root, '111'))
+        self.touchRelative(root, '222')
+
+        res = self.watchmanCommand('query', root, {
+            'since': clock,
+            'expression': ['exists'],
+            'fields': ['name']})
+        self.assertFalse(res['is_fresh_instance'], res)
+        self.assertTrue('warning' not in res, res)
+        self.assertEqual(self.normWatchmanFileList(res['files']),
+                         self.normFileList(['222']))
+

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -31,6 +31,7 @@ struct fsevents_root_state {
 
   struct watchman_fsevent *fse_head, *fse_tail;
   struct fse_stream *stream;
+  bool attempt_resync_on_user_drop;
 };
 
 static const struct flag_map kflags[] = {
@@ -279,6 +280,9 @@ static void *fsevents_thread(void *arg)
 
   // Block until fsevents_root_start is waiting for our initialization
   pthread_mutex_lock(&state->fse_mtx);
+
+  state->attempt_resync_on_user_drop =
+      cfg_get_bool(root, "fsevents_try_resync", false);
 
   memset(&fdctx, 0, sizeof(fdctx));
   fdctx.info = root;

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -137,7 +137,8 @@ static void fse_stream_free(struct fse_stream *fse_stream) {
   }
 }
 
-static struct fse_stream *fse_stream_make(w_root_t *root) {
+static struct fse_stream *fse_stream_make(w_root_t *root,
+                                          FSEventStreamEventId since) {
   FSEventStreamContext ctx;
   CFMutableArrayRef parray = NULL;
   CFStringRef cpath = NULL;
@@ -178,7 +179,7 @@ static struct fse_stream *fse_stream_make(w_root_t *root) {
       latency);
 
   fse_stream->stream = FSEventStreamCreate(NULL, fse_callback,
-      &ctx, parray, kFSEventStreamEventIdSinceNow,
+      &ctx, parray, since,
       latency,
       kFSEventStreamCreateFlagNoDefer|
       kFSEventStreamCreateFlagWatchRoot|
@@ -282,7 +283,7 @@ static void *fsevents_thread(void *arg)
     CFRelease(fdsrc);
   }
 
-  fse_stream = fse_stream_make(root);
+  fse_stream = fse_stream_make(root, kFSEventStreamEventIdSinceNow);
   if (!fse_stream) {
     goto done;
   }


### PR DESCRIPTION
This PR implements a new configurable feature that will attempt to resync from the persistent fsevents journal in the event of a user-space overflow.

In my recent performance tests I've been unable to trigger a UserDropped event while watchman is running under instrumentation.  Furthermore, the performance data shows that the processing callback takes only a handful of milliseconds to run, with the critical section taking microseconds.  This leads me to believe that the root cause of the UserDropped events is not tardiness in the processing loop, but rather that we are not getting the CPU in a timely fashion.

Therefore it seems reasonable that we should be able to successfully resync from the fsevents journal when we do eventually get back on the CPU.

The approach taken here is to refactor the code that creates the stream such that we can create more than one, and pass in the event id as the since parameter.

Initially we sync from the current point in time, but if we do experience a UserDropped event we will set up a new stream using the last observed good event id.

This resync is not as heavyweight as a full recrawl because fsevents promises to tell us about the changes that we didn't see; we're effectively rewinding the stream to resync.  This should cut out a lot of recursive crawling IO and take less time over all.

Testing: I've spent a couple of hours and have been unable to trigger a UserDropped event with the 4.6 release candidate code thus far (my test case for this involves changing the sparse status of a deep tree), but our telemetry shows that this has happened for a couple of our mac users.  I'm going to try some build intensive tests when I get back into the office.
