### PR TITLE
Adding the possibility to exclude file patterns from watchman-make

### DIFF
--- a/python/bin/watchman-make
+++ b/python/bin/watchman-make
@@ -7,13 +7,19 @@ import sys
 import subprocess
 
 
-def patterns_to_terms(pats):
+def patterns_to_terms(pats, excl):
     # convert a list of globs into the equivalent watchman expression term
-    if pats is None or len(pats) == 0:
-        return ['true']
-    terms = ['anyof']
-    for p in pats:
-        terms.append(['match', p, 'wholename', {'includedotfiles': True}])
+    terms = ['allof', ['type', 'f']]
+    if pats:
+      p_terms = ['anyof']
+      for p in pats:
+          p_terms.append(['match', p, 'wholename', {'includedotfiles': True}])
+      terms.append(p_terms)
+    if excl:
+      e_terms = ['anyof']
+      for e in excl:
+          e_terms.append(['match', e, 'wholename', {'includedotfiles': True}])
+      terms.append(['not', e_terms])
     return terms
 
 
@@ -27,20 +33,21 @@ class Target(object):
     we should execute the command to build this target.
     """
 
-    def __init__(self, name, make, targets, patterns):
+    def __init__(self, name, make, targets, patterns, excluded_patterns):
         self.name = name
         self.make = make
         self.targets = targets
         self.patterns = patterns
+        self.excluded_patterns = excluded_patterns
         self.triggered = False
 
     def __repr__(self):
-        return '{make=%r targets=%r pat=%r}' % (
-            self.make, self.targets, self.patterns)
+        return '{make=%r targets=%r pat=%r excl=%r}' % (
+            self.make, self.targets, self.patterns, self.excluded_patterns)
 
     def start(self, client, root):
         query = {
-            'expression': patterns_to_terms(self.patterns),
+            'expression': patterns_to_terms(self.patterns, self.excluded_patterns),
             'fields': ['name']
         }
         watch = client.query('watch-project', root)
@@ -53,9 +60,23 @@ class Target(object):
         # get the initial clock value so that we only get updates
         query['since'] = client.query('clock', root_dir)['clock']
 
-        print('# Changes to files matching %s will execute `%s %s`' % (
-            ' '.join(self.patterns), self.make, ' '.join(self.targets)),
-            file=sys.stderr)
+        configuration_message = ''
+        if not(not self.patterns):
+            configuration_message += 'matching %s' % (' '.join(self.patterns))
+        if not(not self.excluded_patterns):
+            if len(configuration_message) > 0:
+                configuration_message += ', but '
+            configuration_message += 'not matching %s' % (' '.join(self.excluded_patterns))
+        if len(configuration_message) > 0:
+            print('# Changes to files %s will execute `%s %s`' % (
+                configuration_message,
+                self.make,
+                ' '.join(self.targets)), file=sys.stderr)
+        else:
+            print('# Changes to any file will execute `%s %s`' % (
+                self.make,
+                ' '.join(self.targets)), file=sys.stderr)
+
         sub = client.query('subscribe', root_dir, self.name, query)
 
     def consumeEvents(self, client):
@@ -88,17 +109,13 @@ class DefineTarget(argparse.Action):
         if isinstance(values, basestring):
             values = [values]
 
-        if namespace.pattern is None or len(namespace.pattern) == 0:
-            print('no patterns were specified for target %s' %
-                  values, file=sys.stderr)
-            sys.exit(1)
-
         target = Target('target_%d' % len(targets),
-                        namespace.make, values, namespace.pattern)
+                        namespace.make, values, namespace.pattern, namespace.exclude)
         targets.append(target)
 
         # Clear out patterns between targets
         namespace.pattern = None
+        namespace.exclude = None
 
 
 parser = argparse.ArgumentParser(
@@ -145,6 +162,14 @@ parser.add_argument('--root', type=str, default='.', help="""
 Define the root of the project.  The default is to use the PWD.
 All patterns are considered to be relative to this root, and the build
 tool is executed with this location set as its PWD.
+""")
+parser.add_argument('-x', '--exclude', type=str, nargs='+',
+                    help="""
+Define a set of filename patterns which, if matching, will mark files as
+ignored from the next --target definition.
+
+The pattern syntax is wildmatch style; globbing with recursive matching via
+'**'. Exclude patterns have higher priority than match patterns.
 """)
 
 args = parser.parse_args()

--- a/python/bin/watchman-make
+++ b/python/bin/watchman-make
@@ -171,6 +171,9 @@ ignored from the next --target definition.
 The pattern syntax is wildmatch style; globbing with recursive matching via
 '**'. Exclude patterns have higher priority than match patterns.
 """)
+parser.add_argument('-U', '--sockname', type=str, default=None, help="""
+Specify the path to the UNIX socket used to communicate with Watchman.
+""")
 
 args = parser.parse_args()
 
@@ -190,7 +193,10 @@ def check_root(desired_root):
         sys.exit(1)
 
 targets = {}
-client = pywatchman.client(timeout=600)
+if args.sockname is not None:
+  client = pywatchman.client(timeout=600, sockpath=args.sockname)
+else:
+  client = pywatchman.client(timeout=600)
 try:
     client.capabilityCheck(
         required=['cmd-watch-project', 'wildmatch'])

--- a/python/bin/watchman-make
+++ b/python/bin/watchman-make
@@ -9,7 +9,7 @@ import subprocess
 
 def patterns_to_terms(pats, excl):
     # convert a list of globs into the equivalent watchman expression term
-    terms = ['allof', ['type', 'f']]
+    terms = ['allof', 'true']
     if pats:
       p_terms = ['anyof']
       for p in pats:

--- a/tests/integration/test_watchman_make.py
+++ b/tests/integration/test_watchman_make.py
@@ -1,0 +1,114 @@
+# vim: ts=4:sw=4:sts=4:et:
+# Copyright 2012-present Facebook, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+# no unicode literals
+
+import WatchmanTestCase
+import os
+import os.path
+import sys
+import re
+import subprocess
+import signal
+import time
+import uuid
+
+class TestWatchmanMake(WatchmanTestCase.WatchmanTestCase):
+
+    def setUp(self):
+        if sys.platform == 'win32':
+            self.skipTest('Continuous integration testing only in Linux / MacOS')
+        if sys.version_info >= (3, 0):
+            self.skipTest('watchman-make is only compatible with Python 2')
+        if self.transport != 'local' or self.encoding != 'bser':
+            self.skipTest('Testing only with local transport and bser encoding')
+        self.marker = 'target-' + str(uuid.uuid4())
+
+    def _run_test(self, args, behavior):
+        root = self.mkdtemp()
+        self.touchRelative(root, '.watchmanconfig')
+        fake_env = dict(os.environ)
+        fake_env['PYTHONPATH'] = ':'.join(sys.path)
+        fake_env['PATH'] = fake_env['PATH'] + ':' + os.getcwd()
+        cmdline = [
+            './python/bin/watchman-make',
+            '-U', self.getClient().sockpath,
+            '-s', '0.05',
+            '--root', root,
+            '--make', '/bin/echo']
+        cmdline.extend(args)
+        cmdline.extend(['-t', self.marker])
+        process = subprocess.Popen(
+            ' '.join(cmdline),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            env=fake_env)
+        time.sleep(1)
+        behavior(root)
+        process.send_signal(signal.SIGINT)
+        return (process.stdout.read(), process.stderr.read())
+
+    def test_noParams(self):
+        def behavior(root):
+            self.touchRelative(root, "foo")
+            time.sleep(1)
+        (stdout, stderr) = self._run_test([], behavior)
+        print(stdout)
+        print(stderr)
+        self.assertTrue(
+            "any file" in stderr,
+            'A message about any file triggers the build')
+        self.assertEquals(
+            1, stdout.count(self.marker),
+            'A single build triggered')
+
+    def test_acceptParams(self):
+        def behavior(root):
+            self.touchRelative(root, 'afile.foo')
+            self.touchRelative(root, 'anotherfile.bar')
+            time.sleep(1)
+        (stdout, stderr) = self._run_test(['-p', '**/*.foo'], behavior)
+        self.assertTrue(
+            "files matching" in stderr,
+            'A message about only files matching the pattern trigger the build')
+        self.assertEquals(
+            1, stdout.count(self.marker),
+            'Only matching file triggers build')
+
+    def test_excludeParams(self):
+        def behavior(root):
+            self.touchRelative(root, 'afile.foo')
+            self.touchRelative(root, 'anotherfile.bar')
+            time.sleep(1)
+        (stdout, stderr) = self._run_test(['-x', '**/*.bar'], behavior)
+        self.assertTrue(
+            "files not matching" in stderr,
+            'A message about only files not matching pattern trigger the build')
+        self.assertEquals(
+            1, stdout.count(self.marker),
+            'Only the file not matching pattern triggers the build')
+
+    def test_acceptAndExcludeParams(self):
+        def behavior(root):
+            self.touchRelative(root, 'afile.foo')
+            self.touchRelative(root, 'anotherfile.bar.foo')
+            time.sleep(1)
+            self.touchRelative(root, 'afile.bar.foo')
+            self.touchRelative(root, 'anotherfile.foo')
+            time.sleep(1)
+        (stdout, stderr) = self._run_test(['-p', '**/*.foo', '-x', '**/*.bar.*'], behavior)
+        self.assertTrue(
+            "files matching" in stderr,
+            'A message about only files matching the pattern trigger the build')
+        self.assertTrue(
+            "but not matching" in stderr,
+            'A message about only files not matching the pattern trigger the build')
+        self.assertEqual(
+            2, stdout.count(self.marker),
+            'Only files matching the required filters trigger the build')
+


### PR DESCRIPTION
This commit is adding the `-e PATTERN [PATTERN]` (or `--exclude`) command-line argument to watchman-make. Using it results in files matching the `PATTERN` being ignored by watchman, and thus not triggering a build/make. Excludes have higher priority than matches (i.e. in case file `FOO` matches both `-p PAT` and `-e EXC`, it will in fact be ignored). 
