### PR TITLE
Fixes a memory leak in the caching of raw C-string in a JSON object.

### DIFF
--- a/thirdparty/jansson/value.c
+++ b/thirdparty/jansson/value.c
@@ -697,6 +697,13 @@ const char *json_string_value(const json_t *json)
         // Safe to return the buffer itself
         return value->buf;
     }
+
+    // If it's not null-terminated, use a cached version that is null-terminated
+
+    if (jstr->cache) {
+        return jstr->cache;
+    }
+
     buf = w_string_dup_buf(value);
     if (!buf) {
         return NULL;


### PR DESCRIPTION
Refer to https://github.com/facebook/watchman/commit/b6599bda54f63203a54d012df9c689c43dcd932d#commitcomment-18461888