### PR TITLE
Fix a nit in perf sampling, add a num_walked to query metadata

### DIFF
--- a/spawn.c
+++ b/spawn.c
@@ -419,16 +419,20 @@ static bool trigger_generator(
     w_query *query,
     w_root_t *root,
     struct w_query_ctx *ctx,
-    void *gendata)
+    void *gendata,
+    int64_t *num_walked)
 {
   struct watchman_file *f;
   struct watchman_trigger_command *cmd = gendata;
+  int64_t n = 0;
+  bool result = true;
 
   w_log(W_LOG_DBG, "assessing trigger %s %p\n",
       cmd->triggername->buf, cmd);
 
   // Walk back in time until we hit the boundary
   for (f = root->latest_file; f; f = f->next) {
+    ++n;
     if (ctx->since.is_timestamp && f->otime.timestamp < ctx->since.timestamp) {
       break;
     }
@@ -442,11 +446,14 @@ static bool trigger_generator(
     }
 
     if (!w_query_process_file(query, ctx, f)) {
-      return false;
+      result = false;
+      goto done;
     }
   }
 
-  return true;
+done:
+  *num_walked = n;
+  return result;
 }
 
 /* must be called with root locked */

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -118,7 +118,8 @@ typedef bool (*w_query_generator)(
     w_query *query,
     w_root_t *root,
     struct w_query_ctx *ctx,
-    void *gendata
+    void *gendata,
+    int64_t *num_walked
 );
 
 struct w_query_result {


### PR DESCRIPTION
Two patches in this PR:

1. Fix missing format specifier for the num_results in a query
2. Add a counter for the number of nodes that a query walks over

This stuff doesn't currently have test infra, which is not great.  I'll probably squeeze the first of these into 4.6 and push the second out to 4.7, along with some tests.