### PR TITLE
Forced bser module import by using pdu_info

### DIFF
--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -42,6 +42,9 @@ import time
 # so fall back to a pure Python implementation.
 try:
     from . import bser
+    # Demandimport causes modules to be loaded lazily. Force the load now
+    # so that we can fall back on pybser if bser doesn't exist
+    bser.pdu_info
 except ImportError:
     from . import pybser as bser
 


### PR DESCRIPTION
Because demandimport lazily import bser, this fallback approach doesn't actually seem to work. I ran into issues with it when trying to get watchman working on windows when I didn't have the compiled bser module.