### PR TITLE
move state saving into its own thread

### DIFF
--- a/listener.c
+++ b/listener.c
@@ -756,6 +756,7 @@ bool w_start_listener(const char *path)
   }
 
   pthread_join(reaper_thread, &ignored);
+  w_state_shutdown();
   cfg_shutdown();
 
   return true;

--- a/watchman.h
+++ b/watchman.h
@@ -835,7 +835,8 @@ static inline double w_timeval_diff(struct timeval start, struct timeval end)
 extern const char *watchman_tmp_dir;
 extern char *watchman_state_file;
 extern int dont_save_state;
-bool w_state_save(void);
+void w_state_shutdown(void);
+void w_state_save(void);
 bool w_state_load(void);
 bool w_root_save_state(json_t *state);
 bool w_root_load_state(json_t *state);


### PR DESCRIPTION
There are a couple of code paths that are made tricky because they may
deadlock around saving the state information.

This removes the source of the trickiness by having a dedicated thread
for saving the state; whenever we need to save the state, we signal the
thread to wakeup and it can block and take its sweet time without fear
of impacting the other threads that have more important things to do.