### PR TITLE
Fixing watchman.jar to include dependencies

### DIFF
--- a/java/BUCK
+++ b/java/BUCK
@@ -1,5 +1,12 @@
-java_library(
+java_binary(
   name = 'watchman',
+  deps = [
+    ':watchman-lib',
+  ]
+)
+
+java_library(
+  name = 'watchman-lib',
   srcs = glob(['src/**/*.java']),
   source = '1.6',
   target = '1.6',
@@ -28,7 +35,7 @@ java_test(
   source = '1.7',
   target = '1.7',
   deps = [
-    ':watchman',
+    ':watchman-lib',
     '//third-party/guava:guava',
     '//third-party/hamcrest:hamcrest-2',
     '//third-party/junit:junit',

--- a/java/README.md
+++ b/java/README.md
@@ -15,12 +15,12 @@ buck build :watchman
 ```
 
 The resulting JAR file is found in:
-`buck-out/gen/lib__watchman__output/watchman.jar`
+`buck-out/gen/watchman.jar'
 
 To run the tests:
 
 ```
 buck fetch :watchman-tests
-buck test :watchman
+buck test :watchman-lib
 ```
 

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -62,7 +62,7 @@ case $(uname) in
     if [[ "$BUILD_JAVA_CLIENT" != "" ]] && [ "${BUILD_JAVA_CLIENT-0}" -eq 1 ]; then
       pushd java
       buck fetch :watchman :watchman-tests || exit 1
-      buck test :watchman || exit 1
+      buck test :watchman-lib || exit 1
       popd
     fi
     ;;


### PR DESCRIPTION
Building the jar without bundling dependencies is confusing, since users would have to manually include them to prevent `ClassNotFoundException`. This PR changes the buck target type, so all the classes of our dependencies are included in the final jar. 

Bonus: watchman.jar is produced in a much friendlier location (`buck-out/gen/watchman.jar`).