### PR TITLE
[docs] fix permalink to docs/install.html

### DIFF
--- a/website/_data/nav.yml
+++ b/website/_data/nav.yml
@@ -1,5 +1,5 @@
 - title: Docs
-  href: docs/install.html
+  href: /watchman/docs/install.html
   category: docs
 
 - title: Support


### PR DESCRIPTION
With the new updates, the "docs" nav link at the top of  http://facebook.github.io/watchman/docs/install.html referred to `http://facebook.github.io/watchman/docs/docs/install.html`.