### PR TITLE
root lock -> reader/writer lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
       - python3.5
       - python3.5-dev
       - gcc-5
+      - libunwind-dev
 #      - ruby
 #      - rubygems
 #      - valgrind

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,6 @@ watchman_SOURCES = \
 	query/empty.c      \
 	watcher/auto.c     \
 	watcher/fsevents.c \
-	watcher/helper.c   \
 	watcher/inotify.c  \
 	watcher/kqueue.c   \
 	watcher/portfs.c   \
@@ -220,7 +219,6 @@ tests_ignore_t_LDADD = $(ART_LIB) $(TAP_LIB) $(JSON_LIB)
 tests_ignore_t_SOURCES = \
 	tests/ignore_test.c \
 	tests/log_stub.c \
-	watcher/helper.c \
 	hash.c \
 	ht.c \
 	ignore.c \
@@ -232,7 +230,6 @@ tests_pending_t_LDADD = $(ART_LIB) $(TAP_LIB) $(JSON_LIB)
 tests_pending_t_SOURCES = \
 	tests/pending_test.c \
 	tests/log_stub.c \
-	watcher/helper.c \
 	hash.c \
 	ht.c \
 	ignore.c \

--- a/cfg.c
+++ b/cfg.c
@@ -84,7 +84,7 @@ static json_t *cfg_get_raw(const char *name, json_t **optr)
   return val;
 }
 
-json_t *cfg_get_json(w_root_t *root, const char *name)
+json_t *cfg_get_json(const w_root_t *root, const char *name)
 {
   json_t *val = NULL;
 
@@ -103,7 +103,7 @@ json_t *cfg_get_json(w_root_t *root, const char *name)
   return val;
 }
 
-const char *cfg_get_string(w_root_t *root, const char *name,
+const char *cfg_get_string(const w_root_t *root, const char *name,
     const char *defval)
 {
   json_t *val = cfg_get_json(root, name);
@@ -209,7 +209,7 @@ json_t *cfg_compute_root_files(bool *enforcing) {
   return json_pack("[ssss]", ".watchmanconfig", ".hg", ".git", ".svn");
 }
 
-json_int_t cfg_get_int(w_root_t *root, const char *name,
+json_int_t cfg_get_int(const w_root_t *root, const char *name,
     json_int_t defval)
 {
   json_t *val = cfg_get_json(root, name);
@@ -224,7 +224,7 @@ json_int_t cfg_get_int(w_root_t *root, const char *name,
   return defval;
 }
 
-bool cfg_get_bool(w_root_t *root, const char *name, bool defval)
+bool cfg_get_bool(const w_root_t *root, const char *name, bool defval)
 {
   json_t *val = cfg_get_json(root, name);
 
@@ -238,7 +238,7 @@ bool cfg_get_bool(w_root_t *root, const char *name, bool defval)
   return defval;
 }
 
-double cfg_get_double(w_root_t *root, const char *name, double defval) {
+double cfg_get_double(const w_root_t *root, const char *name, double defval) {
   json_t *val = cfg_get_json(root, name);
 
   if (val) {
@@ -281,7 +281,7 @@ MAKE_GET_PERM(others, OTH)
  * This function expects the config to be an object containing the keys 'group'
  * and 'others', each a bool.
  */
-mode_t cfg_get_perms(w_root_t *root, const char *name, bool write_bits,
+mode_t cfg_get_perms(const w_root_t *root, const char *name, bool write_bits,
                      bool execute_bits) {
   json_t *val = cfg_get_json(root, name);
   mode_t ret = S_IRUSR | S_IWUSR;

--- a/clockspec.c
+++ b/clockspec.c
@@ -250,16 +250,17 @@ bool clock_id_string(uint32_t root_number, uint32_t ticks, char *buf,
 
 // Renders the current clock id string to the supplied buffer.
 // Must be called with the root locked.
-static bool current_clock_id_string(w_root_t *root, char *buf, size_t bufsize) {
-  return clock_id_string(root->number, root->ticks, buf, bufsize);
+static bool current_clock_id_string(struct read_locked_watchman_root *lock,
+                                    char *buf, size_t bufsize) {
+  return clock_id_string(lock->root->number, lock->root->ticks, buf, bufsize);
 }
 
 /* Add the current clock value to the response.
  * must be called with the root locked */
-void annotate_with_clock(w_root_t *root, json_t *resp) {
+void annotate_with_clock(struct read_locked_watchman_root *lock, json_t *resp) {
   char buf[128];
 
-  if (current_clock_id_string(root, buf, sizeof(buf))) {
+  if (current_clock_id_string(lock, buf, sizeof(buf))) {
     set_prop(resp, "clock", typed_string_to_json(buf, W_STRING_UNICODE));
   }
 }

--- a/cmds/debug.c
+++ b/cmds/debug.c
@@ -112,8 +112,7 @@ static void cmd_debug_poison(struct watchman_client *client, json_t *args)
 
   gettimeofday(&now, NULL);
 
-  set_poison_state(unlocked.root, unlocked.root->root_path, now, "debug-poison",
-                   ENOMEM, NULL);
+  set_poison_state(unlocked.root->root_path, now, "debug-poison", ENOMEM, NULL);
 
   resp = make_response();
   set_unicode_prop(resp, "poison", poisoned_reason);

--- a/cmds/debug.c
+++ b/cmds/debug.c
@@ -5,9 +5,9 @@
 
 static void cmd_debug_recrawl(struct watchman_client *client, json_t *args)
 {
-  w_root_t *root;
   json_t *resp;
   struct write_locked_watchman_root lock;
+  struct unlocked_watchman_root unlocked;
 
   /* resolve the root */
   if (json_array_size(args) != 2) {
@@ -16,30 +16,28 @@ static void cmd_debug_recrawl(struct watchman_client *client, json_t *args)
     return;
   }
 
-  root = resolve_root_or_err(client, args, 1, false);
-
-  if (!root) {
+  if (!resolve_root_or_err(client, args, 1, false, &unlocked)) {
     return;
   }
 
   resp = make_response();
 
-  w_root_lock(&root, "debug-recrawl", &lock);
+  w_root_lock(&unlocked.root, "debug-recrawl", &lock);
   w_root_schedule_recrawl(lock.root, "debug-recrawl");
-  root = w_root_unlock(&lock);
+  unlocked.root = w_root_unlock(&lock);
 
   set_prop(resp, "recrawl", json_true());
   send_and_dispose_response(client, resp);
-  w_root_delref(root);
+  w_root_delref(unlocked.root);
 }
 W_CMD_REG("debug-recrawl", cmd_debug_recrawl, CMD_DAEMON, w_cmd_realpath_root)
 
 static void cmd_debug_show_cursors(struct watchman_client *client, json_t *args)
 {
-  w_root_t *root;
   json_t *resp, *cursors;
   w_ht_iter_t i;
   struct write_locked_watchman_root lock;
+  struct unlocked_watchman_root unlocked;
 
   /* resolve the root */
   if (json_array_size(args) != 2) {
@@ -48,25 +46,23 @@ static void cmd_debug_show_cursors(struct watchman_client *client, json_t *args)
     return;
   }
 
-  root = resolve_root_or_err(client, args, 1, false);
-
-  if (!root) {
+  if (!resolve_root_or_err(client, args, 1, false, &unlocked)) {
     return;
   }
 
   resp = make_response();
 
-  w_root_lock(&root, "debug-show-cursors", &lock);
+  w_root_lock(&unlocked.root, "debug-show-cursors", &lock);
   cursors = json_object_of_size(w_ht_size(lock.root->cursors));
   if (w_ht_first(lock.root->cursors, &i)) do {
     w_string_t *name = w_ht_val_ptr(i.key);
     set_prop(cursors, name->buf, json_integer(i.value));
   } while (w_ht_next(lock.root->cursors, &i));
-  root = w_root_unlock(&lock);
+  unlocked.root = w_root_unlock(&lock);
 
   set_prop(resp, "cursors", cursors);
   send_and_dispose_response(client, resp);
-  w_root_delref(root);
+  w_root_delref(unlocked.root);
 }
 W_CMD_REG("debug-show-cursors", cmd_debug_show_cursors,
     CMD_DAEMON, w_cmd_realpath_root)
@@ -74,10 +70,10 @@ W_CMD_REG("debug-show-cursors", cmd_debug_show_cursors,
 /* debug-ageout */
 static void cmd_debug_ageout(struct watchman_client *client, json_t *args)
 {
-  w_root_t *root;
   json_t *resp;
   int min_age;
   struct write_locked_watchman_root lock;
+  struct unlocked_watchman_root unlocked;
 
   /* resolve the root */
   if (json_array_size(args) != 3) {
@@ -86,9 +82,7 @@ static void cmd_debug_ageout(struct watchman_client *client, json_t *args)
     return;
   }
 
-  root = resolve_root_or_err(client, args, 1, false);
-
-  if (!root) {
+  if (!resolve_root_or_err(client, args, 1, false, &unlocked)) {
     return;
   }
 
@@ -96,35 +90,35 @@ static void cmd_debug_ageout(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(&root, "debug-ageout", &lock);
+  w_root_lock(&unlocked.root, "debug-ageout", &lock);
   w_root_perform_age_out(&lock, min_age);
-  root = w_root_unlock(&lock);
+  unlocked.root = w_root_unlock(&lock);
 
   set_prop(resp, "ageout", json_true());
   send_and_dispose_response(client, resp);
-  w_root_delref(root);
+  w_root_delref(unlocked.root);
 }
 W_CMD_REG("debug-ageout", cmd_debug_ageout, CMD_DAEMON, w_cmd_realpath_root)
 
 static void cmd_debug_poison(struct watchman_client *client, json_t *args)
 {
-  w_root_t *root;
   struct timeval now;
   json_t *resp;
+  struct unlocked_watchman_root unlocked;
 
-  root = resolve_root_or_err(client, args, 1, false);
-  if (!root) {
+  if (!resolve_root_or_err(client, args, 1, false, &unlocked)) {
     return;
   }
 
   gettimeofday(&now, NULL);
 
-  set_poison_state(root, root->root_path, now, "debug-poison", ENOMEM, NULL);
+  set_poison_state(unlocked.root, unlocked.root->root_path, now, "debug-poison",
+                   ENOMEM, NULL);
 
   resp = make_response();
   set_unicode_prop(resp, "poison", poisoned_reason);
   send_and_dispose_response(client, resp);
-  w_root_delref(root);
+  w_root_delref(unlocked.root);
 }
 W_CMD_REG("debug-poison", cmd_debug_poison, CMD_DAEMON, w_cmd_realpath_root)
 

--- a/cmds/debug.c
+++ b/cmds/debug.c
@@ -22,9 +22,9 @@ static void cmd_debug_recrawl(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(&unlocked.root, "debug-recrawl", &lock);
+  w_root_lock(&unlocked, "debug-recrawl", &lock);
   w_root_schedule_recrawl(lock.root, "debug-recrawl");
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   set_prop(resp, "recrawl", json_true());
   send_and_dispose_response(client, resp);
@@ -52,13 +52,13 @@ static void cmd_debug_show_cursors(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(&unlocked.root, "debug-show-cursors", &lock);
+  w_root_lock(&unlocked, "debug-show-cursors", &lock);
   cursors = json_object_of_size(w_ht_size(lock.root->cursors));
   if (w_ht_first(lock.root->cursors, &i)) do {
     w_string_t *name = w_ht_val_ptr(i.key);
     set_prop(cursors, name->buf, json_integer(i.value));
   } while (w_ht_next(lock.root->cursors, &i));
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   set_prop(resp, "cursors", cursors);
   send_and_dispose_response(client, resp);
@@ -90,9 +90,9 @@ static void cmd_debug_ageout(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(&unlocked.root, "debug-ageout", &lock);
+  w_root_lock(&unlocked, "debug-ageout", &lock);
   w_root_perform_age_out(&lock, min_age);
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   set_prop(resp, "ageout", json_true());
   send_and_dispose_response(client, resp);

--- a/cmds/info.c
+++ b/cmds/info.c
@@ -126,7 +126,7 @@ static void cmd_get_config(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(&unlocked.root, "cmd_get_config", &lock);
+  w_root_lock(&unlocked, "cmd_get_config", &lock);
   {
     config = lock.root->config_file;
     if (config) {
@@ -134,7 +134,7 @@ static void cmd_get_config(struct watchman_client *client, json_t *args)
       json_incref(config);
     }
   }
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   if (!config) {
     // set_prop will own this

--- a/cmds/query.c
+++ b/cmds/query.c
@@ -68,7 +68,13 @@ static void cmd_query(struct watchman_client *client, json_t *args)
   set_prop(response, "is_fresh_instance",
            json_pack("b", res.is_fresh_instance));
   set_prop(response, "files", file_list);
-  add_root_warnings_to_response(response, unlocked.root);
+
+  {
+    struct read_locked_watchman_root lock;
+    w_root_read_lock(&unlocked, "obtain_warnings", &lock);
+    add_root_warnings_to_response(response, &lock);
+    w_root_read_unlock(&lock, &unlocked);
+  }
 
   send_and_dispose_response(client, response);
   w_root_delref(unlocked.root);

--- a/cmds/since.c
+++ b/cmds/since.c
@@ -67,7 +67,13 @@ static void cmd_since(struct watchman_client *client, json_t *args)
   set_prop(response, "is_fresh_instance",
            json_pack("b", res.is_fresh_instance));
   set_prop(response, "files", file_list);
-  add_root_warnings_to_response(response, unlocked.root);
+
+  {
+    struct read_locked_watchman_root lock;
+    w_root_read_lock(&unlocked, "obtain_warnings", &lock);
+    add_root_warnings_to_response(response, &lock);
+    w_root_read_unlock(&lock, &unlocked);
+  }
 
   send_and_dispose_response(client, response);
   w_root_delref(unlocked.root);

--- a/cmds/subscribe.c
+++ b/cmds/subscribe.c
@@ -4,7 +4,7 @@
 #include "watchman.h"
 
 static bool subscription_generator(w_query *query,
-                                   struct write_locked_watchman_root *lock,
+                                   struct read_locked_watchman_root *lock,
                                    struct w_query_ctx *ctx, void *gendata,
                                    int64_t *num_walked) {
   struct watchman_file *f;

--- a/cmds/subscribe.c
+++ b/cmds/subscribe.c
@@ -340,9 +340,9 @@ static void cmd_subscribe(struct watchman_client *clientbase, json_t *args)
   add_root_warnings_to_response(resp, unlocked.root);
   send_and_dispose_response(&client->client, resp);
 
-  w_root_lock(&unlocked.root, "initial subscription query", &lock);
+  w_root_lock(&unlocked, "initial subscription query", &lock);
   resp = build_subscription_results(sub, &lock);
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   if (resp) {
     send_and_dispose_response(&client->client, resp);

--- a/cmds/subscribe.c
+++ b/cmds/subscribe.c
@@ -141,7 +141,7 @@ void w_run_subscription_rules(
   }
 }
 
-void w_cancel_subscriptions_for_root(w_root_t *root) {
+void w_cancel_subscriptions_for_root(const w_root_t *root) {
   w_ht_iter_t iter;
   pthread_mutex_lock(&w_client_lock);
   if (w_ht_first(clients, &iter)) {

--- a/cmds/subscribe.c
+++ b/cmds/subscribe.c
@@ -3,13 +3,10 @@
 
 #include "watchman.h"
 
-static bool subscription_generator(
-    w_query *query,
-    w_root_t *root,
-    struct w_query_ctx *ctx,
-    void *gendata,
-    int64_t *num_walked)
-{
+static bool subscription_generator(w_query *query,
+                                   struct write_locked_watchman_root *lock,
+                                   struct w_query_ctx *ctx, void *gendata,
+                                   int64_t *num_walked) {
   struct watchman_file *f;
   struct watchman_client_subscription *sub = gendata;
   int64_t n = 0;
@@ -19,7 +16,7 @@ static bool subscription_generator(
       sub->name->buf, sub);
 
   // Walk back in time until we hit the boundary
-  for (f = root->latest_file; f; f = f->next) {
+  for (f = lock->root->latest_file; f; f = f->next) {
     ++n;
     if (ctx->since.is_timestamp && f->otime.timestamp < ctx->since.timestamp) {
       break;

--- a/cmds/trigger.c
+++ b/cmds/trigger.c
@@ -193,7 +193,7 @@ void w_trigger_command_free(struct watchman_trigger_command *cmd)
 }
 
 struct watchman_trigger_command *w_build_trigger_from_def(
-  w_root_t *root, json_t *trig, char **errmsg)
+  const w_root_t *root, json_t *trig, char **errmsg)
 {
   struct watchman_trigger_command *cmd;
   json_t *ele, *query, *relative_root;

--- a/cmds/trigger.c
+++ b/cmds/trigger.c
@@ -58,7 +58,7 @@ static void cmd_trigger_list(struct watchman_client *client, json_t *args)
 {
   json_t *resp;
   json_t *arr;
-  struct write_locked_watchman_root lock;
+  struct read_locked_watchman_root lock;
   struct unlocked_watchman_root unlocked;
 
   if (!resolve_root_or_err(client, args, 1, false, &unlocked)) {
@@ -66,9 +66,9 @@ static void cmd_trigger_list(struct watchman_client *client, json_t *args)
   }
 
   resp = make_response();
-  w_root_lock(&unlocked, "trigger-list", &lock);
-  arr = w_root_trigger_list_to_json(lock.root);
-  w_root_unlock(&lock, &unlocked);
+  w_root_read_lock(&unlocked, "trigger-list", &lock);
+  arr = w_root_trigger_list_to_json(&lock);
+  w_root_read_unlock(&lock, &unlocked);
 
   set_prop(resp, "triggers", arr);
   send_and_dispose_response(client, resp);

--- a/cmds/trigger.c
+++ b/cmds/trigger.c
@@ -32,9 +32,9 @@ static void cmd_trigger_delete(struct watchman_client *client, json_t *args)
   }
   tname = json_to_w_string_incref(jname);
 
-  w_root_lock(&unlocked.root, "trigger-del", &lock);
+  w_root_lock(&unlocked, "trigger-del", &lock);
   res = w_ht_del(lock.root->commands, w_ht_ptr_val(tname));
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   if (res) {
     w_state_save();
@@ -66,9 +66,9 @@ static void cmd_trigger_list(struct watchman_client *client, json_t *args)
   }
 
   resp = make_response();
-  w_root_lock(&unlocked.root, "trigger-list", &lock);
+  w_root_lock(&unlocked, "trigger-list", &lock);
   arr = w_root_trigger_list_to_json(lock.root);
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   set_prop(resp, "triggers", arr);
   send_and_dispose_response(client, resp);
@@ -351,7 +351,7 @@ static void cmd_trigger(struct watchman_client *client, json_t *args)
   resp = make_response();
   set_prop(resp, "triggerid", w_string_to_json(cmd->triggername));
 
-  w_root_lock(&unlocked.root, "trigger-add", &lock);
+  w_root_lock(&unlocked, "trigger-add", &lock);
 
   old = w_ht_val_ptr(w_ht_get(lock.root->commands,
           w_ht_ptr_val(cmd->triggername)));
@@ -371,7 +371,7 @@ static void cmd_trigger(struct watchman_client *client, json_t *args)
     lock.root->ticks++;
     lock.root->pending_trigger_tick = lock.root->ticks;
   }
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   if (need_save) {
     w_state_save();

--- a/cmds/watch.c
+++ b/cmds/watch.c
@@ -96,7 +96,7 @@ static void cmd_watch_delete(struct watchman_client *client, json_t *args)
   }
 
   resp = make_response();
-  set_prop(resp, "watch-del", json_boolean(w_root_stop_watch(unlocked.root)));
+  set_prop(resp, "watch-del", json_boolean(w_root_stop_watch(&unlocked)));
   set_prop(resp, "root", w_string_to_json(unlocked.root->root_path));
   send_and_dispose_response(client, resp);
   w_root_delref(unlocked.root);

--- a/cmds/watch.c
+++ b/cmds/watch.c
@@ -68,9 +68,9 @@ static void cmd_clock(struct watchman_client *client, json_t *args)
   }
 
   resp = make_response();
-  w_root_lock(&unlocked.root, "clock", &lock);
+  w_root_lock(&unlocked, "clock", &lock);
   annotate_with_clock(lock.root, resp);
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   send_and_dispose_response(client, resp);
   w_root_delref(unlocked.root);
@@ -312,7 +312,7 @@ static void cmd_watch(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(&unlocked.root, "watch", &lock);
+  w_root_lock(&unlocked, "watch", &lock);
   if (lock.root->failure_reason) {
     set_prop(resp, "error", w_string_to_json(lock.root->failure_reason));
   } else if (lock.root->cancelled) {
@@ -323,7 +323,7 @@ static void cmd_watch(struct watchman_client *client, json_t *args)
   }
   add_root_warnings_to_response(resp, lock.root);
   send_and_dispose_response(client, resp);
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
   w_root_delref(unlocked.root);
 }
 W_CMD_REG("watch", cmd_watch, CMD_DAEMON | CMD_ALLOW_ANY_USER,
@@ -361,7 +361,7 @@ static void cmd_watch_project(struct watchman_client *client, json_t *args)
 
   resp = make_response();
 
-  w_root_lock(&unlocked.root, "watch-project", &lock);
+  w_root_lock(&unlocked, "watch-project", &lock);
   if (lock.root->failure_reason) {
     set_prop(resp, "error", w_string_to_json(lock.root->failure_reason));
   } else if (lock.root->cancelled) {
@@ -375,7 +375,7 @@ static void cmd_watch_project(struct watchman_client *client, json_t *args)
     set_bytestring_prop(resp, "relative_path",rel_path_from_watch);
   }
   send_and_dispose_response(client, resp);
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
   w_root_delref(unlocked.root);
   free(dir_to_watch);
 }

--- a/configure.ac
+++ b/configure.ac
@@ -266,6 +266,19 @@ AC_CHECK_FUNCS(backtrace backtrace_symbols backtrace_symbols_fd)
 AC_CHECK_FUNCS(sys_siglist)
 AC_CHECK_FUNCS(memmem)
 
+dnl Can't just use AC_SEARCH_LIBS because the true symbols are hidden through
+dnl preprocessor magicks
+AC_CHECK_HEADERS(libunwind.h)
+save_libs="$LIBS"
+LIBS="$LIBS -lunwind-generic"
+AC_TRY_LINK([
+#include <libunwind.h>
+],[unw_init_local(0,0);],[
+AC_DEFINE([HAVE_UNW_INIT_LOCAL],[],[Have unw_init_local])
+],[
+LIBS="$save_libs"
+])
+
 if test -n "$ac_cv_header_sys_statvfs_h"; then
 AC_CHECK_MEMBERS([struct statvfs.f_fstypename,struct statvfs.f_basetype],
   [AC_DEFINE([STATVFS_HAS_FSTYPE_AS_STRING], [1],[if statvfs holds fstype as string])],[],[[#include <sys/statvfs.h>]])

--- a/ignore.c
+++ b/ignore.c
@@ -46,7 +46,7 @@ void w_ignore_addstr(struct watchman_ignore *ignore, w_string_t *path,
   }
 }
 
-bool w_ignore_check(struct watchman_ignore *ignore, const char *path,
+bool w_ignore_check(const struct watchman_ignore *ignore, const char *path,
                     uint32_t pathlen) {
   const char *skip_prefix;
   uint32_t len;

--- a/listener-user.c
+++ b/listener-user.c
@@ -17,9 +17,11 @@ static void cmd_shutdown(struct watchman_client *client, json_t *args) {
 }
 W_CMD_REG("shutdown-server", cmd_shutdown, CMD_DAEMON|CMD_POISON_IMMUNE, NULL)
 
-void add_root_warnings_to_response(json_t *response, w_root_t *root) {
+void add_root_warnings_to_response(json_t *response,
+                                   struct read_locked_watchman_root *lock) {
   char *str = NULL;
   char *full = NULL;
+  const w_root_t *root = lock->root;
 
   if (!root->last_recrawl_reason && !root->warning) {
     return;

--- a/perf.c
+++ b/perf.c
@@ -92,7 +92,7 @@ void w_perf_add_meta(w_perf_t *perf, const char *key, json_t *val) {
   set_prop(perf->meta_data, key, val);
 }
 
-void w_perf_add_root_meta(w_perf_t *perf, w_root_t *root) {
+void w_perf_add_root_meta(w_perf_t *perf, const w_root_t *root) {
   // Note: if the root lock isn't held, we may read inaccurate numbers for
   // some of these properties.  We're ok with that, and don't want to force
   // the root lock to be re-acquired just for this.

--- a/query/eval.c
+++ b/query/eval.c
@@ -473,7 +473,7 @@ bool w_query_execute_locked(
   res->ticks = lock->root->ticks;
 
   // Evaluate the cursor for this root
-  w_clockspec_eval(lock->root, query->since_spec, &ctx.since);
+  w_clockspec_eval(lock, query->since_spec, &ctx.since);
 
   res->is_fresh_instance = !ctx.since.is_timestamp &&
     ctx.since.clock.is_fresh_instance;
@@ -558,7 +558,7 @@ bool w_query_execute(
   res->ticks = lock.root->ticks;
 
   // Evaluate the cursor for this root
-  w_clockspec_eval(lock.root, query->since_spec, &ctx.since);
+  w_clockspec_eval(&lock, query->since_spec, &ctx.since);
 
   res->is_fresh_instance = !ctx.since.is_timestamp &&
     ctx.since.clock.is_fresh_instance;

--- a/query/eval.c
+++ b/query/eval.c
@@ -557,11 +557,12 @@ bool w_query_execute(
 
   if (query->since_spec && query->since_spec->tag == w_cs_named_cursor) {
     // We need a write lock to evaluate this cursor
-    if (!w_root_lock_with_timeout(unlocked, "w_query_execute",
+    if (!w_root_lock_with_timeout(unlocked, "w_query_execute_named_cursor",
                                   query->lock_timeout, &wlock)) {
-      ignore_result(asprintf(&res->errmsg, "couldn't acquire root lock within "
-                                           "lock_timeout of %dms. root is "
-                                           "currently busy (%s)\n",
+      ignore_result(asprintf(&res->errmsg,
+                             "couldn't acquire root wrlock within "
+                             "lock_timeout of %dms. root is "
+                             "currently busy (%s)\n",
                              query->lock_timeout, unlocked->root->lock_reason));
       return false;
     }
@@ -577,9 +578,10 @@ bool w_query_execute(
   } else {
     if (!w_root_read_lock_with_timeout(unlocked, "w_query_execute",
                                   query->lock_timeout, &rlock)) {
-      ignore_result(asprintf(&res->errmsg, "couldn't acquire root lock within "
-                                           "lock_timeout of %dms. root is "
-                                           "currently busy (%s)\n",
+      ignore_result(asprintf(&res->errmsg,
+                             "couldn't acquire root rdlock within "
+                             "lock_timeout of %dms. root is "
+                             "currently busy (%s)\n",
                              query->lock_timeout, unlocked->root->lock_reason));
       return false;
     }

--- a/query/eval.c
+++ b/query/eval.c
@@ -563,7 +563,7 @@ bool w_query_execute(
    */
 
   // Lock the root and begin generation
-  if (!w_root_lock_with_timeout(&unlocked->root, "w_query_execute",
+  if (!w_root_lock_with_timeout(unlocked, "w_query_execute",
                                 query->lock_timeout, &lock)) {
     ignore_result(asprintf(&res->errmsg, "couldn't acquire root lock within "
                                          "lock_timeout of %dms. root is "
@@ -599,7 +599,7 @@ bool w_query_execute(
                               ));
     w_perf_log(&sample);
   }
-  unlocked->root = w_root_unlock(&lock);
+  w_root_unlock(&lock, unlocked);
   w_perf_destroy(&sample);
 
   if (ctx.wholename) {

--- a/query/parse.c
+++ b/query/parse.c
@@ -195,8 +195,8 @@ static bool parse_paths(w_query *res, json_t *query)
 
 W_CAP_REG("relative_root")
 
-static bool parse_relative_root(w_root_t *root, w_query *res, json_t *query)
-{
+static bool parse_relative_root(const w_root_t *root, w_query *res,
+                                json_t *query) {
   json_t *relative_root;
   w_string_t *path, *canon_path;
 
@@ -305,7 +305,7 @@ static bool parse_case_sensitive(w_query *res, const w_root_t *root, json_t *que
   return true;
 }
 
-w_query *w_query_parse(w_root_t *root, json_t *query, char **errmsg)
+w_query *w_query_parse(const w_root_t *root, json_t *query, char **errmsg)
 {
   w_query *res;
 
@@ -404,7 +404,7 @@ bool w_query_legacy_field_list(struct w_query_field_list *flist)
 // Translate from the legacy array into the new style, then
 // delegate to the main parser.
 // We build a big anyof expression
-w_query *w_query_parse_legacy(w_root_t *root, json_t *args, char **errmsg,
+w_query *w_query_parse_legacy(const w_root_t *root, json_t *args, char **errmsg,
     int start, uint32_t *next_arg,
     const char *clockspec, json_t **expr_p)
 {

--- a/query/since.c
+++ b/query/since.c
@@ -22,8 +22,9 @@ static bool eval_since(struct w_query_ctx *ctx,
   w_clock_t clock;
   struct w_query_since since;
   time_t tval = 0;
+  struct read_locked_watchman_root lock = {ctx->root};
 
-  w_clockspec_eval(ctx->root, term->spec, &since);
+  w_clockspec_eval_readonly(&lock, term->spec, &since);
 
   switch (term->field) {
     case SINCE_OCLOCK:

--- a/query/since.c
+++ b/query/since.c
@@ -22,9 +22,8 @@ static bool eval_since(struct w_query_ctx *ctx,
   w_clock_t clock;
   struct w_query_since since;
   time_t tval = 0;
-  struct read_locked_watchman_root lock = {ctx->root};
 
-  w_clockspec_eval_readonly(&lock, term->spec, &since);
+  w_clockspec_eval_readonly(ctx->lock, term->spec, &since);
 
   switch (term->field) {
     case SINCE_OCLOCK:

--- a/root.c
+++ b/root.c
@@ -1249,7 +1249,7 @@ void handle_open_errno(struct write_locked_watchman_root *lock,
     log_warning = true;
     transient = false;
   } else if (err == ENFILE || err == EMFILE) {
-    set_poison_state(lock->root, dir_name, now, syscall, err, strerror(err));
+    set_poison_state(dir_name, now, syscall, err, strerror(err));
     w_string_delref(dir_name);
     return;
   } else {
@@ -1295,12 +1295,9 @@ void w_root_set_warning(w_root_t *root, w_string_t *str) {
   }
 }
 
-void set_poison_state(w_root_t *root, w_string_t *dir,
-    struct timeval now, const char *syscall, int err, const char *reason)
-{
+void set_poison_state(w_string_t *dir, struct timeval now,
+                      const char *syscall, int err, const char *reason) {
   char *why = NULL;
-
-  unused_parameter(root);
 
   if (poisoned_reason) {
     return;

--- a/root.c
+++ b/root.c
@@ -299,107 +299,104 @@ static w_root_t *w_root_new(const char *path, char **errmsg)
   return root;
 }
 
-void w_root_lock(struct unlocked_watchman_root *unlocked, const char *purpose,
-                 struct write_locked_watchman_root *lock) {
-  int err;
-
-  if (!unlocked || !unlocked->root) {
-    w_log(W_LOG_FATAL, "vacated or already locked root passed to w_root_lock "
-                       "with purpose %s\n",
-          purpose);
+#define define_lock_funcs(lock_type, locker, do_lock, timedlocker,             \
+                          do_timed_lock, do_try_lock, unlocker)                \
+  void locker(struct unlocked_watchman_root *unlocked, const char *purpose,    \
+              lock_type *lock) {                                               \
+    int err;                                                                   \
+    if (!unlocked || !unlocked->root) {                                        \
+      w_log(W_LOG_FATAL,                                                       \
+            "vacated or already locked root passed to " #locker "with "        \
+            "purpose "                                                         \
+            "%s\n",                                                            \
+            purpose);                                                          \
+    }                                                                          \
+    err = do_lock(&unlocked->root->lock);                                      \
+    if (err != 0) {                                                            \
+      w_log(W_LOG_FATAL, "lock (%s) [%.*s]: %s\n", purpose,                    \
+            unlocked->root->root_path->len, unlocked->root->root_path->buf,    \
+            strerror(err));                                                    \
+    }                                                                          \
+    unlocked->root->lock_reason = purpose;                                     \
+    /* We've logically moved the callers root into the lock holder */          \
+    lock->root = unlocked->root;                                               \
+    unlocked->root = NULL;                                                     \
+  }                                                                            \
+  bool timedlocker(struct unlocked_watchman_root *unlocked,                    \
+                   const char *purpose, int timeoutms, lock_type *lock) {      \
+    struct timespec ts;                                                        \
+    struct timeval delta, now, target;                                         \
+    int err;                                                                   \
+    if (!unlocked || !unlocked->root) {                                        \
+      w_log(W_LOG_FATAL, "vacated or already locked root passed "              \
+                         "to " #timedlocker "with purpose %s\n",               \
+            purpose);                                                          \
+    }                                                                          \
+    if (timeoutms <= 0) {                                                      \
+      /* Special case an immediate check, because the implementation of */     \
+      /* pthread_mutex_timedlock may return immediately if we are already */   \
+      /* past-due. */                                                          \
+      err = do_try_lock(&unlocked->root->lock);                                \
+    } else {                                                                   \
+      /* Add timeout to current time, convert to absolute timespec */          \
+      gettimeofday(&now, NULL);                                                \
+      delta.tv_sec = timeoutms / 1000;                                         \
+      delta.tv_usec = (timeoutms - (delta.tv_sec * 1000)) * 1000;              \
+      w_timeval_add(now, delta, &target);                                      \
+      w_timeval_to_timespec(target, &ts);                                      \
+      err = do_timed_lock(&unlocked->root->lock, &ts);                         \
+    }                                                                          \
+    if (err == ETIMEDOUT || err == EBUSY) {                                    \
+      w_log(W_LOG_ERR,                                                         \
+            "lock (%s) [%.*s] failed after %dms, current lock purpose: %s\n",  \
+            purpose, unlocked->root->root_path->len,                           \
+            unlocked->root->root_path->buf, timeoutms,                         \
+            unlocked->root->lock_reason);                                      \
+      errno = ETIMEDOUT;                                                       \
+      return false;                                                            \
+    }                                                                          \
+    if (err != 0) {                                                            \
+      w_log(W_LOG_FATAL, "lock (%s) [%.*s]: %s\n", purpose,                    \
+            unlocked->root->root_path->len, unlocked->root->root_path->buf,    \
+            strerror(err));                                                    \
+    }                                                                          \
+    unlocked->root->lock_reason = purpose;                                     \
+    /* We've logically moved the callers root into the lock holder */          \
+    lock->root = unlocked->root;                                               \
+    unlocked->root = NULL;                                                     \
+    return true;                                                               \
+  }                                                                            \
+  void unlocker(lock_type *lock, struct unlocked_watchman_root *unlocked) {    \
+    int err;                                                                   \
+    /* we need a non-const root local for the read lock case */                \
+    w_root_t *root = (w_root_t *)lock->root;                                   \
+    if (!root) {                                                               \
+      w_log(W_LOG_FATAL, "vacated or already unlocked!\n");                    \
+    }                                                                          \
+    if (unlocked->root) {                                                      \
+      w_log(W_LOG_FATAL, "destination of unlock already holds a root!?\n");    \
+    }                                                                          \
+    root->lock_reason = NULL;                                                  \
+    err = pthread_rwlock_unlock(&root->lock);                                  \
+    if (err != 0) {                                                            \
+      w_log(W_LOG_FATAL, "lock: [%.*s] %s\n", lock->root->root_path->len,      \
+            lock->root->root_path->buf, strerror(err));                        \
+    }                                                                          \
+    unlocked->root = root;                                                     \
+    lock->root = NULL;                                                         \
   }
 
-  err = pthread_rwlock_wrlock(&unlocked->root->lock);
-  if (err != 0) {
-    w_log(W_LOG_FATAL, "lock (%s) [%.*s]: %s\n",
-        purpose,
-        unlocked->root->root_path->len,
-        unlocked->root->root_path->buf,
-        strerror(err)
-    );
-  }
-  unlocked->root->lock_reason = purpose;
+define_lock_funcs(struct write_locked_watchman_root,
+    w_root_lock, pthread_rwlock_wrlock,
+    w_root_lock_with_timeout, pthread_rwlock_timedwrlock,
+    pthread_rwlock_trywrlock,
+    w_root_unlock)
 
-  // We've logically moved the callers root into the lock holder
-  lock->root = unlocked->root;
-  unlocked->root = NULL;
-}
-
-bool w_root_lock_with_timeout(struct unlocked_watchman_root *unlocked,
-                              const char *purpose, int timeoutms,
-                              struct write_locked_watchman_root *lock) {
-  struct timespec ts;
-  struct timeval delta, now, target;
-  int err;
-
-  if (!unlocked || !unlocked->root) {
-    w_log(W_LOG_FATAL, "vacated or already locked root passed to w_root_lock "
-                       "with purpose %s\n",
-          purpose);
-  }
-
-
-  if (timeoutms <= 0) {
-    // Special case an immediate check, because the implementation of
-    // pthread_mutex_timedlock may return immediately if we are already
-    // past-due.
-    err = pthread_rwlock_trywrlock(&unlocked->root->lock);
-  } else {
-    // Add timeout to current time, convert to absolute timespec
-    gettimeofday(&now, NULL);
-    delta.tv_sec = timeoutms / 1000;
-    delta.tv_usec = (timeoutms - (delta.tv_sec * 1000)) * 1000;
-    w_timeval_add(now, delta, &target);
-    w_timeval_to_timespec(target, &ts);
-
-    err = pthread_rwlock_timedwrlock(&unlocked->root->lock, &ts);
-  }
-  if (err == ETIMEDOUT || err == EBUSY) {
-    w_log(W_LOG_ERR,
-          "lock (%s) [%.*s] failed after %dms, current lock purpose: %s\n",
-          purpose, unlocked->root->root_path->len,
-          unlocked->root->root_path->buf, timeoutms,
-          unlocked->root->lock_reason);
-    errno = ETIMEDOUT;
-    return false;
-  }
-  if (err != 0) {
-    w_log(W_LOG_FATAL, "lock (%s) [%.*s]: %s\n",
-        purpose,
-        unlocked->root->root_path->len,
-        unlocked->root->root_path->buf,
-        strerror(err)
-    );
-  }
-  unlocked->root->lock_reason = purpose;
-
-  // We've logically moved the callers root into the lock holder
-  lock->root = unlocked->root;
-  unlocked->root = NULL;
-  return true;
-}
-
-void w_root_unlock(struct write_locked_watchman_root *lock,
-                   struct unlocked_watchman_root *unlocked) {
-  int err;
-
-  if (unlocked->root) {
-    w_log(W_LOG_FATAL, "destination of unlock already holds a root!?\n");
-  }
-
-  lock->root->lock_reason = NULL;
-  err = pthread_rwlock_unlock(&lock->root->lock);
-  if (err != 0) {
-    w_log(W_LOG_FATAL, "lock: [%.*s] %s\n",
-        lock->root->root_path->len,
-        lock->root->root_path->buf,
-        strerror(err)
-    );
-  }
-
-  unlocked->root = lock->root;
-  lock->root = NULL;
-}
+define_lock_funcs(struct read_locked_watchman_root,
+    w_root_read_lock, pthread_rwlock_rdlock,
+    w_root_read_lock_with_timeout, pthread_rwlock_timedrdlock,
+    pthread_rwlock_tryrdlock,
+    w_root_read_unlock)
 
 /* Ensure that we're synchronized with the state of the
  * filesystem at the current time.

--- a/spawn.c
+++ b/spawn.c
@@ -417,7 +417,7 @@ static void spawn_command(w_root_t *root,
 }
 
 static bool trigger_generator(w_query *query,
-                              struct write_locked_watchman_root *lock,
+                              struct read_locked_watchman_root *lock,
                               struct w_query_ctx *ctx, void *gendata,
                               int64_t *num_walked) {
   struct watchman_file *f;

--- a/spawn.c
+++ b/spawn.c
@@ -416,13 +416,10 @@ static void spawn_command(w_root_t *root,
   }
 }
 
-static bool trigger_generator(
-    w_query *query,
-    w_root_t *root,
-    struct w_query_ctx *ctx,
-    void *gendata,
-    int64_t *num_walked)
-{
+static bool trigger_generator(w_query *query,
+                              struct write_locked_watchman_root *lock,
+                              struct w_query_ctx *ctx, void *gendata,
+                              int64_t *num_walked) {
   struct watchman_file *f;
   struct watchman_trigger_command *cmd = gendata;
   int64_t n = 0;
@@ -432,7 +429,7 @@ static bool trigger_generator(
       cmd->triggername->buf, cmd);
 
   // Walk back in time until we hit the boundary
-  for (f = root->latest_file; f; f = f->next) {
+  for (f = lock->root->latest_file; f; f = f->next) {
     ++n;
     if (ctx->since.is_timestamp && f->otime.timestamp < ctx->since.timestamp) {
       break;

--- a/tests/ignore_test.c
+++ b/tests/ignore_test.c
@@ -42,7 +42,7 @@ struct test_case {
 
 void run_correctness_test(struct watchman_ignore *state,
                           const struct test_case *tests, uint32_t num_tests,
-                          bool (*checker)(struct watchman_ignore *,
+                          bool (*checker)(const struct watchman_ignore *,
                                           const char *, uint32_t)) {
 
   uint32_t i;
@@ -136,7 +136,7 @@ w_string_t** build_list_with_prefix(const char *prefix, size_t limit) {
 static const size_t kWordLimit = 230000;
 
 void bench_list(const char *label, const char *prefix,
-                bool (*checker)(struct watchman_ignore *, const char *,
+                bool (*checker)(const struct watchman_ignore *, const char *,
                                 uint32_t)) {
 
   struct watchman_ignore state;

--- a/timedlock.c
+++ b/timedlock.c
@@ -4,36 +4,39 @@
 #include "watchman.h"
 
 #ifdef __APPLE__
-// We get to emulate this function because Darwin doesn't implement it
+// We get to emulate these functions because Darwin doesn't implement them
 
-int pthread_mutex_timedlock(pthread_mutex_t *m,
-                            const struct timespec *deadline_ts) {
-  int result;
-  struct timeval now, deadline;
-  int usec = 1;
-
-  w_timespec_to_timeval(*deadline_ts, &deadline);
-
-  while (true) {
-    gettimeofday(&now, NULL);
-    if (w_timeval_compare(now, deadline) >= 0) {
-      return ETIMEDOUT;
-    }
-
-    result = pthread_mutex_trylock(m);
-    if (result != EBUSY) {
-      return result;
-    }
-
-    // Exponential backoff on the sleep period
-    usec = MIN(usec * 2, 1024);
-    if (now.tv_sec == deadline.tv_sec) {
-      // Cap the sleep if we are close to the deadline
-      usec = MIN(usec, deadline.tv_usec - now.tv_usec);
-    }
-    usleep(usec);
+#define timed_helper(func_name, object_type, try_func)                         \
+  int func_name(object_type *lock, const struct timespec *deadline_ts) {       \
+    int result;                                                                \
+    struct timeval now, deadline;                                              \
+    int usec = 1;                                                              \
+    w_timespec_to_timeval(*deadline_ts, &deadline);                            \
+    while (true) {                                                             \
+      gettimeofday(&now, NULL);                                                \
+      if (w_timeval_compare(now, deadline) >= 0) {                             \
+        return ETIMEDOUT;                                                      \
+      }                                                                        \
+      result = try_func(lock);                                                 \
+      if (result != EBUSY) {                                                   \
+        return result;                                                         \
+      }                                                                        \
+      /* Exponential backoff on the sleep period */                            \
+      usec = MIN(usec * 2, 1024);                                              \
+      if (now.tv_sec == deadline.tv_sec) {                                     \
+        /* Cap the sleep if we are close to the deadline */                    \
+        usec = MIN(usec, deadline.tv_usec - now.tv_usec);                      \
+      }                                                                        \
+      usleep(usec);                                                            \
+    }                                                                          \
   }
-}
+
+timed_helper(pthread_mutex_timedlock, pthread_mutex_t, pthread_mutex_trylock)
+timed_helper(pthread_rwlock_timedwrlock, pthread_rwlock_t,
+             pthread_rwlock_trywrlock)
+timed_helper(pthread_rwlock_timedrdlock, pthread_rwlock_t,
+             pthread_rwlock_tryrdlock)
+
 #endif
 
 /* vim:ts=2:sw=2:et:

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -192,7 +192,7 @@ propagate:
       len--;
     }
 
-    if (w_is_ignored(root, path, len)) {
+    if (w_ignore_check(&root->ignore, path, len)) {
       continue;
     }
 

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -767,11 +767,11 @@ static void cmd_debug_fsevents_inject_drop(struct watchman_client *client,
     return;
   }
 
-  w_root_lock(&unlocked.root, "debug-fsevents-inject-drop", &lock);
+  w_root_lock(&unlocked, "debug-fsevents-inject-drop", &lock);
   state = lock.root->watch;
 
   if (!state->attempt_resync_on_user_drop) {
-    unlocked.root = w_root_unlock(&lock);
+    w_root_unlock(&lock, &unlocked);
     send_error_response(client, "fsevents_try_resync is not enabled");
     w_root_delref(unlocked.root);
     return;
@@ -782,7 +782,7 @@ static void cmd_debug_fsevents_inject_drop(struct watchman_client *client,
   state->stream->inject_drop = true;
   pthread_mutex_unlock(&state->fse_mtx);
 
-  unlocked.root = w_root_unlock(&lock);
+  w_root_unlock(&lock, &unlocked);
 
   resp = make_response();
   set_prop(resp, "last_good", json_integer(last_good));

--- a/watcher/fsevents.c
+++ b/watcher/fsevents.c
@@ -686,36 +686,40 @@ static bool fsevents_root_wait_notify(w_root_t *root, int timeoutms) {
   return state->fse_head ? true : false;
 }
 
-static bool fsevents_root_start_watch_file(w_root_t *root,
-    struct watchman_file *file) {
-  unused_parameter(root);
+static bool
+fsevents_root_start_watch_file(struct write_locked_watchman_root *lock,
+                               struct watchman_file *file) {
+  unused_parameter(lock);
   unused_parameter(file);
   return true;
 }
 
-static void fsevents_root_stop_watch_file(w_root_t *root,
-    struct watchman_file *file) {
-  unused_parameter(root);
+static void
+fsevents_root_stop_watch_file(struct write_locked_watchman_root *lock,
+                              struct watchman_file *file) {
+  unused_parameter(lock);
   unused_parameter(file);
 }
 
-static struct watchman_dir_handle *fsevents_root_start_watch_dir(
-      w_root_t *root, struct watchman_dir *dir, struct timeval now,
-      const char *path) {
+static struct watchman_dir_handle *
+fsevents_root_start_watch_dir(struct write_locked_watchman_root *lock,
+                              struct watchman_dir *dir, struct timeval now,
+                              const char *path) {
   struct watchman_dir_handle *osdir;
 
   osdir = w_dir_open(path);
   if (!osdir) {
-    handle_open_errno(root, dir, now, "opendir", errno, NULL);
+    handle_open_errno(lock, dir, now, "opendir", errno, NULL);
     return NULL;
   }
 
   return osdir;
 }
 
-static void fsevents_root_stop_watch_dir(w_root_t *root,
-    struct watchman_dir *dir) {
-  unused_parameter(root);
+static void
+fsevents_root_stop_watch_dir(struct write_locked_watchman_root *lock,
+                             struct watchman_dir *dir) {
+  unused_parameter(lock);
   unused_parameter(dir);
 }
 

--- a/watcher/helper.c
+++ b/watcher/helper.c
@@ -1,9 +1,0 @@
-/* Copyright 2012-present Facebook, Inc.
- * Licensed under the Apache License, Version 2.0 */
-
-#include "watchman.h"
-
-bool w_is_ignored(w_root_t *root, const char *path, uint32_t pathlen)
-{
-  return w_ignore_check(&root->ignore, path, pathlen);
-}

--- a/watcher/portfs.c
+++ b/watcher/portfs.c
@@ -164,9 +164,10 @@ out:
   return success;
 }
 
-static bool portfs_root_start_watch_file(w_root_t *root,
-    struct watchman_file *file) {
-  struct portfs_root_state *state = root->watch;
+static bool
+portfs_root_start_watch_file(struct write_locked_watchman_root *lock,
+                             struct watchman_file *file) {
+  struct portfs_root_state *state = lock->root->watch;
   w_string_t *name;
   bool success = false;
 
@@ -180,23 +181,24 @@ static bool portfs_root_start_watch_file(w_root_t *root,
   return success;
 }
 
-static void portfs_root_stop_watch_file(w_root_t *root,
-    struct watchman_file *file) {
-  unused_parameter(root);
+static void portfs_root_stop_watch_file(struct write_locked_watchman_root *lock,
+                                        struct watchman_file *file) {
+  unused_parameter(lock);
   unused_parameter(file);
 }
 
-static struct watchman_dir_handle *portfs_root_start_watch_dir(
-    w_root_t *root, struct watchman_dir *dir, struct timeval now,
-    const char *path) {
-  struct portfs_root_state *state = root->watch;
+static struct watchman_dir_handle *
+portfs_root_start_watch_dir(struct write_locked_watchman_root *lock,
+                            struct watchman_dir *dir, struct timeval now,
+                            const char *path) {
+  struct portfs_root_state *state = lock->root->watch;
   struct watchman_dir_handle *osdir;
   struct stat st;
   w_string_t *dir_name;
 
   osdir = w_dir_open(path);
   if (!osdir) {
-    handle_open_errno(root, dir, now, "opendir", errno, NULL);
+    handle_open_errno(lock, dir, now, "opendir", errno, NULL);
     return NULL;
   }
 
@@ -220,9 +222,9 @@ static struct watchman_dir_handle *portfs_root_start_watch_dir(
   return osdir;
 }
 
-static void portfs_root_stop_watch_dir(w_root_t *root,
-    struct watchman_dir *dir) {
-  unused_parameter(root);
+static void portfs_root_stop_watch_dir(struct write_locked_watchman_root *lock,
+                                       struct watchman_dir *dir) {
+  unused_parameter(lock);
   unused_parameter(dir);
 }
 

--- a/watcher/win32.c
+++ b/watcher/win32.c
@@ -221,7 +221,7 @@ static void *readchanges_thread(void *arg) {
           full = w_string_path_cat(root->root_path, name);
           w_string_delref(name);
 
-          if (w_is_ignored(root, full->buf, full->len)) {
+          if (w_ignore_check(&root->ignore, full->buf, full->len)) {
             w_string_delref(full);
           } else {
             item = calloc(1, sizeof(*item));

--- a/watchman.h
+++ b/watchman.h
@@ -449,7 +449,7 @@ struct watchman_root {
   bool case_sensitive;
 
   /* our locking granularity is per-root */
-  pthread_mutex_t lock;
+  pthread_rwlock_t lock;
   const char *lock_reason;
   pthread_t notify_thread;
   pthread_t io_thread;
@@ -1065,6 +1065,10 @@ void w_expand_flags(const struct flag_map *fmap, uint32_t flags,
 
 #ifdef __APPLE__
 int pthread_mutex_timedlock(pthread_mutex_t *m, const struct timespec *ts);
+int pthread_rwlock_timedwrlock(pthread_rwlock_t *restrict rwlock,
+                               const struct timespec *ts);
+int pthread_rwlock_timedrdlock(pthread_rwlock_t *restrict rwlock,
+                               const struct timespec *ts);
 #endif
 
 #ifdef __cplusplus

--- a/watchman.h
+++ b/watchman.h
@@ -657,8 +657,10 @@ void w_timeoutms_to_abs_timespec(int timeoutms, struct timespec *deadline);
 w_string_t *w_fstype(const char *path);
 
 void w_root_crawl_recursive(w_root_t *root, w_string_t *dir_name, time_t now);
-w_root_t *w_root_resolve(const char *path, bool auto_watch, char **errmsg);
-w_root_t *w_root_resolve_for_client_mode(const char *filename, char **errmsg);
+bool w_root_resolve(const char *path, bool auto_watch, char **errmsg,
+                    struct unlocked_watchman_root *unlocked);
+bool w_root_resolve_for_client_mode(const char *filename, char **errmsg,
+                                    struct unlocked_watchman_root *unlocked);
 char *w_find_enclosing_root(const char *filename, char **relpath);
 struct watchman_file *w_root_resolve_file(w_root_t *root,
     struct watchman_dir *dir, w_string_t *file_name,
@@ -693,12 +695,13 @@ void w_root_mark_file_changed(w_root_t *root, struct watchman_file *file,
 
 bool w_root_sync_to_now(struct unlocked_watchman_root *unlocked, int timeoutms);
 
-void w_root_lock(w_root_t **root, const char *purpose,
+void w_root_lock(struct unlocked_watchman_root *unlocked, const char *purpose,
                  struct write_locked_watchman_root *locked);
-bool w_root_lock_with_timeout(w_root_t **root, const char *purpose,
-                              int timeoutms,
+bool w_root_lock_with_timeout(struct unlocked_watchman_root *unlocked,
+                              const char *purpose, int timeoutms,
                               struct write_locked_watchman_root *locked);
-w_root_t *w_root_unlock(struct write_locked_watchman_root *locked);
+void w_root_unlock(struct write_locked_watchman_root *locked,
+                   struct unlocked_watchman_root *unlocked);
 
 /* Bob Jenkins' lookup3.c hash function */
 uint32_t w_hash_bytes(const void *key, size_t length, uint32_t initval);

--- a/watchman.h
+++ b/watchman.h
@@ -948,9 +948,12 @@ void print_command_list_for_help(FILE *where);
 
 struct w_clockspec *w_clockspec_new_clock(uint32_t root_number, uint32_t ticks);
 struct w_clockspec *w_clockspec_parse(json_t *value);
-void w_clockspec_eval(w_root_t *root,
-    const struct w_clockspec *spec,
-    struct w_query_since *since);
+void w_clockspec_eval(struct write_locked_watchman_root *lock,
+                      const struct w_clockspec *spec,
+                      struct w_query_since *since);
+void w_clockspec_eval_readonly(struct read_locked_watchman_root *lock,
+                               const struct w_clockspec *spec,
+                               struct w_query_since *since);
 void w_clockspec_free(struct w_clockspec *spec);
 void w_clockspec_init(void);
 

--- a/watchman.h
+++ b/watchman.h
@@ -711,6 +711,15 @@ bool w_root_lock_with_timeout(struct unlocked_watchman_root *unlocked,
 void w_root_unlock(struct write_locked_watchman_root *locked,
                    struct unlocked_watchman_root *unlocked);
 
+void w_root_read_lock(struct unlocked_watchman_root *unlocked,
+                      const char *purpose,
+                      struct read_locked_watchman_root *locked);
+bool w_root_read_lock_with_timeout(struct unlocked_watchman_root *unlocked,
+                                   const char *purpose, int timeoutms,
+                                   struct read_locked_watchman_root *locked);
+void w_root_read_unlock(struct read_locked_watchman_root *locked,
+                        struct unlocked_watchman_root *unlocked);
+
 /* Bob Jenkins' lookup3.c hash function */
 uint32_t w_hash_bytes(const void *key, size_t length, uint32_t initval);
 

--- a/watchman.h
+++ b/watchman.h
@@ -711,6 +711,9 @@ void w_root_set_warning(w_root_t *root, w_string_t *str);
 
 struct watchman_dir *w_root_resolve_dir(struct write_locked_watchman_root *lock,
                                         w_string_t *dir_name, bool create);
+struct watchman_dir *
+w_root_resolve_dir_read(struct read_locked_watchman_root *lock,
+                        w_string_t *dir_name);
 void w_root_process_path(struct write_locked_watchman_root *root,
     struct watchman_pending_collection *coll, w_string_t *full_path,
     struct timeval now, int flags,

--- a/watchman.h
+++ b/watchman.h
@@ -706,7 +706,8 @@ void w_root_mark_deleted(struct write_locked_watchman_root *lock,
 void w_root_reap(void);
 void w_root_delref(w_root_t *root);
 void w_root_addref(w_root_t *root);
-void w_root_set_warning(w_root_t *root, w_string_t *str);
+void w_root_set_warning(struct write_locked_watchman_root *lock,
+                        w_string_t *str);
 
 struct watchman_dir *w_root_resolve_dir(struct write_locked_watchman_root *lock,
                                         w_string_t *dir_name, bool create);
@@ -898,7 +899,7 @@ void w_state_save(void);
 bool w_state_load(void);
 bool w_root_save_state(json_t *state);
 bool w_root_load_state(json_t *state);
-json_t *w_root_trigger_list_to_json(w_root_t *root);
+json_t *w_root_trigger_list_to_json(struct read_locked_watchman_root *lock);
 json_t *w_root_watch_list_to_json(void);
 
 #ifdef __APPLE__

--- a/watchman.h
+++ b/watchman.h
@@ -425,6 +425,7 @@ static inline w_string_t *w_file_get_name(struct watchman_file *file) {
 #define WATCHMAN_COOKIE_PREFIX ".watchman-cookie-"
 struct watchman_query_cookie {
   pthread_cond_t cond;
+  pthread_mutex_t lock;
   bool seen;
 };
 

--- a/watchman.h
+++ b/watchman.h
@@ -540,6 +540,27 @@ struct read_locked_watchman_root {
   const w_root_t *root;
 };
 
+/** Massage a write lock into a read lock.
+ * This is suitable for passing a write lock to functions that want a
+ * read lock.  It works by simply casting the address of the write lock
+ * pointer to a read lock pointer.  Casting in this direction is fine,
+ * but not casting in the opposite direction.
+ * This is safe for a couple of reasons:
+ *
+ *  1. The read and write lock holders are binary compatible with each
+ *     other; they both simply hold a root pointer.
+ *  2. The underlying unlock function pthread_rwlock_unlock works regardless
+ *     of the read-ness or write-ness of the lock, even though we have
+ *     a separate read and write unlock functions.
+ *  3. We're careful to pass a pointer to the existing lock instance
+ *     around rather than copying it around; that way don't lose track of
+ *     the fact that we unlocked the root.
+ */
+static inline struct read_locked_watchman_root *
+w_root_read_lock_from_write(struct write_locked_watchman_root *lock) {
+  return (struct read_locked_watchman_root*)lock;
+}
+
 struct unlocked_watchman_root {
   w_root_t *root;
 };

--- a/watchman.h
+++ b/watchman.h
@@ -678,7 +678,6 @@ extern pthread_t reaper_thread;
 
 void w_request_shutdown(void);
 
-bool w_is_ignored(w_root_t *root, const char *path, uint32_t pathlen);
 void w_timeoutms_to_abs_timespec(int timeoutms, struct timespec *deadline);
 
 // Returns the name of the filesystem for the specified path

--- a/watchman.h
+++ b/watchman.h
@@ -530,6 +530,10 @@ struct write_locked_watchman_root {
 };
 
 struct read_locked_watchman_root {
+  const w_root_t *root;
+};
+
+struct unlocked_watchman_root {
   w_root_t *root;
 };
 
@@ -687,7 +691,7 @@ bool w_root_process_pending(struct write_locked_watchman_root *lock,
 void w_root_mark_file_changed(w_root_t *root, struct watchman_file *file,
     struct timeval now);
 
-bool w_root_sync_to_now(w_root_t *root, int timeoutms);
+bool w_root_sync_to_now(struct unlocked_watchman_root *unlocked, int timeoutms);
 
 void w_root_lock(w_root_t **root, const char *purpose,
                  struct write_locked_watchman_root *locked);
@@ -742,7 +746,7 @@ struct w_query_since {
 void w_run_subscription_rules(
     struct watchman_user_client *client,
     struct watchman_client_subscription *sub,
-    w_root_t *root);
+    struct write_locked_watchman_root *lock);
 void w_cancel_subscriptions_for_root(w_root_t *root);
 
 void w_match_results_free(uint32_t num_matches,
@@ -1014,7 +1018,8 @@ struct watchman_trigger_command {
 };
 
 void w_trigger_command_free(struct watchman_trigger_command *cmd);
-void w_assess_trigger(w_root_t *root, struct watchman_trigger_command *cmd);
+void w_assess_trigger(struct write_locked_watchman_root *lock,
+                      struct watchman_trigger_command *cmd);
 struct watchman_trigger_command *w_build_trigger_from_def(
   w_root_t *root, json_t *trig, char **errmsg);
 

--- a/watchman.h
+++ b/watchman.h
@@ -791,7 +791,7 @@ void w_run_subscription_rules(
     struct watchman_user_client *client,
     struct watchman_client_subscription *sub,
     struct write_locked_watchman_root *lock);
-void w_cancel_subscriptions_for_root(w_root_t *root);
+void w_cancel_subscriptions_for_root(const w_root_t *root);
 
 void w_match_results_free(uint32_t num_matches,
     struct watchman_rule_match *matches);
@@ -1013,14 +1013,14 @@ static inline void set_mixed_string_prop(json_t *obj, const char *key,
 void cfg_shutdown(void);
 void cfg_set_arg(const char *name, json_t *val);
 void cfg_load_global_config_file(void);
-json_t *cfg_get_json(w_root_t *root, const char *name);
-const char *cfg_get_string(w_root_t *root, const char *name,
+json_t *cfg_get_json(const w_root_t *root, const char *name);
+const char *cfg_get_string(const w_root_t *root, const char *name,
     const char *defval);
-json_int_t cfg_get_int(w_root_t *root, const char *name,
+json_int_t cfg_get_int(const w_root_t *root, const char *name,
     json_int_t defval);
-bool cfg_get_bool(w_root_t *root, const char *name, bool defval);
-double cfg_get_double(w_root_t *root, const char *name, double defval);
-mode_t cfg_get_perms(w_root_t *root, const char *name, bool write_bits,
+bool cfg_get_bool(const w_root_t *root, const char *name, bool defval);
+double cfg_get_double(const w_root_t *root, const char *name, double defval);
+mode_t cfg_get_perms(const w_root_t *root, const char *name, bool write_bits,
                      bool execute_bits);
 const char *cfg_get_trouble_url(void);
 json_t *cfg_compute_root_files(bool *enforcing);
@@ -1068,11 +1068,10 @@ void w_trigger_command_free(struct watchman_trigger_command *cmd);
 void w_assess_trigger(struct write_locked_watchman_root *lock,
                       struct watchman_trigger_command *cmd);
 struct watchman_trigger_command *w_build_trigger_from_def(
-  w_root_t *root, json_t *trig, char **errmsg);
+  const w_root_t *root, json_t *trig, char **errmsg);
 
-void set_poison_state(w_root_t *root, w_string_t *dir,
-    struct timeval now, const char *syscall, int err,
-    const char *reason);
+void set_poison_state(w_string_t *dir, struct timeval now, const char *syscall,
+                      int err, const char *reason);
 
 void watchman_watcher_init(void);
 void handle_open_errno(struct write_locked_watchman_root *lock,

--- a/watchman_cmd.h
+++ b/watchman_cmd.h
@@ -69,11 +69,9 @@ void send_and_dispose_response(struct watchman_client *client,
 bool enqueue_response(struct watchman_client *client,
     json_t *json, bool ping);
 
-w_root_t *resolve_root_or_err(
-    struct watchman_client *client,
-    json_t *args,
-    int root_index,
-    bool create);
+bool resolve_root_or_err(struct watchman_client *client, json_t *args,
+                         int root_index, bool create,
+                         struct unlocked_watchman_root *unlocked);
 
 json_t *make_response(void);
 void annotate_with_clock(w_root_t *root, json_t *resp);

--- a/watchman_cmd.h
+++ b/watchman_cmd.h
@@ -74,8 +74,9 @@ bool resolve_root_or_err(struct watchman_client *client, json_t *args,
                          struct unlocked_watchman_root *unlocked);
 
 json_t *make_response(void);
-void annotate_with_clock(w_root_t *root, json_t *resp);
-void add_root_warnings_to_response(json_t *response, w_root_t *root);
+void annotate_with_clock(struct read_locked_watchman_root *lock, json_t *resp);
+void add_root_warnings_to_response(json_t *response,
+                                   struct read_locked_watchman_root *lock);
 
 bool clock_id_string(uint32_t root_number, uint32_t ticks, char *buf,
     size_t bufsize);

--- a/watchman_ignore.h
+++ b/watchman_ignore.h
@@ -36,7 +36,7 @@ void w_ignore_addstr(struct watchman_ignore *ignore, w_string_t *path,
 
 // Tests whether path is ignored.
 // Returns true if the path is ignored, false otherwise.
-bool w_ignore_check(struct watchman_ignore *ignore, const char *path,
+bool w_ignore_check(const struct watchman_ignore *ignore, const char *path,
                     uint32_t pathlen);
 
 // Releases ignore state

--- a/watchman_perf.h
+++ b/watchman_perf.h
@@ -61,7 +61,7 @@ bool w_perf_finish(w_perf_t *perf);
 void w_perf_add_meta(w_perf_t *perf, const char *key, json_t *val);
 
 // Annotate the sample with some standard metadata taken from a root.
-void w_perf_add_root_meta(w_perf_t *perf, w_root_t *root);
+void w_perf_add_root_meta(w_perf_t *perf, const w_root_t *root);
 
 // Force the sample to go to the log
 void w_perf_force_log(w_perf_t *perf);

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -17,7 +17,7 @@ typedef struct w_query_expr w_query_expr;
 // Holds state for the execution of a query
 struct w_query_ctx {
   struct w_query *query;
-  w_root_t *root;
+  struct read_locked_watchman_root *lock;
   struct watchman_file *file;
   w_string_t *wholename;
   struct w_query_since since;

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -121,13 +121,10 @@ bool w_query_process_file(
 
 // Generator callback, used to plug in an alternate
 // generator when used in triggers or subscriptions
-typedef bool (*w_query_generator)(
-    w_query *query,
-    w_root_t *root,
-    struct w_query_ctx *ctx,
-    void *gendata,
-    int64_t *num_walked
-);
+typedef bool (*w_query_generator)(w_query *query,
+                                  struct write_locked_watchman_root *lock,
+                                  struct w_query_ctx *ctx, void *gendata,
+                                  int64_t *num_walked);
 
 struct w_query_result {
   bool is_fresh_instance;

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -122,7 +122,7 @@ bool w_query_process_file(
 // Generator callback, used to plug in an alternate
 // generator when used in triggers or subscriptions
 typedef bool (*w_query_generator)(w_query *query,
-                                  struct write_locked_watchman_root *lock,
+                                  struct read_locked_watchman_root *lock,
                                   struct w_query_ctx *ctx, void *gendata,
                                   int64_t *num_walked);
 

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -143,7 +143,15 @@ void w_query_result_free(w_query_res *res);
 
 bool w_query_execute(
     w_query *query,
-    w_root_t *root,
+    struct unlocked_watchman_root *unlocked,
+    w_query_res *results,
+    w_query_generator generator,
+    void *gendata
+);
+
+bool w_query_execute_locked(
+    w_query *query,
+    struct write_locked_watchman_root *lock,
     w_query_res *results,
     w_query_generator generator,
     void *gendata

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -95,7 +95,7 @@ bool w_query_register_expression_parser(
     const char *term,
     w_query_expr_parser parser);
 
-w_query *w_query_parse(w_root_t *root, json_t *query, char **errmsg);
+w_query *w_query_parse(const w_root_t *root, json_t *query, char **errmsg);
 void w_query_delref(w_query *query);
 
 w_query_expr *w_query_expr_parse(w_query *query, json_t *term);
@@ -174,7 +174,7 @@ struct w_query_field_list {
 };
 
 // parse the old style since and find queries
-w_query *w_query_parse_legacy(w_root_t *root, json_t *args, char **errmsg,
+w_query *w_query_parse_legacy(const w_root_t *root, json_t *args, char **errmsg,
     int start, uint32_t *next_arg, const char *clockspec, json_t **expr_p);
 bool w_query_legacy_field_list(struct w_query_field_list *flist);
 

--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -83,7 +83,6 @@ SRCS=\
 	query\empty.c      \
 	watcher\auto.c \
 	watcher\win32.c \
-	watcher\helper.c \
 	listener.c   \
 	listener-user.c   \
 	clientmode.c \
@@ -218,7 +217,6 @@ tests\art.exe: tests\art_test.obj $(TEST_OBJS) \
 	$(LINKER) $** $(LIBS)
 
 tests\ignore.exe: tests\ignore_test.obj $(TEST_OBJS) \
-		watcher\helper.obj \
 		hash.obj \
 		ht.obj \
 		ignore.obj \
@@ -230,7 +228,6 @@ tests\ignore.exe: tests\ignore_test.obj $(TEST_OBJS) \
 	$(LINKER) $** $(LIBS)
 
 tests\pending.exe: tests\pending_test.obj $(TEST_OBJS) \
-		watcher\helper.obj \
 		hash.obj \
 		ht.obj \
 		ignore.obj \


### PR DESCRIPTION
This is a series of diffs that cut us over to a reader/writer lock around the w_root_t internals.  The intention is to reduce contention in some busy query scenarios, with an eye on Bucks glob queries in particular, and around some interactions between the Mercurial fsmonitor extension and Nuclide.

Note that since queries that use named cursors still execute under a write lock, as we need to update the state of the named cursor as part of evaluating the query.  Buck uses named cursors to track the clock for its main file cache invalidation checks.  I'm not sure how big a deal this is in practice, but it may be worth experimenting with changing buck to not use a named cursor and see if that makes a difference.

This is just the first pass; I'm sure I'll need to tweak this for windows and linux builds as the CI errors out.

At a high level the approach taken here is:

1. Introduce three new types:
 * `write_locked_watchman_root` holds a write-locked root reference
 * `read_locked_watchman_root` holds a read-locked root reference
 * `unlocked_watchman_root` holds an unlocked root reference
2. Adjust various function parameters to accept the required type of root reference.  This allows the compiler to error at compile time if an inappropriately locked reference is passed to the wrong place.
3. Introduced locked/unlocked and/or read/write locked variants of a couple of functions based on the compiler errors from the above.  This allows removing the recursive component of the root lock.
4. Change the cookie condition variable to use a mutex in the cookie itself, rather than in the root.  We didn't actually need to lock the root as part of waking up from a cookie notification, and this allows us to change the type of the root lock to a reader/writer lock.

