### PR TITLE
Fix watch-project relative_path docs

### DIFF
--- a/website/_docs/cmd.watch-project.markdown
+++ b/website/_docs/cmd.watch-project.markdown
@@ -97,7 +97,7 @@ $ watchman watch-project ~/www/some/child/dir
 {
   "version": "3.0.1",
   "watch": "/Users/wez/www",
-  "relative_path": "www"
+  "relative_path": "some/child/dir"
 }
 ```
 


### PR DESCRIPTION
The ["Using watch-project"](https://facebook.github.io/watchman/docs/cmd/watch-project.html#using-watch-project) section of the documentation for
`watch-project` erroneously listed 'www' as the `relative_path` in the
result of running `watchman watch-project ~/www/some/child/dir` with a
mercurial repo at '~/www'.

Change this to list the correct "some/child/dir" path.


Tested with:
```sh
$ mkdir -p ~/www/some/child/dir
$ cd ~/www
$ hg init
$ watchman watch-project ~/www/some/child/dir
```

Which produced the output:
```json
{
    "version": "4.9.0",
    "relative_path": "some/child/dir",
    "watch": "/home/cpick/www",
    "watcher": "inotify"
}
```