### PR TITLE
ht: fix w_ht_iter_del to not skip over entries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -138,6 +138,7 @@ TESTS = \
 		tests/art.t \
 		tests/argv.t \
 		tests/bser.t \
+		tests/ht.t \
 		tests/ignore.t \
 		tests/pending.t \
 		tests/log.t \
@@ -222,6 +223,16 @@ tests_argv_t_SOURCES = \
 	argv.cpp \
 	string.cpp \
 	hash.cpp \
+	log.cpp
+
+tests_ht_t_CPPFLAGS = $(THIRDPARTY_CPPFLAGS) @IRONMANCFLAGS@
+tests_ht_t_LDADD = $(ART_LIB) $(TAP_LIB) $(JSON_LIB)
+tests_ht_t_SOURCES = \
+	tests/ht_test.cpp \
+	tests/log_stub.cpp \
+	hash.cpp \
+	ht.cpp \
+	string.cpp \
 	log.cpp
 
 tests_ignore_t_CPPFLAGS = $(THIRDPARTY_CPPFLAGS) @IRONMANCFLAGS@

--- a/ht.cpp
+++ b/ht.cpp
@@ -349,15 +349,19 @@ bool w_ht_iter_del(w_ht_t *ht, w_ht_iter_t *iter)
   /* walk back to the prior iterm, because ht_next will be used
    * to walk forwards; we want to land on the next item and not skip
    * it */
+  uint32_t slot = iter->slot;
   if (b->prev) {
     iter->ptr = b->prev;
   } else {
     /* we were the front of that bucket slot, arrange for iteration
-     * to find the front of it again */
+     * to find the front of the *same* slot */
     iter->ptr = NULL;
+    /* If iter->slot is 0, this will underflow to (uint32_t)-1. That is fine.
+     * It'll be as if the iterator is starting from the beginning. */
+    iter->slot--;
   }
 
-  delete_bucket(ht, b, iter->slot, false);
+  delete_bucket(ht, b, slot, false);
 
   return true;
 }

--- a/tests/TARGETS
+++ b/tests/TARGETS
@@ -39,6 +39,14 @@ t_test(
 )
 
 t_test(
+    name='ht',
+    srcs=['ht_test.cpp', 'log_stub.cpp'],
+    deps=[
+      '@/watchman:testsupport',
+    ],
+)
+
+t_test(
     name='ignore',
     srcs=['ignore_test.cpp', 'log_stub.cpp'],
     deps=[

--- a/tests/ht_test.cpp
+++ b/tests/ht_test.cpp
@@ -1,0 +1,41 @@
+/* Copyright 2016-present Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0. */
+
+#include "watchman.h"
+#include "thirdparty/tap.h"
+
+void test_ht_iter_del() {
+  auto ht = w_ht_new(2, &w_ht_dict_funcs);
+  for (int i = 0; i < 32; i++) {
+    auto key = w_string::printf("key%d", i);
+    auto val = w_string::printf("val%d", i);
+    bool inserted = w_ht_set(ht, w_ht_ptr_val(key), w_ht_ptr_val(val));
+    ok(inserted, "%s -> %s inserted", key.c_str(), val.c_str());
+  }
+
+  w_ht_iter_t citer;
+  int count_iter = 0;
+  if (w_ht_first(ht, &citer)) {
+    do {
+      bool deleted = w_ht_iter_del(ht, &citer);
+      ok(deleted, "item %d deleted", count_iter);
+      count_iter++;
+    } while (w_ht_next(ht, &citer));
+  }
+
+  uint32_t final_size = w_ht_size(ht);
+  ok(final_size == 0, "size after deletion: expected=0 actual=%d", final_size);
+
+  ok(count_iter == 32,
+     "count iterated over while deleting: expected=32 actual=%d", count_iter);
+}
+
+int main(int argc, char **argv) {
+  (void)argc;
+  (void)argv;
+
+  plan_tests(66);
+  test_ht_iter_del();
+
+  return exit_status();
+}

--- a/winbuild/Makefile
+++ b/winbuild/Makefile
@@ -133,6 +133,7 @@ TEST_DIR_SRCS=\
 TEST_DIR_SRCS_CPP=\
 	tests\argv.cpp \
 	tests\bser.cpp \
+	tests\ht_test.cpp \
 	tests\ignore_test.cpp \
 	tests\log_stub.cpp \
 	tests\log.cpp
@@ -141,7 +142,7 @@ OBJS=$(SRCS_CPP:.cpp=.obj) $(SRCS_C:.c=.obj)
 TEST_OBJS=$(TEST_SRCS_CPP:.cpp=.obj) $(TEST_SRCS_C:.c=.obj)
 TEST_DIR_OBJS=$(TEST_DIR_SRCS:.c=.obj) $(TEST_DIR_SRCS_CPP:.cpp=.obj)
 TESTS=tests\argv.exe tests\log.exe tests\bser.exe tests\wildmatch_test.exe \
-			tests\art.exe tests\ignore.exe tests\pending.exe
+			tests\art.exe tests\ignore.exe tests\pending.exe tests\ht.exe
 
 {}.cpp{}.obj::
 	@echo CXX $<
@@ -243,6 +244,15 @@ tests\art.exe: tests\art_test.obj $(TEST_OBJS) \
 	@echo LINK $@
 	$(LINKER) $** $(LIBS)
 
+tests\ht.exe: tests\ht_test.obj $(TEST_OBJS) \
+		hash.obj \
+		ht.obj \
+		string.obj \
+		log.obj \
+		tests\log_stub.obj
+	@echo LINK $@
+	$(LINKER) $** $(LIBS)
+
 tests\ignore.exe: tests\ignore_test.obj $(TEST_OBJS) \
 		hash.obj \
 		ht.obj \
@@ -308,4 +318,3 @@ clean:
 	-del $(OBJS) $(TEST_OBJS) $(TEST_DIR_OBJS) *.exe
 
 distclean: clean
-


### PR DESCRIPTION
This was happening because if the first entry in a bucket was deleted, we'd
skip over that bucket entirely. Subtract 1 from the slot to make sure we retry
the same slot.

Included are both unit and integration tests demonstrating the issue.

I believe I've ticked all the boxes (buck, Windows), but please let me know if I missed something.