### PR TITLE
Attempt to fix appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
     - gh-pages
 
 install:
-  - cinst -y php
+  - cinst -y php --version 7.0.9
 
 build_script:
   - make


### PR DESCRIPTION
Summary: Looks like the last successful run on appveyor was using PHP
7.0.9.  The current PHP release fails to install and breaks the build,
so let's try pinning to this last known good version.