### PR TITLE
Make `bser_load()` match Python implementation for optional args

### DIFF
--- a/python/pywatchman/bser.c
+++ b/python/pywatchman/bser.c
@@ -1136,11 +1136,15 @@ static PyObject* bser_loads(PyObject* self, PyObject* args, PyObject* kw) {
 }
 
 static PyObject* bser_load(PyObject* self, PyObject* args, PyObject* kw) {
-  PyObject *load, *string;
+  PyObject* load;
+  PyObject* load_method;
+  PyObject* string;
+  PyObject* load_method_args;
+  PyObject* load_method_kwargs;
   PyObject* fp = NULL;
   PyObject* mutable_obj = NULL;
-  const char* value_encoding = NULL;
-  const char* value_errors = NULL;
+  PyObject* value_encoding = NULL;
+  PyObject* value_errors = NULL;
 
   static char* kw_list[] = {
       "fp", "mutable", "value_encoding", "value_errors", NULL};
@@ -1148,7 +1152,7 @@ static PyObject* bser_load(PyObject* self, PyObject* args, PyObject* kw) {
   if (!PyArg_ParseTupleAndKeywords(
           args,
           kw,
-          "OOzz:load",
+          "O|OOO:load",
           kw_list,
           &fp,
           &mutable_obj,
@@ -1161,8 +1165,33 @@ static PyObject* bser_load(PyObject* self, PyObject* args, PyObject* kw) {
   if (load == NULL) {
     return NULL;
   }
-  string = PyObject_CallMethod(
-      load, "load", "OOzz", fp, mutable_obj, value_encoding, value_errors);
+  load_method = PyObject_GetAttrString(load, "load");
+  if (load_method == NULL) {
+    return NULL;
+  }
+  // Mandatory method arguments
+  load_method_args = Py_BuildValue("(O)", fp);
+  if (load_method_args == NULL) {
+    return NULL;
+  }
+  // Optional method arguments
+  load_method_kwargs = PyDict_New();
+  if (load_method_kwargs == NULL) {
+    return NULL;
+  }
+  if (mutable_obj) {
+    PyDict_SetItemString(load_method_kwargs, "mutable", mutable_obj);
+  }
+  if (value_encoding) {
+    PyDict_SetItemString(load_method_kwargs, "value_encoding", value_encoding);
+  }
+  if (value_errors) {
+    PyDict_SetItemString(load_method_kwargs, "value_errors", value_errors);
+  }
+  string = PyObject_Call(load_method, load_method_args, load_method_kwargs);
+  Py_DECREF(load_method_kwargs);
+  Py_DECREF(load_method_args);
+  Py_DECREF(load_method);
   Py_DECREF(load);
   return string;
 }

--- a/python/tests/tests.py
+++ b/python/tests/tests.py
@@ -327,6 +327,14 @@ class TestBSERDump(unittest.TestCase):
         self.assertRaises(ValueError, self.bser_mod.pdu_info,
                           b'\x00\x02')
 
+    def test_bser_load_without_default_args(self):
+        val = {u'hello': u'there'}
+        enc = self.bser_mod.dumps(val)
+        fp = FakeFile(enc)
+        dec = self.bser_mod.load(fp)
+        self.assertEqual(val, dec)
+
+
 if __name__ == '__main__':
     suite = load_tests(unittest.TestLoader())
     unittest.TextTestRunner().run(suite)


### PR DESCRIPTION
The C implementation of `bser.load()` makes all arguments required, but the Python implementation  only requires the first argument.

This makes the C implementation match the Python implementation. 
