### PR TITLE
Avoid possible NPE when subscription is removed

### DIFF
--- a/java/src/com/facebook/watchman/WatchmanClientImpl.java
+++ b/java/src/com/facebook/watchman/WatchmanClientImpl.java
@@ -255,11 +255,13 @@ public class WatchmanClientImpl implements WatchmanClient {
             .name(subscriptionId)
             .root(root)
             .build();
-        if (!subscriptions.containsKey(subscription)) {
+
+        Callback listener = subscriptions.get(subscription);
+        if (listener == null) {
           // TODO log error?!
           return;
         }
-        subscriptions.get(subscription).call(message);
+        listener.call(message);
       }
     }
   }


### PR DESCRIPTION
NPE can happen when a subscription is removed in the middle
of unilateral callback. The fix is to avoid accessing a map twice,
just use the first result.

This fix also prevents an NPE when a client adds a null listener.