### PR TITLE
Docs watch project link

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
+gem 'redcarpet'
+gem 'pygments.rb'

--- a/website/_docs/cmd.watch.markdown
+++ b/website/_docs/cmd.watch.markdown
@@ -7,7 +7,7 @@ permalink: docs/cmd/watch.html
 ---
 
 Deprecated starting in version 3.1.  We recommend that clients adopt
-the [watch-project](../cmd/watch-project.html) command.
+the [watch-project](/watchman/docs/cmd/watch-project.html) command.
 
 Requests that the specified dir is watched for changes.
 Watchman will track all files and dirs rooted at the specified path.


### PR DESCRIPTION
The link to `watch-project` on the [docs for watch](https://facebook.github.io/watchman/docs/cmd/watch.html) is broken.
This fixes the link + adds missing deps to the Gemfile so the current github-pages and jekyll versions will work after `bundle install`.