### PR TITLE
check for an invalid relative_root during globbing

### DIFF
--- a/query/eval.c
+++ b/query/eval.c
@@ -465,6 +465,7 @@ static bool execute_common(struct w_query_ctx *ctx, w_perf_t *sample,
                            w_query_res *res, w_query_generator generator,
                            void *gendata) {
   int64_t num_walked = 0;
+  bool result = true;
 
   if (ctx->query->dedup_results) {
     ctx->dedup = w_ht_new(64, &w_ht_string_funcs);
@@ -478,7 +479,11 @@ static bool execute_common(struct w_query_ctx *ctx, w_perf_t *sample,
       generator = default_generators;
     }
 
-    generator(ctx->query, ctx->lock, ctx, gendata, &num_walked);
+    if (!generator(ctx->query, ctx->lock, ctx, gendata, &num_walked)) {
+      res->errmsg = ctx->query->errmsg;
+      ctx->query->errmsg = NULL;
+      result = false;
+    }
   }
 
   if (w_perf_finish(sample)) {
@@ -507,7 +512,7 @@ static bool execute_common(struct w_query_ctx *ctx, w_perf_t *sample,
   res->results = ctx->results;
   res->num_results = ctx->num_results;
 
-  return true;
+  return result;
 }
 
 bool w_query_execute_locked(

--- a/query/glob.c
+++ b/query/glob.c
@@ -525,6 +525,13 @@ bool glob_generator(w_query *query, struct read_locked_watchman_root *lock,
     relative_root = lock->root->root_path;
   }
   dir = w_root_resolve_dir_read(lock, relative_root);
+  if (!dir) {
+    ignore_result(asprintf(&query->errmsg,
+                           "glob_generator could not resolve %.*s, check your "
+                           "relative_root parameter!\n",
+                           relative_root->len, relative_root->buf));
+    return false;
+  }
 
   return glob_generator_tree(ctx, num_walked, lock, query->glob_tree, dir);
 }

--- a/tests/integration/test_glob.py
+++ b/tests/integration/test_glob.py
@@ -12,6 +12,7 @@ import tempfile
 import os
 import os.path
 import shutil
+import pywatchman
 
 
 @WatchmanTestCase.expand_matrix
@@ -116,3 +117,8 @@ class TestGlob(WatchmanTestCase.WatchmanTestCase):
         self.assertEqual(self.normFileList(['includes/b.h']),
                          self.normWatchmanFileList(res['files']))
 
+        with self.assertRaises(pywatchman.WatchmanError) as ctx:
+            self.watchmanCommand('query', root, {
+                'glob': ['*/*.h'],
+                'relative_root': 'bogus'})
+        self.assertIn('check your relative_root', str(ctx.exception))


### PR DESCRIPTION
Summary: this avoids a segfault in the case that the relative_root
cannot be resolved for the first step of a glob.

To facilitate this, we now actually look at the return value from
a generator and, (this is the slightly nasty bit), propagate the
`errmsg` field from the `query` into the results object.  This is
slightly nasty because we would ideally put this directly in the results
object.

Since we're going to flip this to C++ very soon, I'd rather just make
this code throw an exception than do the plumbing now in C.