### PR TITLE
Allow for fast_fail field in query

### DIFF
--- a/cmds/debug.cpp
+++ b/cmds/debug.cpp
@@ -51,7 +51,7 @@ static void cmd_debug_delay_next_recrawl(struct watchman_client *client,
 
   w_root_lock(&unlocked, "debug-delay-next-recrawl", &lock);
   lock.root->recrawl_delay = std::chrono::milliseconds(
-      (int)json_integer_value(json_array_get(args, 2)));
+      json_integer_value(json_array_get(args, 2)));
   w_root_unlock(&lock, &unlocked);
 
   resp = make_response();

--- a/cmds/debug.cpp
+++ b/cmds/debug.cpp
@@ -32,8 +32,39 @@ static void cmd_debug_recrawl(struct watchman_client *client, json_t *args)
 }
 W_CMD_REG("debug-recrawl", cmd_debug_recrawl, CMD_DAEMON, w_cmd_realpath_root)
 
-static void cmd_debug_show_cursors(struct watchman_client *client, json_t *args)
-{
+static void cmd_debug_delay_next_recrawl(struct watchman_client *client,
+                                         json_t *args) {
+  json_t *resp;
+  struct write_locked_watchman_root lock;
+  struct unlocked_watchman_root unlocked;
+
+  if (json_array_size(args) != 3) {
+    send_error_response(
+        client, "wrong number of arguments for 'debug-delay-next-recrawl'");
+    return;
+  }
+
+  /* resolve the root */
+  if (!resolve_root_or_err(client, args, 1, false, &unlocked)) {
+    return;
+  }
+
+  w_root_lock(&unlocked, "debug-recrawl", &lock);
+  lock.root->recrawl_delay = std::chrono::milliseconds(
+      (int)json_integer_value(json_array_get(args, 2)));
+  w_root_unlock(&lock, &unlocked);
+
+  resp = make_response();
+
+  set_prop(resp, "delay", json_true());
+  send_and_dispose_response(client, resp);
+  w_root_delref(&unlocked);
+}
+W_CMD_REG("debug-delay-next-recrawl", cmd_debug_delay_next_recrawl, CMD_DAEMON,
+          w_cmd_realpath_root)
+
+static void cmd_debug_show_cursors(struct watchman_client *client,
+                                   json_t *args) {
   json_t *resp, *cursors;
   w_ht_iter_t i;
   struct write_locked_watchman_root lock;

--- a/cmds/debug.cpp
+++ b/cmds/debug.cpp
@@ -49,7 +49,7 @@ static void cmd_debug_delay_next_recrawl(struct watchman_client *client,
     return;
   }
 
-  w_root_lock(&unlocked, "debug-recrawl", &lock);
+  w_root_lock(&unlocked, "debug-delay-next-recrawl", &lock);
   lock.root->recrawl_delay = std::chrono::milliseconds(
       (int)json_integer_value(json_array_get(args, 2)));
   w_root_unlock(&lock, &unlocked);

--- a/query/eval.cpp
+++ b/query/eval.cpp
@@ -566,7 +566,7 @@ bool w_query_execute(
 
   w_perf_t sample("query_execute");
 
-  if (query->fast_fail &&
+  if (query->dont_wait_for_recrawl &&
       (unlocked->root->inner.should_recrawl ||
       !unlocked->root->inner.done_initial)) {
     ignore_result(asprintf(&res->errmsg, "recrawl is active\n"));

--- a/query/eval.cpp
+++ b/query/eval.cpp
@@ -566,6 +566,13 @@ bool w_query_execute(
 
   w_perf_t sample("query_execute");
 
+  if (query->fast_fail &&
+      (unlocked->root->inner.should_recrawl ||
+      !unlocked->root->inner.done_initial)) {
+    ignore_result(asprintf(&res->errmsg, "recrawl is active\n"));
+    return false;
+  }
+
   if (query->sync_timeout &&
       !w_root_sync_to_now(unlocked, query->sync_timeout)) {
     ignore_result(asprintf(&res->errmsg, "synchronization failed: %s\n",

--- a/query/parse.cpp
+++ b/query/parse.cpp
@@ -295,6 +295,20 @@ static bool parse_dedup(w_query *res, json_t *query)
   return true;
 }
 
+static bool parse_fast_fail(w_query *res, json_t *query)
+{
+  int value = 0;
+
+  if (query &&
+      json_unpack(query, "{s?:b*}", "fast_fail", &value) != 0) {
+    res->errmsg = strdup("fast_fail must be a boolean");
+    return false;
+  }
+
+  res->fast_fail = (bool) value;
+  return true;
+}
+
 static bool parse_empty_on_fresh_instance(w_query *res, json_t *query)
 {
   int value = 0;
@@ -344,6 +358,10 @@ w_query *w_query_parse(const w_root_t *root, json_t *query, char **errmsg)
   }
 
   if (!parse_dedup(res, query)) {
+    goto error;
+  }
+
+  if (!parse_fast_fail(res, query)) {
     goto error;
   }
 

--- a/query/parse.cpp
+++ b/query/parse.cpp
@@ -295,17 +295,17 @@ static bool parse_dedup(w_query *res, json_t *query)
   return true;
 }
 
-static bool parse_fast_fail(w_query *res, json_t *query)
+static bool parse_dont_wait_for_recrawl(w_query *res, json_t *query)
 {
   int value = 0;
 
   if (query &&
-      json_unpack(query, "{s?:b*}", "fast_fail", &value) != 0) {
-    res->errmsg = strdup("fast_fail must be a boolean");
+      json_unpack(query, "{s?:b*}", "dont_wait_for_recrawl", &value) != 0) {
+    res->errmsg = strdup("dont_wait_for_recrawl must be a boolean");
     return false;
   }
 
-  res->fast_fail = (bool) value;
+  res->dont_wait_for_recrawl = (bool) value;
   return true;
 }
 
@@ -361,7 +361,7 @@ w_query *w_query_parse(const w_root_t *root, json_t *query, char **errmsg)
     goto error;
   }
 
-  if (!parse_fast_fail(res, query)) {
+  if (!parse_dont_wait_for_recrawl(res, query)) {
     goto error;
   }
 

--- a/root/iothread.cpp
+++ b/root/iothread.cpp
@@ -35,6 +35,7 @@ static void io_thread(struct unlocked_watchman_root *unlocked)
       struct timeval start;
       w_perf_t sample("full-crawl");
 
+      /* sleep override */
       std::this_thread::sleep_for(unlocked->root->recrawl_delay);
 
       /* first order of business is to find all the files under our root */

--- a/root/iothread.cpp
+++ b/root/iothread.cpp
@@ -3,6 +3,8 @@
 
 #include "watchman.h"
 
+#include <thread>
+
 static void io_thread(struct unlocked_watchman_root *unlocked)
 {
   int timeoutms, biggest_timeout;
@@ -32,6 +34,8 @@ static void io_thread(struct unlocked_watchman_root *unlocked)
     if (!unlocked->root->inner.done_initial) {
       struct timeval start;
       w_perf_t sample("full-crawl");
+
+      std::this_thread::sleep_for(unlocked->root->recrawl_delay);
 
       /* first order of business is to find all the files under our root */
       if (cfg_get_bool(unlocked->root, "iothrottle", false)) {

--- a/tests/integration/test_recrawl.py
+++ b/tests/integration/test_recrawl.py
@@ -26,8 +26,10 @@ class TestRecrawl(WatchmanTestCase.WatchmanTestCase):
         # Trigger the recrawl
         self.watchmanCommand('debug-recrawl', root)
 
-        with self.assertRaises(pywatchman.WatchmanError):
+        with self.assertRaises(pywatchman.WatchmanError) as ctx:
             self.watchmanCommand('query', root, {
                 'relative_root': 'subdir',
                 'fields': ['name'],
                 "dont_wait_for_recrawl": True })
+
+        self.assertIn("recrawl is active", str(ctx.exception))

--- a/tests/integration/test_recrawl.py
+++ b/tests/integration/test_recrawl.py
@@ -1,0 +1,33 @@
+# vim:ts=4:sw=4:et:
+# Copyright 2016-present Facebook, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+# no unicode literals
+
+import WatchmanTestCase
+import pywatchman
+
+
+@WatchmanTestCase.expand_matrix
+class TestRecrawl(WatchmanTestCase.WatchmanTestCase):
+
+    def test_failDontWaitForRecrawl(self):
+        root = self.mkdtemp()
+        self.touchRelative(root, '111')
+
+        self.watchmanCommand('watch', root)
+
+        # Force the next recrawl to have a delay
+        self.watchmanCommand('debug-delay-next-recrawl', root, 1000)
+
+        # Trigger the recrawl
+        self.watchmanCommand('debug-recrawl', root)
+
+        with self.assertRaises(pywatchman.WatchmanError):
+            self.watchmanCommand('query', root, {
+                'relative_root': 'subdir',
+                'fields': ['name'],
+                "dont_wait_for_recrawl": True })

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -84,6 +84,7 @@ struct w_query {
   bool case_sensitive;
   bool empty_on_fresh_instance;
   bool dedup_results;
+  bool fast_fail;
 
   /* optional full path to relative root, without and with trailing slash */
   w_string_t *relative_root;

--- a/watchman_query.h
+++ b/watchman_query.h
@@ -84,7 +84,7 @@ struct w_query {
   bool case_sensitive;
   bool empty_on_fresh_instance;
   bool dedup_results;
-  bool fast_fail;
+  bool dont_wait_for_recrawl;
 
   /* optional full path to relative root, without and with trailing slash */
   w_string_t *relative_root;

--- a/watchman_root.h
+++ b/watchman_root.h
@@ -2,6 +2,7 @@
  * Licensed under the Apache License, Version 2.0 */
 #pragma once
 #include <unordered_map>
+#include <atomic>
 
 #define HINT_NUM_DIRS 128*1024
 #define CFG_HINT_NUM_DIRS "hint_num_dirs"

--- a/watchman_root.h
+++ b/watchman_root.h
@@ -90,10 +90,10 @@ struct watchman_root {
     /* current tick */
     uint32_t ticks{1};
 
-    bool done_initial{0};
+    std::atomic<bool> done_initial{0};
     /* if true, we've decided that we should re-crawl the root
      * for the sake of ensuring consistency */
-    bool should_recrawl{0};
+    std::atomic<bool> should_recrawl{0};
     bool cancelled{0};
 
     /* map of cursor name => last observed tick value */

--- a/watchman_root.h
+++ b/watchman_root.h
@@ -38,7 +38,7 @@ struct watchman_root {
   pthread_t notify_thread;
   pthread_t io_thread;
 
-  /* Time to wait before locking */
+  /* Time to wait prior to performing a recrawl */
   std::chrono::milliseconds recrawl_delay;
 
   /* map of rule id => struct watchman_trigger_command */

--- a/watchman_root.h
+++ b/watchman_root.h
@@ -3,6 +3,7 @@
 #pragma once
 #include <unordered_map>
 #include <atomic>
+#include <chrono>
 
 #define HINT_NUM_DIRS 128*1024
 #define CFG_HINT_NUM_DIRS "hint_num_dirs"
@@ -36,6 +37,9 @@ struct watchman_root {
   const char *lock_reason{nullptr};
   pthread_t notify_thread;
   pthread_t io_thread;
+
+  /* Time to wait before locking */
+  std::chrono::milliseconds recrawl_delay;
 
   /* map of rule id => struct watchman_trigger_command */
   w_ht_t *commands{nullptr};


### PR DESCRIPTION
In the event a recrawl is active, we might want to short circuit so we
can return immediately instead of waiting for the lock.
