### PR TITLE
In the Java client, allow the user to select a watchman binary

### DIFF
--- a/java/src/com/facebook/watchman/WatchmanSocketBuilder.java
+++ b/java/src/com/facebook/watchman/WatchmanSocketBuilder.java
@@ -91,12 +91,14 @@ public class WatchmanSocketBuilder {
     Optional<Path> optionalExecutable = ExecutableFinder.getOptionalExecutable(
         Paths.get("watchman"),
         ImmutableMap.copyOf(System.getenv()));
-
     if (!optionalExecutable.isPresent()) {
       throw new WatchmanSocketUnavailableException();
     }
+    return discoverSocket(optionalExecutable.get(), duration, unit);
+  }
 
-    Path watchmanPath = optionalExecutable.get();
+  public static Socket discoverSocket(Path watchmanPath, long duration, TimeUnit unit)
+      throws WatchmanSocketUnavailableException {
     NuProcessBuilder processBuilder = new NuProcessBuilder(
         watchmanPath.toString(),
         "--output-encoding=bser",


### PR DESCRIPTION
Summary:
In the Java client, the WatchmanSocketBuilder finds the first watchman binary
on the user's PATH and uses it by default.  This change allows the user of the
watchman library to pass in a path to an arbitrary executable.  In theory, this
allows a user of this library to use a version of `watchman` that isn't the
first instance on their path, or to use a binary that isn't called `watchman`.

Testing:
Manual testing.