### PR TITLE
tests: fix --debug-watchman

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -92,7 +92,7 @@ parser.add_argument(
     '--debug-watchman',
     action='store_true',
     help='Pauses start up and prints out the PID for watchman server process.' +
-    'Use with concurrency set to 1')
+    'Forces concurrency to 1.')
 
 parser.add_argument(
     '--watchman-path',
@@ -348,7 +348,9 @@ def queue_jobs(tests):
         tests_queue.put(test)
 
 all_tests = expand_suite(suite)
-if len(all_tests) < args.concurrency:
+if args.debug_watchman:
+    args.concurrency = 1
+elif len(all_tests) < args.concurrency:
     args.concurrency = len(all_tests)
 queue_jobs(all_tests)
 

--- a/tests/integration/WatchmanInstance.py
+++ b/tests/integration/WatchmanInstance.py
@@ -169,9 +169,11 @@ class _Instance(object):
                                      stderr=self.cli_log_file)
         if self.debug_watchman:
             print('Watchman instance PID: ' + str(self.proc.pid))
-            if not pywatchman.compat.PYTHON3:
-                input = raw_input
-            input('Press any key to continue...')
+            if pywatchman.compat.PYTHON3:
+                user_input = input
+            else:
+                user_input = raw_input
+            user_input('Press Enter to continue...')
 
         # wait for it to come up
         deadline = time.time() + self.start_timeout


### PR DESCRIPTION
* Force concurrency to 1.
* Python 3 chokes on `input` because it doesn't figure out that `input` is actually a global. So use a different name.

Test Plan:

`python3 runtests.py --debug-watchman`
`python2 runtests.py --debug-watchman`