### PR TITLE
perf: capture the slow query in the query perf sample

### DIFF
--- a/log.c
+++ b/log.c
@@ -144,7 +144,7 @@ const char *w_set_thread_name(const char *fmt, ...) {
 
 void w_log(int level, WATCHMAN_FMT_STRING(const char *fmt), ...)
 {
-  char buf[4096];
+  char buf[4096*4];
   va_list ap;
   int len, len2;
   bool fatal = false;

--- a/query/eval.c
+++ b/query/eval.c
@@ -503,10 +503,11 @@ bool w_query_execute(
   if (w_perf_finish(&sample)) {
     w_perf_add_root_meta(&sample, root);
     w_perf_add_meta(&sample, "query_execute",
-                    json_pack("{s:b, s:i, s:i}",                        //
+                    json_pack("{s:b, s:i, s:i, s:O}",                   //
                               "fresh_instance", res->is_fresh_instance, //
                               "num_results", ctx.num_results,           //
-                              "num_walked", num_walked                  //
+                              "num_walked", num_walked,                 //
+                              "query", ctx.query->query_spec           //
                               ));
     w_perf_log(&sample);
   }

--- a/query/parse.c
+++ b/query/parse.c
@@ -342,6 +342,9 @@ w_query *w_query_parse(w_root_t *root, json_t *query, char **errmsg)
     goto error;
   }
 
+  res->query_spec = query;
+  json_incref(res->query_spec);
+
   return res;
 error:
   if (res) {
@@ -548,6 +551,10 @@ void w_query_delref(w_query *query)
       }
     }
     free(query->suffixes);
+  }
+
+  if (query->query_spec) {
+    json_decref(query->query_spec);
   }
 
   free(query);

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -77,6 +77,9 @@ struct w_query {
 
   // Error message placeholder while parsing
   char *errmsg;
+
+  // The query that we parsed into this struct
+  json_t *query_spec;
 };
 
 typedef w_query_expr *(*w_query_expr_parser)(


### PR DESCRIPTION
I thought we were already doing this, but apparently not.
This captures a reference to the incoming query so that we can send it
out along with the perf sample if that query proves to be a slow query.

To accomodate some of the queries produced by buck and logged to the log
file, we need to increase the size of the stack buffer that we use to
log a line.