### PR TITLE
Improve crawler reliability on windows

### DIFF
--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -237,6 +237,7 @@ tests\pending.exe: tests\pending_test.obj $(TEST_OBJS) \
 		cfg.obj \
 		time.obj \
 		string.obj \
+		stream_win.obj \
 		log.obj \
 		tests\log_stub.obj \
 		thirdparty\libart\src\art.obj \

--- a/winbuild/stat.c
+++ b/winbuild/stat.c
@@ -25,6 +25,27 @@ int mkdir(const char *path, int mode) {
   return -1;
 }
 
+/** Replace open with a version that enables all sharing flags.
+ * This minimizes the chances that we'll encounter a sharing violation
+ * while we try to examine a file. */
+int open_and_share(const char *path, int flags, ...) {
+  HANDLE h;
+  int fd;
+
+  h = w_handle_open(path, flags);
+  if (h == INVALID_HANDLE_VALUE) {
+    return -1;
+  }
+
+  fd = _open_osfhandle((intptr_t)h, flags);
+
+  if (fd == -1) {
+    CloseHandle(h);
+  }
+
+  return fd;
+}
+
 int lstat(const char *path, struct stat *st) {
   FILE_BASIC_INFO binfo;
   FILE_STANDARD_INFO sinfo;

--- a/winbuild/sys/stat.h
+++ b/winbuild/sys/stat.h
@@ -31,6 +31,8 @@ struct stat {
 
 int lstat(const char *path, struct stat *st);
 int mkdir(const char *path, int mode);
+int open_and_share(const char *path, int flags, ...);
+#define open open_and_share
 
 #define S_ISUID       0004000     ///< set user id on execution
 #define S_ISGID       0002000     ///< set group id on execution


### PR DESCRIPTION
Looking into the logs from a windows build test failure:

```
$ grep overhere inst_z1sqm/log | grep -i denied
2016-08-20T00:25:39,937: [io C:\Users\appveyor\AppData\Local\Temp\1\watchmantestofdjxy\test_find.TestFind.test_find.local.bser\tmpmv0btc] w_lstat(C:\Users\appveyor\AppData\Local\Temp\1\watchmantestofdjxy\test_find.TestFind.test_find.local.bser\tmpmv0btc\adir\overhere) file=0000000000000000 dir=0000000000000000 res=-1 Permission denied
```

I believe this is caused by our use of the mscrt `open` function, which doesn't
have a way to express FILE_SHARE_DELETE.

This diff is an attempt to deal with that by using our own implementation that
opens a handle and then wraps it in an mscrt file descriptor.