### PR TITLE
avoid crash if we sample a root concurrently with a recrawl

### DIFF
--- a/perf.c
+++ b/perf.c
@@ -99,15 +99,24 @@ void w_perf_add_root_meta(w_perf_t *perf, w_root_t *root) {
 
   // The funky comments at the end of the line force clang-format to keep the
   // elements on lines of their own
-  w_perf_add_meta(perf, "root",
-                  json_pack("{s:o, s:i, s:i, s:i, s:b, s:u}",          //
-                            "path", w_string_to_json(root->root_path), //
-                            "recrawl_count", root->recrawl_count,      //
-                            "number", root->number,                    //
-                            "ticks", root->ticks,                      //
-                            "case_sensitive", root->case_sensitive,    //
-                            "watcher", root->watcher_ops->name         //
-                            ));
+  w_perf_add_meta(
+      perf, "root",
+      json_pack(
+          "{s:o, s:i, s:i, s:i, s:b, s:u}",          //
+          "path", w_string_to_json(root->root_path), //
+          "recrawl_count", root->recrawl_count,      //
+          "number", root->number,                    //
+          "ticks", root->ticks,                      //
+          "case_sensitive", root->case_sensitive,    //
+          // there is potential to race with a concurrent w_root_init in some
+          // recrawl scenarios in the test harness.  In those cases it is
+          // possible that root->watcher_ops is briefly set to a NULL pointer.
+          // Since the target of that pointer is always a structure with a
+          // stable address, we can safely deal with reading a stale value, but
+          // we do need to guard against a NULL pointer value.
+          "watcher",
+          root->watcher_ops ? root->watcher_ops->name : "<recrawling>" //
+          ));
 }
 
 void w_perf_set_wall_time_thresh(w_perf_t *perf, double thresh) {


### PR DESCRIPTION
Since we call this function outside of a lock, there is a small window
of opportunity to read a NULL pointer for the watcher_ops member.