### PR TITLE
Fix compilation on some flavors of visual studio 2015

### DIFF
--- a/winbuild/backtrace.cpp
+++ b/winbuild/backtrace.cpp
@@ -2,6 +2,8 @@
  * Licensed under the Apache License, Version 2.0 */
 
 #include "watchman.h"
+// some versions of dbghelp.h do: typedef enum {}; with no typedef name
+#pragma warning(disable: 4091)
 #include <Dbghelp.h>
 #include <mutex>
 


### PR DESCRIPTION
I just tried building watchman on my PC at home with a fresh install
of the community edition of visual studio and hit this compilation
error:

```
C:\Program Files (x86)\Windows Kits\8.1\include\um\Dbghelp.h(1544):
error C2220: warning treated as error - no 'object' file generated
(compiling source file winbuild\backtrace.cpp)
C:\Program Files (x86)\Windows Kits\8.1\include\um\Dbghelp.h(1544):
warning C4091: 'typedef ': ignored on left of '' when no variable is
declared (compiling source file winbuild\backtrace.cpp)
C:\Program Files (x86)\Windows Kits\8.1\include\um\Dbghelp.h(3190):
warning C4091: 'typedef ': ignored on left of '' when no variable is
declared (compiling source file winbuild\backtrace.cpp)
```

Turns out that the header does this:

```
typedef enum {
  hdBase = 0, // root directory for dbghelp
  hdSym,      // where symbols are stored
  hdSrc,      // where source is stored
  hdMax       // end marker
};
```

and since we're turning warnings into errors, this was the cause of the
compilation failure.

This diff just turns off this warning when we're building this file.