### PR TITLE
Shave off some memory usage around watchman_file

### DIFF
--- a/clockspec.c
+++ b/clockspec.c
@@ -47,8 +47,7 @@ struct w_clockspec *w_clockspec_parse(json_t *value) {
 
   if (json_is_integer(value)) {
     spec->tag = w_cs_timestamp;
-    spec->timestamp.tv_usec = 0;
-    spec->timestamp.tv_sec = (time_t)json_integer_value(value);
+    spec->timestamp = (time_t)json_integer_value(value);
     return spec;
   }
 

--- a/cmds/subscribe.c
+++ b/cmds/subscribe.c
@@ -17,8 +17,7 @@ static bool subscription_generator(
 
   // Walk back in time until we hit the boundary
   for (f = root->latest_file; f; f = f->next) {
-    if (ctx->since.is_timestamp &&
-        w_timeval_compare(f->otime.tv, ctx->since.timestamp) < 0) {
+    if (ctx->since.is_timestamp && f->otime.timestamp < ctx->since.timestamp) {
       break;
     }
     if (!ctx->since.is_timestamp &&

--- a/query/eval.c
+++ b/query/eval.c
@@ -32,7 +32,8 @@ w_string_t *w_query_ctx_get_wholename(
     name_start = ctx->root->root_path->len + 1;
   }
 
-  full_name = w_string_path_cat(ctx->file->parent->path, ctx->file->name);
+  full_name =
+      w_string_path_cat(ctx->file->parent->path, w_file_get_name(ctx->file));
   // Record the name relative to the root
   ctx->wholename = w_string_slice(full_name, name_start,
       full_name->len - name_start);

--- a/query/eval.c
+++ b/query/eval.c
@@ -95,7 +95,7 @@ bool w_query_process_file(
 
   m->file = file;
   if (ctx->since.is_timestamp) {
-    m->is_new = w_timeval_compare(ctx->since.timestamp, file->ctime.tv) > 0;
+    m->is_new = ctx->since.timestamp > file->ctime.timestamp;
   } else if (ctx->since.clock.is_fresh_instance) {
     m->is_new = true;
   } else {
@@ -141,8 +141,7 @@ static bool time_generator(
 
   // Walk back in time until we hit the boundary
   for (f = root->latest_file; f; f = f->next) {
-    if (ctx->since.is_timestamp &&
-        w_timeval_compare(f->otime.tv, ctx->since.timestamp) < 0) {
+    if (ctx->since.is_timestamp && f->otime.timestamp < ctx->since.timestamp) {
       break;
     }
     if (!ctx->since.is_timestamp &&

--- a/query/match.c
+++ b/query/match.c
@@ -26,7 +26,7 @@ static bool eval_wildmatch(struct w_query_ctx *ctx,
   if (match->wholename) {
     str = w_query_ctx_get_wholename(ctx);
   } else {
-    str = file->name;
+    str = w_file_get_name(file);
   }
 
 #ifdef _WIN32

--- a/query/name.c
+++ b/query/name.c
@@ -20,7 +20,7 @@ static bool eval_name(struct w_query_ctx *ctx,
   if (name->wholename) {
     str = w_query_ctx_get_wholename(ctx);
   } else {
-    str = file->name;
+    str = w_file_get_name(file);
   }
 
   if (name->map) {

--- a/query/pcre.c
+++ b/query/pcre.c
@@ -21,7 +21,7 @@ static bool eval_pcre(struct w_query_ctx *ctx,
   if (match->wholename) {
     str = w_query_ctx_get_wholename(ctx);
   } else {
-    str = file->name;
+    str = w_file_get_name(file);
   }
 
   rc = pcre_exec(match->re, match->extra,

--- a/query/since.c
+++ b/query/since.c
@@ -30,7 +30,7 @@ static bool eval_since(struct w_query_ctx *ctx,
     case SINCE_CCLOCK:
       clock = (term->field == SINCE_OCLOCK) ? file->otime : file->ctime;
       if (since.is_timestamp) {
-        return w_timeval_compare(since.timestamp, clock.tv) > 0;
+        return since.timestamp > clock.timestamp;
       }
       if (since.clock.is_fresh_instance) {
         return file->exists;
@@ -45,7 +45,7 @@ static bool eval_since(struct w_query_ctx *ctx,
   }
 
   assert(since.is_timestamp);
-  return tval > since.timestamp.tv_sec;
+  return tval > since.timestamp;
 }
 
 static void dispose_since(void *data)

--- a/query/suffix.c
+++ b/query/suffix.c
@@ -11,7 +11,7 @@ static bool eval_suffix(struct w_query_ctx *ctx,
 
   unused_parameter(ctx);
 
-  return w_string_suffix_match(file->name, suffix);
+  return w_string_suffix_match(w_file_get_name(file), suffix);
 }
 
 static void dispose_suffix(void *data)

--- a/root.c
+++ b/root.c
@@ -623,7 +623,7 @@ void w_root_mark_file_changed(w_root_t *root, struct watchman_file *file,
     stop_watching_file(root, file);
   }
 
-  file->otime.tv = now;
+  file->otime.timestamp = now.tv_sec;
   file->otime.ticks = root->ticks;
 
   if (root->latest_file != file) {
@@ -677,7 +677,7 @@ struct watchman_file *w_root_resolve_file(w_root_t *root,
   file->parent = dir;
   file->exists = true;
   file->ctime.ticks = root->ticks;
-  file->ctime.tv = now;
+  file->ctime.timestamp = now.tv_sec;
 
   suffix = w_string_suffix(file_name);
   if (suffix) {
@@ -891,7 +891,7 @@ static void stat_path(w_root_t *root,
       /* we're transitioning from deleted to existing,
        * so we're effectively new again */
       file->ctime.ticks = root->ticks;
-      file->ctime.tv = now;
+      file->ctime.timestamp = now.tv_sec;
       /* if a dir was deleted and now exists again, we want
        * to crawl it again */
       recursive = true;
@@ -1597,7 +1597,7 @@ void w_root_perform_age_out(w_root_t *root, int min_age)
 
   file = root->latest_file;
   while (file) {
-    if (file->exists || file->otime.tv.tv_sec + min_age > now) {
+    if (file->exists || file->otime.timestamp + min_age > now) {
       file = file->next;
       continue;
     }

--- a/spawn.c
+++ b/spawn.c
@@ -429,8 +429,7 @@ static bool trigger_generator(
 
   // Walk back in time until we hit the boundary
   for (f = root->latest_file; f; f = f->next) {
-    if (ctx->since.is_timestamp &&
-        w_timeval_compare(f->otime.tv, ctx->since.timestamp) < 0) {
+    if (ctx->since.is_timestamp && f->otime.timestamp < ctx->since.timestamp) {
       break;
     }
     if (!ctx->since.is_timestamp &&

--- a/string.c
+++ b/string.c
@@ -44,6 +44,27 @@ uint32_t strlen_uint32(const char *str) {
   return (uint32_t)slen;
 }
 
+// Returns the memory size required to embed str into some other struct
+uint32_t w_string_embedded_size(w_string_t *str) {
+  return sizeof(*str) + str->len + 1;
+}
+
+// Copies src -> dest.  dest is assumed to be some memory of at least
+// w_string_embedded_size().
+void w_string_embedded_copy(w_string_t *dest, w_string_t *src) {
+  char *buf;
+  dest->refcnt = 1;
+  dest->hval = src->hval;
+  dest->len = src->len;
+  dest->slice = NULL;
+
+  buf = (char*)(dest + 1);
+  memcpy(buf, src->buf, src->len);
+  buf[dest->len] = 0;
+
+  dest->buf = buf;
+}
+
 w_string_t *w_string_new_len_with_refcnt_typed(const char* str,
     uint32_t len, long refcnt, w_string_type_t type) {
 

--- a/watcher/kqueue.c
+++ b/watcher/kqueue.c
@@ -105,7 +105,7 @@ static bool kqueue_root_start_watch_file(
   int fd;
   w_string_t *full_name;
 
-  full_name = w_string_path_cat(file->parent->path, file->name);
+  full_name = w_string_path_cat(file->parent->path, w_file_get_name(file));
   pthread_mutex_lock(&state->lock);
   if (w_ht_lookup(state->name_to_fd, w_ht_ptr_val(full_name), &fdval, false)) {
     // Already watching it

--- a/watchman.h
+++ b/watchman.h
@@ -244,7 +244,7 @@ typedef void *watchman_watcher_t;
 
 struct watchman_clock {
   uint32_t ticks;
-  struct timeval tv;
+  time_t timestamp;
 };
 typedef struct watchman_clock w_clock_t;
 
@@ -702,7 +702,7 @@ enum w_clockspec_tag {
 struct w_clockspec {
   enum w_clockspec_tag tag;
   union {
-    struct timeval timestamp;
+    time_t timestamp;
     struct {
       uint64_t start_time;
       int pid;
@@ -718,7 +718,7 @@ struct w_clockspec {
 struct w_query_since {
   bool is_timestamp;
   union {
-    struct timeval timestamp;
+    time_t timestamp;
     struct {
       bool is_fresh_instance;
       uint32_t ticks;

--- a/watchman.h
+++ b/watchman.h
@@ -379,8 +379,6 @@ void w_dir_close(struct watchman_dir_handle *dir);
 int w_dir_fd(struct watchman_dir_handle *dir);
 
 struct watchman_file {
-  /* our name within the parent dir */
-  w_string_t *name;
   /* the parent dir */
   struct watchman_dir *parent;
 
@@ -410,6 +408,10 @@ struct watchman_file {
    * Can be NULL if not a symlink, or we failed to read the target */
   w_string_t *symlink_target;
 };
+
+static inline w_string_t *w_file_get_name(struct watchman_file *file) {
+  return (w_string_t*)(file + 1);
+}
 
 #define WATCHMAN_COOKIE_PREFIX ".watchman-cookie-"
 struct watchman_query_cookie {

--- a/watchman_string.h
+++ b/watchman_string.h
@@ -89,6 +89,9 @@ size_t w_string_strlen(w_string_t *str);
 uint32_t strlen_uint32(const char *str);
 uint32_t w_hash_bytes(const void *key, size_t length, uint32_t initval);
 
+uint32_t w_string_embedded_size(w_string_t *str);
+void w_string_embedded_copy(w_string_t *dest, w_string_t *src);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Two commits here:

1. We make better usage of the allocator bucketing/binning by embedding the filename string directly into the watchman_file struct

2. We never use more than second granularity for timestamp based (rather than tick based) since comparisons, so we can save 16 bytes per file entry if we switch from using a timeval to a time_t.