### PR TITLE
Provide human readable errors for log commands

### DIFF
--- a/cmds/log.cpp
+++ b/cmds/log.cpp
@@ -36,7 +36,19 @@ W_CMD_REG("log-level", cmd_loglevel, CMD_DAEMON, NULL)
 
 // log "debug" "text to log"
 static void cmd_log(struct watchman_client* client, const json_ref& args) {
-  auto level = watchman::logLabelToLevel(json_to_w_string(args.at(1)));
+  if (json_array_size(args) != 3) {
+    send_error_response(client, "wrong number of arguments to 'log'");
+    return;
+  }
+
+  watchman::LogLevel level;
+  try {
+    level = watchman::logLabelToLevel(json_to_w_string(args.at(1)));
+  } catch(std::out_of_range &e) {
+    send_error_response(client, "invalid log level for 'log'");
+    return;
+  }
+
   auto text = json_to_w_string(args.at(2));
 
   watchman::log(level, text, "\n");

--- a/cmds/log.cpp
+++ b/cmds/log.cpp
@@ -7,8 +7,19 @@
 // log-level "error"
 // log-level "off"
 static void cmd_loglevel(struct watchman_client* client, const json_ref& args) {
-  const auto& label = json_to_w_string(args.at(1));
-  auto level = watchman::logLabelToLevel(label);
+  if (json_array_size(args) != 2) {
+    send_error_response(client, "wrong number of arguments to 'log-level'");
+    return;
+  }
+
+  watchman::LogLevel level;
+  try {
+    level = watchman::logLabelToLevel(json_to_w_string(args.at(1)));
+  } catch(std::out_of_range &e) {
+    send_error_response(client, "invalid log level for 'log-level'");
+    return;
+  }
+
   auto clientRef = client->shared_from_this();
   auto notify = [clientRef]() { clientRef->ping->notify(); };
   auto& log = watchman::getLog();

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -1,0 +1,28 @@
+# vim:ts=4:sw=4:et:
+# Copyright 2017-present Facebook, Inc.
+# Licensed under the Apache License, Version 2.0
+import WatchmanTestCase
+import json
+import os
+import os.path
+import pywatchman
+
+@WatchmanTestCase.expand_matrix
+class TestLog(WatchmanTestCase.WatchmanTestCase):
+
+    def test_invalidNumArgsLog(self):
+        for params in [
+            ['log'],
+            ['log', 'debug'],
+            ['log', 'debug', 'test', 'extra'],
+        ]:
+            with self.assertRaises(pywatchman.WatchmanError) as ctx:
+                self.watchmanCommand(*params)
+
+            self.assertIn('wrong number of arguments', str(ctx.exception))
+
+    def test_invalidLevelLog(self):
+        with self.assertRaises(pywatchman.WatchmanError) as ctx:
+            self.watchmanCommand('log', 'invalid', 'test')
+
+        self.assertIn('invalid log level', str(ctx.exception))

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -10,6 +10,22 @@ import pywatchman
 @WatchmanTestCase.expand_matrix
 class TestLog(WatchmanTestCase.WatchmanTestCase):
 
+    def test_invalidNumArgsLogLevel(self):
+        for params in [
+            ['log-level'],
+            ['log-level', 'debug', 'extra'],
+        ]:
+            with self.assertRaises(pywatchman.WatchmanError) as ctx:
+                self.watchmanCommand(*params)
+
+            self.assertIn('wrong number of arguments', str(ctx.exception))
+
+    def test_invalidLevelLogLevel(self):
+        with self.assertRaises(pywatchman.WatchmanError) as ctx:
+            self.watchmanCommand('log-level', 'invalid')
+
+        self.assertIn('invalid log level', str(ctx.exception))
+
     def test_invalidNumArgsLog(self):
         for params in [
             ['log'],


### PR DESCRIPTION
Previously, erroneous or the wrong number of arguments for `log` or
`log-level` commands would throw and return a cryptic error.

Validate log-level command's arguments server-side and return human
readable errors.