### PR TITLE
travis: try upgrading to Python 3.5.2

### DIFF
--- a/travis/deps.sh
+++ b/travis/deps.sh
@@ -24,8 +24,8 @@ case `uname` in
         pyenv global 2.7.11
         ;;
       python3.5)
-        pyenv install 3.5.1
-        pyenv global 3.5.1
+        pyenv install 3.5.2
+        pyenv global 3.5.2
         ;;
     esac
     ;;


### PR DESCRIPTION
See if this fixes "Can't mix strings and bytes in path components" errors like in https://travis-ci.org/facebook/watchman/jobs/184356116.