### PR TITLE
Fix BSER for nodejs

### DIFF
--- a/node/bser/index.js
+++ b/node/bser/index.js
@@ -120,6 +120,9 @@ Accumulator.prototype.peekInt = function(size) {
 
 Accumulator.prototype.readInt = function(bytes) {
   var ival = this.peekInt(bytes);
+  if (ival instanceof Int64 && isFinite(ival.valueOf())) {
+    ival = ival.valueOf();
+  }
   this.readOffset += bytes;
   return ival;
 }
@@ -207,8 +210,8 @@ var ST_NEED_PDU = 0; // Need to read and decode PDU length
 var ST_FILL_PDU = 1; // Know the length, need to read whole content
 
 var MAX_INT8 = 127;
-var MAX_INT16 = 32768;
-var MAX_INT32 = 2147483648;
+var MAX_INT16 = 32767;
+var MAX_INT32 = 2147483647;
 
 function BunserBuf() {
   EE.call(this);
@@ -490,8 +493,13 @@ function dump_int(buf, val) {
 function dump_any(buf, val) {
   switch (typeof(val)) {
     case 'number':
-      buf.writeByte(BSER_REAL);
-      buf.writeDouble(val);
+      // check if it is an integer or a float
+      if (isFinite(val) && Math.floor(val) === val) {
+        dump_int(buf, val);
+      } else {
+        buf.writeByte(BSER_REAL);
+        buf.writeDouble(val);
+      }
       return;
     case 'string':
       buf.writeByte(BSER_STRING);

--- a/node/bser/test/bser.js
+++ b/node/bser/test/bser.js
@@ -10,7 +10,7 @@ var template =  "\x00\x01\x03\x28" +
                 "\x1e\x0c\x03\x19" ;
 
 var val = bser.loadFromBuffer(template);
-assert.deepEqual(val, [
+assert.deepStrictEqual(val, [
   {"name": "fred", "age": 20},
   {"name": "pete", "age": 30},
   {"age": 25}
@@ -19,7 +19,7 @@ assert.deepEqual(val, [
 function roundtrip(val) {
   var encoded = bser.dumpToBuffer(val);
   var decoded = bser.loadFromBuffer(encoded);
-  assert.deepEqual(decoded, val);
+  assert.deepStrictEqual(decoded, val);
 }
 
 var values_to_test = [
@@ -28,7 +28,7 @@ var values_to_test = [
   1.5,
   false,
   true,
-  new Int64('0x0123456789'),
+  new Int64('0x0123456789abcdef'),
   127,
   128,
   129,
@@ -71,4 +71,16 @@ assert.equal(acc.peekString(2), 'lo', 'have the correct remainder');
 
 // Don't include keys that have undefined values
 var res = bser.dumpToBuffer({expression: undefined});
-assert.deepEqual(bser.loadFromBuffer(res), {});
+assert.deepStrictEqual(bser.loadFromBuffer(res), {});
+
+// Dump numbers without fraction to integers
+var buffer;
+buffer = bser.dumpToBuffer(1);
+assert.equal(buffer.toString('hex'), "000105020000000301");
+buffer = bser.dumpToBuffer(1.0);
+assert.equal(buffer.toString('hex'), "000105020000000301");
+
+// Dump numbers with fraction to double
+buffer = bser.dumpToBuffer(1.1);
+assert.equal(buffer.toString('hex'), "00010509000000079a9999999999f13f");
+


### PR DESCRIPTION
This fixes several issues with the nodejs implementation of BSER. Javascript is tricky as it treats all numbers as float, so there are some drawbacks of this implementation.

* Fixed the MAX_INT16 and MAX_INT32 constants to be correct. They were both +1 which led to `argument is out of bounds` if trying to dump `32768` or `2147483648` as int
* Fixed detection of integers inside `dump_any()` by checking if it is an integer with the polyfill outline in this [MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Polyfill).
  * This has the drawback that a float cannot be enforced anymore, as `1.0` will also be detected as int because `1.0 === 1`
  * The only real solution to properly fix all cases which I can see, is to have a `new Double()` class or `new Integer()`class, which a user would need to supply to enforce the type.
* Changed `readInt()` when reading an 64bit integer to check if the value can be handled by node.js. If yes it returns the primitive number otherwise returns the instance of `Int64`. This imho is nice, even if the return value in some cases could be either `number` or `Int64` (not sure what is the actual limit)
  * This is a breaking change for users who always expect a `number > MAX_INT32` to be an instance of Int64. (e.g. `mtime_ms` in watchman was always a `Int64` and could now be a `number`)
  * If not desired, let me know, I can revert this.
* Changed the tests to use deepStrictEqual to ensure primitive types are checked with `===`

Fixes #392 