### PR TITLE
stat: avoid dereferencing a null pointer

### DIFF
--- a/root/stat.cpp
+++ b/root/stat.cpp
@@ -75,9 +75,7 @@ void InMemoryView::statPath(
           path,
           ") -> ",
           strerror(err),
-          " so stopping watch on ",
-          file->getName(),
-          "\n");
+          " so stopping watch\n");
     }
     if (file) {
       if (file->exists) {


### PR DESCRIPTION
`file` might be `nullptr` at this point. The information is already exposed as `path` so there's no need for `file` to also be printed.