### PR TITLE
force launchd to unload plist

### DIFF
--- a/main.c
+++ b/main.c
@@ -440,6 +440,7 @@ static void spawn_via_launchd(void)
     char *unload_argv[MAX_DAEMON_ARGS] = {
       "/bin/launchctl",
       "unload",
+      "-F",
       NULL
     };
     append_argv(unload_argv, plist_path);


### PR DESCRIPTION
Summary: in https://github.com/facebook/watchman/issues/358 we ended up
in a state where the contents of the plist were correct but launchd
still thought that it should be monitoring the older 4.6 binary.

I don't know how we ended up in such a state, as we unload before we
write out the new plist.

My working theory is that the unload failed for some unknown reason but
we carried on anyway.

Also, this nugget from the man page:

> NOTE: Due to bugs in the previous implementation and long-standing
> client expectations around those bugs, the load and unload subcommands
> will only return a non-zero exit code due to improper usage.
> Otherwise, zero is always returned.

This is a speculative diff to add the `-F` force flag in.  I have no way
to prove whether this will solve this, only that it doesn't break
spawning watchman for me today.

Test Plan: with watchman not running and my plist referencing the
internal FB build of watchman, build and run watchman from the checkout
on my mac as `./watchman version`.  Inspect the plist and observe that
the executable path has changed from the installed location of the
binary to the path to my checkout and that we got a valid watchman
version response.