### PR TITLE
make HINT_NUM_DIRS configurable

### DIFF
--- a/root.c
+++ b/root.c
@@ -117,7 +117,9 @@ static bool w_root_init(w_root_t *root, char **errmsg)
   root->cursors = w_ht_new(2, &w_ht_string_funcs);
   root->suffixes = w_ht_new(2, &w_ht_string_funcs);
 
-  root->dirname_to_dir = w_ht_new(HINT_NUM_DIRS, &dirname_hash_funcs);
+  root->dirname_to_dir =
+      w_ht_new((uint32_t)cfg_get_int(root, CFG_HINT_NUM_DIRS, HINT_NUM_DIRS),
+               &dirname_hash_funcs);
   root->ticks = 1;
 
   // "manually" populate the initial dir, as the dir resolver will

--- a/watcher/inotify.c
+++ b/watcher/inotify.c
@@ -127,7 +127,9 @@ bool inot_root_init(w_root_t *root, char **errmsg) {
     return false;
   }
   w_set_cloexec(state->infd);
-  state->wd_to_name = w_ht_new(HINT_NUM_DIRS, &w_ht_string_val_funcs);
+  state->wd_to_name =
+      w_ht_new(cfg_get_int(root, CFG_HINT_NUM_DIRS, HINT_NUM_DIRS),
+               &w_ht_string_val_funcs);
   state->move_map = w_ht_new(2, &move_hash_funcs);
 
   return true;

--- a/watcher/kqueue.c
+++ b/watcher/kqueue.c
@@ -45,6 +45,8 @@ const struct watchman_hash_funcs name_to_fd_funcs = {
 
 bool kqueue_root_init(w_root_t *root, char **errmsg) {
   struct kqueue_root_state *state;
+  json_int_t hint_num_dirs =
+      cfg_get_int(root, CFG_HINT_NUM_DIRS, HINT_NUM_DIRS);
 
   state = calloc(1, sizeof(*state));
   if (!state) {
@@ -53,8 +55,8 @@ bool kqueue_root_init(w_root_t *root, char **errmsg) {
   }
   root->watch = state;
   pthread_mutex_init(&state->lock, NULL);
-  state->name_to_fd = w_ht_new(HINT_NUM_DIRS, &name_to_fd_funcs);
-  state->fd_to_name = w_ht_new(HINT_NUM_DIRS, &w_ht_string_val_funcs);
+  state->name_to_fd = w_ht_new(hint_num_dirs, &name_to_fd_funcs);
+  state->fd_to_name = w_ht_new(hint_num_dirs, &w_ht_string_val_funcs);
 
   state->kq_fd = kqueue();
   if (state->kq_fd == -1) {

--- a/watcher/portfs.c
+++ b/watcher/portfs.c
@@ -83,7 +83,8 @@ bool portfs_root_init(w_root_t *root, char **errmsg) {
   root->watch = state;
 
   pthread_mutex_init(&state->lock, NULL);
-  state->port_files = w_ht_new(HINT_NUM_DIRS, &port_file_funcs);
+  state->port_files = w_ht_new(
+      cfg_get_int(root, CFG_HINT_NUM_DIRS, HINT_NUM_DIRS), &port_file_funcs);
 
   state->port_fd = port_create();
   if (state->port_fd == -1) {

--- a/watchman.h
+++ b/watchman.h
@@ -235,6 +235,7 @@ struct watchman_string {
 /* small for testing, but should make this greater than the number of dirs we
  * have in our repos to avoid realloc */
 #define HINT_NUM_DIRS 128*1024
+#define CFG_HINT_NUM_DIRS "hint_num_dirs"
 
 /* We leverage the fact that our aligned pointers will never set the LSB of a
  * pointer value.  We can use the LSB to indicate whether kqueue entries are

--- a/website/_docs/configuration.markdown
+++ b/website/_docs/configuration.markdown
@@ -55,6 +55,7 @@ Option | Scope | Since version
 `fsevents_latency` | fallback | 3.2
 `idle_reap_age_seconds` | local | 3.7
 `hint_num_files_per_dir` | fallback | 3.9
+`hint_num_dirs` | fallback | 4.6
 
 ### Configuration Options
 
@@ -258,3 +259,18 @@ is 1; you would pay the cost of the collisions during the initial crawl and
 have a more optimal memory usage.  Since watchman is primarily employed as an
 accelerator, we'd recommend biasing towards using more memory and taking less
 time to run.
+
+### hint_num_dirs
+
+*Since 4.6*
+
+Used to pre-size hash tables that are used to track the total set of files
+in the entire watched tree.  The default value for this is 131072.
+
+The optimal size is a power-of-two larger than the number of directories
+in your tree; running `find . -type d | wc -l` will tell you the number
+that you have.
+
+Making this number too large is potentially wasteful of memory.  Making this
+number too small results in increased latency during crawling while the
+hash tables are rebuilt.


### PR DESCRIPTION
I noticed that this was still a fixed #define in the header.
Turn it into a `.watchmanconfig` option with the same default value.

This allows us to better match the value for our various repos.