### PR TITLE
Add Docker build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM gcc
+
+ADD . /usr/src/watchman/
+WORKDIR /usr/src/watchman/
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install \
+      python-dev \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/ \
+  && \
+  ./autogen.sh && \
+  ./configure && \
+  make && \
+  make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,6 @@ RUN \
   ./configure && \
   make && \
   make install
+
+ENTRYPOINT [ "watchman" ]
+CMD [ "--help" ]


### PR DESCRIPTION
Add Dockerfile to enable image building.
Using the official GCC image. More info at https://hub.docker.com/_/gcc/

Build:
```
$ docker build -t watchman .
```

Run server:
```
$ docker run --rm -it --name watchman-server -v /usr/local/var/run/ watchman --foreground --log-level 2 [more options...]
```
From another terminal, run a client command (for example, shutdown server):
```
docker run --rm -it --volumes-from watchman-server watchman shutdown-server
```
If run without arguments, ```-help``` is used, as per the CMD in the Dockerfile.

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:
```
$ docker run --rm -it -v /usr/local/var/run/ --name watchman-server pataquets/watchman --foreground --log-level 2 [more options...]
```
Using ```--rm``` instead of ```-d``` makes the container not go background and it to be deleted after stop. Should stop by ```CTRL+C```'ing it, but looks like to me that it is ignoring ```TERM``` signals. We should use the ```--volumes-from``` option in the client container in order to give it acces to the server's socket file volume'd with the ```-v``` option. Also, you might want to add more ```-v /host/dir/path:/container/path/``` options in order to mount host's directories into the server container.

Optional improvement to come:
* Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process.