### PR TITLE
Remove version pinning from appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
     - gh-pages
 
 install:
-  - cinst -y php --version 7.0.9
+  - cinst -y php -i
 
 build_script:
   - make


### PR DESCRIPTION
Refs: https://github.com/facebook/watchman/issues/423

This pinning was added because newer versions failed to install.

http://help.appveyor.com/discussions/problems/5616-not-able-to-build-due-to-problem-in-chocolateyinstallps1#comment_41337217

suggests adding the `-i` flag to ignore deps, which is what we needed here to prevent the deps of php wanting to reboot the appveyor environment.