### PR TITLE
avoid blocking on write during shutdown

### DIFF
--- a/watchman.h
+++ b/watchman.h
@@ -595,6 +595,10 @@ struct watchman_client {
   json_t *current_command;
   w_perf_t perf_sample;
 
+  // This handle is not joinable (CREATE_DETACHED), but can be
+  // used to deliver signals.
+  pthread_t thread_handle;
+
   struct watchman_client_response *head, *tail;
 };
 


### PR DESCRIPTION
Summary: we've seen a couple of instances where watchman has one
or more client threads blocked in write while the listener thread
is waiting for threads to finish.

The pre-condition appears to be that we need to have enough data
buffered up prior to initiating shutdown (possibly in conjunction
with a tardy client on the other end of the socket) that the blocking
write blocks the thread for some period of time.  The precise
conditions are hard to gather from the data we've gotten so far.

From inspecting the code, there are a couple of things we can do
to reduce the chances of blocking forever:

If we've been waiting a bit, send a signal to shake the thread out of a
blocking syscall.  That should bubble up as an EINTR and terminate
whatever loop they were in, and then they should notice that we're
shutting down.  Why not send the signal immediately?  I'm slightly
worried that it might interrupt some of the normal tear down in the
client thread if we send it too soon after signalling it via
client->ping.

Test Plan: it doesn't break make integration (I was concerned that
we'd make the shutdown a bit more aggro, but it seems ok).

Manually: `watchan --foreground` in one window, `tail -f log` in another
window, and in a third window `watchman shutdown-server`.  The shutdown
command completes with a valid shutdown response before the server
shuts down.