### PR TITLE
add a --run option to execute a given script

### DIFF
--- a/python/bin/watchman-make
+++ b/python/bin/watchman-make
@@ -16,27 +16,20 @@ def patterns_to_terms(pats):
         terms.append(['match', p, 'wholename', {'includedotfiles': True}])
     return terms
 
-
 class Target(object):
-    """ Represents a makefile target that we'd like to build
+    """ Base Class for a Target
 
     We track the patterns that we consider to be the dependencies for
     this target and establish a subscription for them.
 
     When we receive notifications for that subscription, we know that
-    we should execute the command to build this target.
+    we should execute the command.
     """
-
-    def __init__(self, name, make, targets, patterns):
+    def __init__(self, name, patterns, cmd):
         self.name = name
-        self.make = make
-        self.targets = targets
         self.patterns = patterns
+        self.cmd = cmd
         self.triggered = False
-
-    def __repr__(self):
-        return '{make=%r targets=%r pat=%r}' % (
-            self.make, self.targets, self.patterns)
 
     def start(self, client, root):
         query = {
@@ -53,8 +46,8 @@ class Target(object):
         # get the initial clock value so that we only get updates
         query['since'] = client.query('clock', root_dir)['clock']
 
-        print('# Changes to files matching %s will execute `%s %s`' % (
-            ' '.join(self.patterns), self.make, ' '.join(self.targets)),
+        print('# Changes to files matching %s will execute `%s`' % (
+            ' '.join(self.patterns), self.cmd),
             file=sys.stderr)
         sub = client.query('subscribe', root_dir, self.name, query)
 
@@ -68,13 +61,35 @@ class Target(object):
         if not self.triggered:
             return
         self.triggered = False
+        print('# Execute: `%s`' % self.cmd, file=sys.stderr)
+        subprocess.call(self.cmd, shell=True)
+
+
+class MakefileTarget(Target):
+    """ Represents a Makefile target that we'd like to build. """
+    def __init__(self, name, make, targets, patterns):
+        self.make = make
+        self.targets = targets
         cmd = "%s %s" % (self.make, " ".join(self.targets))
-        print('# Execute: `%s`' % cmd, file=sys.stderr)
-        subprocess.call(cmd, shell=True)
+        super(MakefileTarget, self).__init__(name, patterns, cmd)
+
+    def __repr__(self):
+        return '{make=%r targets=%r pat=%r}' % (
+            self.make, self.targets, self.patterns)
+
+class RunTarget(Target):
+    """ Represents a script that we'd like to run. """
+    def __init__(self, name, runfile, patterns):
+        self.runfile = runfile
+        super(RunTarget, self).__init__(name, patterns, self.runfile)
+
+    def __repr__(self):
+        return '{runfile=%r pat=%r}' % (
+            self.runfile, self.patterns)
 
 
 class DefineTarget(argparse.Action):
-    """ argument parser helper to manage defining Target instances. """
+    """ argument parser helper to manage defining MakefileTarget instances. """
 
     def __init__(self, option_strings, dest, **kwargs):
         super(DefineTarget, self).__init__(option_strings, dest, **kwargs)
@@ -93,7 +108,7 @@ class DefineTarget(argparse.Action):
                   values, file=sys.stderr)
             sys.exit(1)
 
-        target = Target('target_%d' % len(targets),
+        target = MakefileTarget('target_%d' % len(targets),
                         namespace.make, values, namespace.pattern)
         targets.append(target)
 
@@ -105,16 +120,17 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
     description="""
 watchman-make waits for changes to files and then invokes a build tool
-(by default, `make`) to process those changes.  It uses the watchman service to
-efficiently watch the appropriate files.
+(by default, `make`) or provided script to process those changes.
+It uses the watchman service to efficiently watch the appropriate files.
 
 Events are consolidated and settled before they are dispatched to your build
 tool, so that it won't start executing until after the files have stopped
 changing.
 
-watchman-make is target-centric; you need to tell it about one or more
-build targets and what the dependencies of those targets are, and it will
-then trigger the build for those targets as changes are detected.
+You can tell watchman-make about one or more build targets and dependencies
+for those targets or provide a script to run.
+watchman-make will then trigger the build for the given targets or
+run the provided script as changes are detected.
 
 """)
 parser.add_argument('-t', '--target', nargs='+', type=str, action=DefineTarget,
@@ -146,13 +162,19 @@ Define the root of the project.  The default is to use the PWD.
 All patterns are considered to be relative to this root, and the build
 tool is executed with this location set as its PWD.
 """)
-
+parser.add_argument('-r', '--run', type=str, help="""
+The script that should be run when changes are detected
+""")
 args = parser.parse_args()
 
-if args.target is None:
-    print('# No targets were specified, nothing to do.', file=sys.stderr)
+if args.target is None and args.run is None:
+    print('# No run script or targets were specified, nothing to do.', file=sys.stderr)
     sys.exit(1)
 
+if args.target is None:
+    args.target = []
+    if args.run is not None:
+        args.target.append(RunTarget('RunTarget', args.run, args.pattern))
 
 def check_root(desired_root):
     try:
@@ -227,3 +249,4 @@ while True:
     except KeyboardInterrupt:
         # suppress ugly stack trace when they Ctrl-C
         break
+

--- a/website/_docs/watchman-make.md
+++ b/website/_docs/watchman-make.md
@@ -6,13 +6,13 @@ category: Invocation
 permalink: docs/watchman-make.html
 ---
 
-`watchman-make` is a convenience tool to help automatically invoke your build
-tool in response to files changing.  It is useful to automate building assets
+`watchman-make` is a convenience tool to help automatically invoke a build
+tool or script in response to files changing.  It is useful to automate building assets
 or running tests as you save files during development.
 
 `watchman-make` will establish a watch on the files you specify and remain
 running in the foreground, waiting for changes to occur.  When a change is
-triggered, your build tool will be run in the foreground with its output being
+triggered, your build tool or script will be run in the foreground with its output being
 passed through to your terminal session (or wherever you may have redirected
 it).
 
@@ -35,7 +35,7 @@ $ watchman-make -p '**/*.c' '**/*.h' 'Makefile*' -t all -p 'tests/**/*.py' 'test
 
 ### Targets
 
-`watchman-make` is target-centric; you tell it about one or more build targets
+You can tell `watchman-make` about one or more build targets
 and their dependencies, and it will then trigger the build for those targets as
 changes are detected.
 
@@ -89,3 +89,21 @@ $ watchman-make -p '*.c' '*.h' 'Makefile*' 'tests/**/*.py' 'tests/**/*.c' -t all
 this will execute `make all integration` if you change any top level `*.c` file
 *or* test source file.
 
+### Run Scripts
+
+*Since 4.8.*
+
+As an alternative to targets, you can provide the path to a script which `watchman-make`
+will execute when changes are detected.
+
+```bash
+$ watchman-make -p '**/*.c' '**/*.h' --run my_script.sh
+```
+
+The above will run the provided script whenever any
+combination of files are changed that have filenames that match either of the
+patterns `*.c` or `*.h` at any level in the directory tree. When it triggers,
+`watchman-make` will execute `my_script.sh`.
+
+You must run `watchman-make` with either `--target` or `--run`, but they cannot
+be run together


### PR DESCRIPTION
This option provides an alternative to the --make
flag. You can now specify a pattern and provide
the path to a script to run upon changes being detected.
Ex:
    `watchman-make -p '*.c' '*.h' --run my_script.sh`

Implements #232 