### PR TITLE
Add troubleshooting hint when watching many files

### DIFF
--- a/website/_docs/troubleshooting.markdown
+++ b/website/_docs/troubleshooting.markdown
@@ -179,8 +179,19 @@ limits for the number of files.
 
 ### How do I resolve this?
 
-[Follow these directions](
-/watchman/docs/troubleshooting.html#i-39-ve-changed-my-limits-how-can-i-clear-the-error)
+If the problem is due to trying to watch too many files (this can happen easily in
+a project with a `node_modules` folder, for example), you should instruct watchman
+to ignore folders that you don't want to watch. Add a [Watchman config file](https://facebook.github.io/watchman/docs/config.html) and specify what to ignore.
+An example `.watchmanconfig` at the root of your project could look like this:
+
+```
+{
+  "ignore_dirs": ["build", "node_modules"]
+}
+```
+
+To clear the error, [follow these directions](
+/watchman/docs/troubleshooting.html#ive-changed-my-limits-how-can-i-clear-the-warning)
 
 If the issue persists, consult your system administrator to identify what
 is consuming these resources and remediate it, or to increase your system


### PR DESCRIPTION
The problem our whole team ran into was that watchman tried to watch the node_modules folder as well. This exceeded the file limit in macOS Sierra and was solved by ignoring that folder through a config file.

Also fixes broken link to “remove the warning” section.