### PR TITLE
Add a cache for the parent path in the query context

### DIFF
--- a/watchman_query.h
+++ b/watchman_query.h
@@ -25,6 +25,10 @@ struct w_query_ctx {
   struct watchman_rule_match *results;
   uint32_t num_results;
   uint32_t num_allocd;
+
+  // Cache for dir name lookups when computing wholename
+  struct watchman_dir *last_parent;
+  w_string_t *last_parent_path;
 };
 
 struct w_query_path {


### PR DESCRIPTION
A recent change made it O(depth-of-tree) to compute the wholename.
We already cache the wholename in the query executor, but there are
some operations where we are also interested in the name of the
parent of a file node.

This diff adds a simple cache for the most recently looked up file
parent and its full name string.