### PR TITLE
[wildmatch] Consume any number of consecutive slashes in pattern

### DIFF
--- a/query/match.c
+++ b/query/match.c
@@ -13,6 +13,7 @@ struct wildmatch_data {
 };
 
 W_CAP_REG("wildmatch")
+W_CAP_REG("wildmatch-multislash")
 
 static bool eval_wildmatch(struct w_query_ctx *ctx,
     struct watchman_file *file,

--- a/tests/wildmatch_test.json
+++ b/tests/wildmatch_test.json
@@ -204,5 +204,7 @@
 [true, 6, "foo/bar/.baz", "**/.*"],
 [true, 0, "foobar", "foo\\bar"],
 [false, 8, "foobar", "foo\\bar"],
-[true, 8, "foo\\bar", "foo\\bar"]
+[true, 8, "foo\\bar", "foo\\bar"],
+[true, 2, "foo/bar/baz", "foo//bar/baz"],
+[true, 2, "foo/bar/baz", "foo/////bar/////////baz"]
 ]

--- a/thirdparty/wildmatch/wildmatch.c
+++ b/thirdparty/wildmatch/wildmatch.c
@@ -89,6 +89,12 @@ static int dowild(const uchar *p, const uchar *text, unsigned int flags)
 				p_ch = *++p;
 			/* FALLTHROUGH */
 		default:
+			if (p_ch == '/') {
+				/* Consume any number of consecutive slashes. */
+				while (*(p + 1) == '/') {
+					++p;
+				}
+			}
 			if (t_ch != p_ch)
 				return WM_NOMATCH;
 			if ((flags & WM_PERIOD) &&


### PR DESCRIPTION
This is to match Python's built-in `glob()` behavior.

Previously, globbing a pattern like `a//b/c` would not match the
path `a/b/c`. Since Unix treats mutiple slashes the same as one
slash, wildmatch should too.