### PR TITLE
remove the symlink rechecker

### DIFF
--- a/watchman.h
+++ b/watchman.h
@@ -526,7 +526,6 @@ struct watchman_root {
   uint32_t pending_trigger_tick;
   uint32_t pending_sub_tick;
   uint32_t last_age_out_tick;
-  uint32_t last_recheck_tick;
   time_t last_age_out_timestamp;
   time_t last_cmd_timestamp;
   time_t last_reap_timestamp;


### PR DESCRIPTION
Summary: this never worked very well at any kind of scale and has been
turned off for a while, so let's just remove the code.