### PR TITLE
Fix a Windows 7 compatibility issue in WinDirHandle::readDir

### DIFF
--- a/winbuild/dir.cpp
+++ b/winbuild/dir.cpp
@@ -209,7 +209,11 @@ class WinDirHandle : public watchman_dir_handle {
       return readDirWin8();
     }
     catch (const std::system_error& err) {
-      // Fallback on Win7 implementation
+      if (err.code().value() != ERROR_INVALID_PARAMETER) {
+        throw;
+      }
+      // Fallback on Win7 implementation. FileFullDirectoryInfo
+      // parameter is not supported before Win8
       win7_ = true;
       return readDirWin7();
     }

--- a/winbuild/dir.cpp
+++ b/winbuild/dir.cpp
@@ -9,19 +9,21 @@ using watchman::Win32Handle;
 
 namespace {
 class WinDirHandle : public watchman_dir_handle {
+  std::wstring dirWPath_;
   Win32Handle h_;
   FILE_FULL_DIR_INFO* info_{nullptr};
   char __declspec(align(8)) buf_[64 * 1024];
+  HANDLE hDirFind_{nullptr};
   char nameBuf_[WATCHMAN_NAME_MAX];
   struct watchman_dir_ent ent_;
 
  public:
   explicit WinDirHandle(const char* path, bool strict) {
     int err = 0;
-    auto wpath = w_string_piece(path).asWideUNC();
+    dirWPath_ = w_string_piece(path).asWideUNC();
 
     h_ = Win32Handle(intptr_t(CreateFileW(
-        wpath.c_str(),
+        dirWPath_.c_str(),
         GENERIC_READ,
         FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
         nullptr,
@@ -48,22 +50,104 @@ class WinDirHandle : public watchman_dir_handle {
   }
 
   const watchman_dir_ent* readDir() override {
-    if (!info_) {
-      if (!GetFileInformationByHandleEx(
-              (HANDLE)h_.handle(), FileFullDirectoryInfo, buf_, sizeof(buf_))) {
-        if (GetLastError() == ERROR_NO_MORE_FILES) {
-          return nullptr;
+    if ((getenv("WATCHMAN_WIN7_COMPAT") && 
+         getenv("WATCHMAN_WIN7_COMPAT")[0] == '1')) {
+      // Before Windows 8, the FileFullDirectoryInfo parameter is not supported when 
+      WIN32_FIND_DATAW findFileData;
+      if (!hDirFind_) { 
+        std::wstring strWPath(dirWPath_);
+        strWPath += L"\\*";
+        if ((hDirFind_ = FindFirstFileW(strWPath.c_str(), &findFileData)) == INVALID_HANDLE_VALUE) {          
+          if (GetLastError() == ERROR_NO_MORE_FILES) {
+            FindClose(hDirFind_);
+            return nullptr;
+          }
+
+          throw std::system_error(
+            GetLastError(),
+            std::system_category(),
+            "FindFirstFileW");
         }
+      }
+      else
+      {
+        if (!FindNextFileW(hDirFind_, &findFileData)) {
+          if (GetLastError() == ERROR_NO_MORE_FILES) {
+            FindClose(hDirFind_);
+            return nullptr;
+          }
+
+          throw std::system_error(
+            GetLastError(),
+            std::system_category(),
+            "FindNextFileW");
+        }
+      }
+
+      DWORD len = WideCharToMultiByte(
+        CP_UTF8,
+        0,
+        findFileData.cFileName,
+        -1,
+        nameBuf_,
+        sizeof(nameBuf_) - 1,
+        NULL,
+        NULL);
+
+      if (len <= 0) {
         throw std::system_error(
+          GetLastError(), std::system_category(), "WideCharToMultiByte");
+      }
+
+      nameBuf_[len] = 0;
+
+      //// Populate stat info to speed up the crawler() routine
+      FILETIME_to_timespec(&findFileData.ftCreationTime, &ent_.stat.ctime);
+      FILETIME_to_timespec(&findFileData.ftLastAccessTime, &ent_.stat.atime);
+      FILETIME_to_timespec(&findFileData.ftLastWriteTime, &ent_.stat.mtime);
+
+      LARGE_INTEGER fileSize;
+      fileSize.HighPart = findFileData.nFileSizeHigh;
+      fileSize.LowPart = findFileData.nFileSizeLow;
+      ent_.stat.size = fileSize.QuadPart;
+
+      if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+        // This is a symlink, but msvcrt has no way to indicate that.
+        // We'll treat it as a regular file until we have a better
+        // representation :-/
+        ent_.stat.mode = _S_IFREG;
+      }
+      else if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+        ent_.stat.mode = _S_IFDIR | S_IEXEC | S_IXGRP | S_IXOTH;
+      }
+      else {
+        ent_.stat.mode = _S_IFREG;
+      }
+      if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_READONLY) {
+        ent_.stat.mode |= 0444;
+      }
+      else {
+        ent_.stat.mode |= 0666;
+      }
+    }
+    else
+    {
+      if (!info_) {
+        if (!GetFileInformationByHandleEx(
+          (HANDLE)h_.handle(), FileFullDirectoryInfo, buf_, sizeof(buf_))) {
+          if (GetLastError() == ERROR_NO_MORE_FILES) {
+            return nullptr;
+          }
+          throw std::system_error(
             GetLastError(),
             std::system_category(),
             "GetFileInformationByHandleEx");
+        }
+        info_ = (FILE_FULL_DIR_INFO*)buf_;
       }
-      info_ = (FILE_FULL_DIR_INFO*)buf_;
-    }
 
-    // Decode the item currently pointed at
-    DWORD len = WideCharToMultiByte(
+      // Decode the item currently pointed at
+      DWORD len = WideCharToMultiByte(
         CP_UTF8,
         0,
         info_->FileName,
@@ -73,39 +157,44 @@ class WinDirHandle : public watchman_dir_handle {
         nullptr,
         nullptr);
 
-    if (len <= 0) {
-      throw std::system_error(
+      if (len <= 0) {
+        throw std::system_error(
           GetLastError(), std::system_category(), "WideCharToMultiByte");
-    }
+      }
 
-    nameBuf_[len] = 0;
+      nameBuf_[len] = 0;
 
-    // Populate stat info to speed up the crawler() routine
-    FILETIME_LARGE_INTEGER_to_timespec(info_->CreationTime, &ent_.stat.ctime);
-    FILETIME_LARGE_INTEGER_to_timespec(info_->LastAccessTime, &ent_.stat.atime);
-    FILETIME_LARGE_INTEGER_to_timespec(info_->LastWriteTime, &ent_.stat.mtime);
-    ent_.stat.size = info_->EndOfFile.QuadPart;
+      // Populate stat info to speed up the crawler() routine
+      FILETIME_LARGE_INTEGER_to_timespec(info_->CreationTime, &ent_.stat.ctime);
+      FILETIME_LARGE_INTEGER_to_timespec(info_->LastAccessTime, &ent_.stat.atime);
+      FILETIME_LARGE_INTEGER_to_timespec(info_->LastWriteTime, &ent_.stat.mtime);
+      ent_.stat.size = info_->EndOfFile.QuadPart;
 
-    if (info_->FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
-      // This is a symlink, but msvcrt has no way to indicate that.
-      // We'll treat it as a regular file until we have a better
-      // representation :-/
-      ent_.stat.mode = _S_IFREG;
-    } else if (info_->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-      ent_.stat.mode = _S_IFDIR | S_IEXEC | S_IXGRP | S_IXOTH;
-    } else {
-      ent_.stat.mode = _S_IFREG;
-    }
-    if (info_->FileAttributes & FILE_ATTRIBUTE_READONLY) {
-      ent_.stat.mode |= 0444;
-    } else {
-      ent_.stat.mode |= 0666;
-    }
+      if (info_->FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+        // This is a symlink, but msvcrt has no way to indicate that.
+        // We'll treat it as a regular file until we have a better
+        // representation :-/
+        ent_.stat.mode = _S_IFREG;
+      }
+      else if (info_->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+        ent_.stat.mode = _S_IFDIR | S_IEXEC | S_IXGRP | S_IXOTH;
+      }
+      else {
+        ent_.stat.mode = _S_IFREG;
+      }
+      if (info_->FileAttributes & FILE_ATTRIBUTE_READONLY) {
+        ent_.stat.mode |= 0444;
+      }
+      else {
+        ent_.stat.mode |= 0666;
+      }
 
-    // Advance the pointer to the next entry ready for the next read
-    info_ = info_->NextEntryOffset == 0
+      // Advance the pointer to the next entry ready for the next read
+      info_ = info_->NextEntryOffset == 0
         ? nullptr
         : (FILE_FULL_DIR_INFO*)(((char*)info_) + info_->NextEntryOffset);
+    }
+
     return &ent_;
   }
 };

--- a/winbuild/dir.cpp
+++ b/winbuild/dir.cpp
@@ -11,11 +11,157 @@ namespace {
 class WinDirHandle : public watchman_dir_handle {
   std::wstring dirWPath_;
   Win32Handle h_;
+  bool win7_{false};
   FILE_FULL_DIR_INFO* info_{nullptr};
   char __declspec(align(8)) buf_[64 * 1024];
   HANDLE hDirFind_{nullptr};
   char nameBuf_[WATCHMAN_NAME_MAX];
   struct watchman_dir_ent ent_;
+
+  const watchman_dir_ent* readDirWin8() {
+    if (!info_) {
+      if (!GetFileInformationByHandleEx(
+        (HANDLE)h_.handle(), FileFullDirectoryInfo, buf_, sizeof(buf_))) {
+        if (GetLastError() == ERROR_NO_MORE_FILES) {
+          return nullptr;
+        }
+        throw std::system_error(
+          GetLastError(),
+          std::system_category(),
+          "GetFileInformationByHandleEx");
+      }
+      info_ = (FILE_FULL_DIR_INFO*)buf_;
+    }
+
+    // Decode the item currently pointed at
+    DWORD len = WideCharToMultiByte(
+      CP_UTF8,
+      0,
+      info_->FileName,
+      info_->FileNameLength / sizeof(WCHAR),
+      nameBuf_,
+      sizeof(nameBuf_) - 1,
+      nullptr,
+      nullptr);
+
+    if (len <= 0) {
+      throw std::system_error(
+        GetLastError(), std::system_category(), "WideCharToMultiByte");
+    }
+
+    nameBuf_[len] = 0;
+
+    // Populate stat info to speed up the crawler() routine
+    FILETIME_LARGE_INTEGER_to_timespec(info_->CreationTime, &ent_.stat.ctime);
+    FILETIME_LARGE_INTEGER_to_timespec(info_->LastAccessTime, &ent_.stat.atime);
+    FILETIME_LARGE_INTEGER_to_timespec(info_->LastWriteTime, &ent_.stat.mtime);
+    ent_.stat.size = info_->EndOfFile.QuadPart;
+
+    if (info_->FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+      // This is a symlink, but msvcrt has no way to indicate that.
+      // We'll treat it as a regular file until we have a better
+      // representation :-/
+      ent_.stat.mode = _S_IFREG;
+    }
+    else if (info_->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+      ent_.stat.mode = _S_IFDIR | S_IEXEC | S_IXGRP | S_IXOTH;
+    }
+    else {
+      ent_.stat.mode = _S_IFREG;
+    }
+    if (info_->FileAttributes & FILE_ATTRIBUTE_READONLY) {
+      ent_.stat.mode |= 0444;
+    }
+    else {
+      ent_.stat.mode |= 0666;
+    }
+
+    // Advance the pointer to the next entry ready for the next read
+    info_ = info_->NextEntryOffset == 0
+      ? nullptr
+      : (FILE_FULL_DIR_INFO*)(((char*)info_) + info_->NextEntryOffset);
+ 
+    return &ent_;
+  }
+
+  const watchman_dir_ent* readDirWin7() {
+    // FileFullDirectoryInfo is not supported prior to Windows 8
+    WIN32_FIND_DATAW findFileData;
+    if (!hDirFind_) {
+      std::wstring strWPath(dirWPath_);
+      strWPath += L"\\*";
+      if ((hDirFind_ = FindFirstFileW(strWPath.c_str(), &findFileData)) == INVALID_HANDLE_VALUE) {
+        if (GetLastError() == ERROR_NO_MORE_FILES) {
+          FindClose(hDirFind_);
+          return nullptr;
+        }
+
+        throw std::system_error(
+          GetLastError(),
+          std::system_category(),
+          "FindFirstFileW");
+      }
+    }
+    else
+    {
+      if (!FindNextFileW(hDirFind_, &findFileData)) {
+        if (GetLastError() == ERROR_NO_MORE_FILES) {
+          FindClose(hDirFind_);
+          return nullptr;
+        }
+
+        throw std::system_error(
+          GetLastError(),
+          std::system_category(),
+          "FindNextFileW");
+      }
+    }
+
+    DWORD len = WideCharToMultiByte(
+      CP_UTF8,
+      0,
+      findFileData.cFileName,
+      -1,
+      nameBuf_,
+      sizeof(nameBuf_) - 1,
+      NULL,
+      NULL);
+
+    if (len <= 0) {
+      throw std::system_error(
+        GetLastError(), std::system_category(), "WideCharToMultiByte");
+    }
+
+    nameBuf_[len] = 0;
+
+    // Populate stat info to speed up the crawler() routine
+    FILETIME_to_timespec(&findFileData.ftCreationTime, &ent_.stat.ctime);
+    FILETIME_to_timespec(&findFileData.ftLastAccessTime, &ent_.stat.atime);
+    FILETIME_to_timespec(&findFileData.ftLastWriteTime, &ent_.stat.mtime);
+
+    LARGE_INTEGER fileSize;
+    fileSize.HighPart = findFileData.nFileSizeHigh;
+    fileSize.LowPart = findFileData.nFileSizeLow;
+    ent_.stat.size = fileSize.QuadPart;
+
+    if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+      ent_.stat.mode = _S_IFREG;
+    }
+    else if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+      ent_.stat.mode = _S_IFDIR | S_IEXEC | S_IXGRP | S_IXOTH;
+    }
+    else {
+      ent_.stat.mode = _S_IFREG;
+    }
+    if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_READONLY) {
+      ent_.stat.mode |= 0444;
+    }
+    else {
+      ent_.stat.mode |= 0666;
+    }  
+
+    return &ent_;
+  }
 
  public:
   explicit WinDirHandle(const char* path, bool strict) {
@@ -41,6 +187,12 @@ class WinDirHandle : public watchman_dir_handle {
           std::string("CreateFileW for opendir: ") + path);
     }
 
+    // Use Win7 compatibility mode for readDir()
+    if (getenv("WATCHMAN_WIN7_COMPAT") &&
+        getenv("WATCHMAN_WIN7_COMPAT")[0] == '1') {
+      win7_ = true;
+    }
+
     memset(&ent_, 0, sizeof(ent_));
     ent_.d_name = nameBuf_;
     ent_.has_stat = true;
@@ -50,152 +202,17 @@ class WinDirHandle : public watchman_dir_handle {
   }
 
   const watchman_dir_ent* readDir() override {
-    if ((getenv("WATCHMAN_WIN7_COMPAT") && 
-         getenv("WATCHMAN_WIN7_COMPAT")[0] == '1')) {
-      // Before Windows 8, the FileFullDirectoryInfo parameter is not supported when 
-      WIN32_FIND_DATAW findFileData;
-      if (!hDirFind_) { 
-        std::wstring strWPath(dirWPath_);
-        strWPath += L"\\*";
-        if ((hDirFind_ = FindFirstFileW(strWPath.c_str(), &findFileData)) == INVALID_HANDLE_VALUE) {          
-          if (GetLastError() == ERROR_NO_MORE_FILES) {
-            FindClose(hDirFind_);
-            return nullptr;
-          }
-
-          throw std::system_error(
-            GetLastError(),
-            std::system_category(),
-            "FindFirstFileW");
-        }
-      }
-      else
-      {
-        if (!FindNextFileW(hDirFind_, &findFileData)) {
-          if (GetLastError() == ERROR_NO_MORE_FILES) {
-            FindClose(hDirFind_);
-            return nullptr;
-          }
-
-          throw std::system_error(
-            GetLastError(),
-            std::system_category(),
-            "FindNextFileW");
-        }
-      }
-
-      DWORD len = WideCharToMultiByte(
-        CP_UTF8,
-        0,
-        findFileData.cFileName,
-        -1,
-        nameBuf_,
-        sizeof(nameBuf_) - 1,
-        NULL,
-        NULL);
-
-      if (len <= 0) {
-        throw std::system_error(
-          GetLastError(), std::system_category(), "WideCharToMultiByte");
-      }
-
-      nameBuf_[len] = 0;
-
-      //// Populate stat info to speed up the crawler() routine
-      FILETIME_to_timespec(&findFileData.ftCreationTime, &ent_.stat.ctime);
-      FILETIME_to_timespec(&findFileData.ftLastAccessTime, &ent_.stat.atime);
-      FILETIME_to_timespec(&findFileData.ftLastWriteTime, &ent_.stat.mtime);
-
-      LARGE_INTEGER fileSize;
-      fileSize.HighPart = findFileData.nFileSizeHigh;
-      fileSize.LowPart = findFileData.nFileSizeLow;
-      ent_.stat.size = fileSize.QuadPart;
-
-      if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
-        // This is a symlink, but msvcrt has no way to indicate that.
-        // We'll treat it as a regular file until we have a better
-        // representation :-/
-        ent_.stat.mode = _S_IFREG;
-      }
-      else if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-        ent_.stat.mode = _S_IFDIR | S_IEXEC | S_IXGRP | S_IXOTH;
-      }
-      else {
-        ent_.stat.mode = _S_IFREG;
-      }
-      if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_READONLY) {
-        ent_.stat.mode |= 0444;
-      }
-      else {
-        ent_.stat.mode |= 0666;
-      }
+    if (win7_) {
+      return readDirWin7();
     }
-    else
-    {
-      if (!info_) {
-        if (!GetFileInformationByHandleEx(
-          (HANDLE)h_.handle(), FileFullDirectoryInfo, buf_, sizeof(buf_))) {
-          if (GetLastError() == ERROR_NO_MORE_FILES) {
-            return nullptr;
-          }
-          throw std::system_error(
-            GetLastError(),
-            std::system_category(),
-            "GetFileInformationByHandleEx");
-        }
-        info_ = (FILE_FULL_DIR_INFO*)buf_;
-      }
-
-      // Decode the item currently pointed at
-      DWORD len = WideCharToMultiByte(
-        CP_UTF8,
-        0,
-        info_->FileName,
-        info_->FileNameLength / sizeof(WCHAR),
-        nameBuf_,
-        sizeof(nameBuf_) - 1,
-        nullptr,
-        nullptr);
-
-      if (len <= 0) {
-        throw std::system_error(
-          GetLastError(), std::system_category(), "WideCharToMultiByte");
-      }
-
-      nameBuf_[len] = 0;
-
-      // Populate stat info to speed up the crawler() routine
-      FILETIME_LARGE_INTEGER_to_timespec(info_->CreationTime, &ent_.stat.ctime);
-      FILETIME_LARGE_INTEGER_to_timespec(info_->LastAccessTime, &ent_.stat.atime);
-      FILETIME_LARGE_INTEGER_to_timespec(info_->LastWriteTime, &ent_.stat.mtime);
-      ent_.stat.size = info_->EndOfFile.QuadPart;
-
-      if (info_->FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
-        // This is a symlink, but msvcrt has no way to indicate that.
-        // We'll treat it as a regular file until we have a better
-        // representation :-/
-        ent_.stat.mode = _S_IFREG;
-      }
-      else if (info_->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-        ent_.stat.mode = _S_IFDIR | S_IEXEC | S_IXGRP | S_IXOTH;
-      }
-      else {
-        ent_.stat.mode = _S_IFREG;
-      }
-      if (info_->FileAttributes & FILE_ATTRIBUTE_READONLY) {
-        ent_.stat.mode |= 0444;
-      }
-      else {
-        ent_.stat.mode |= 0666;
-      }
-
-      // Advance the pointer to the next entry ready for the next read
-      info_ = info_->NextEntryOffset == 0
-        ? nullptr
-        : (FILE_FULL_DIR_INFO*)(((char*)info_) + info_->NextEntryOffset);
+    try {
+      return readDirWin8();
     }
-
-    return &ent_;
+    catch (const std::system_error& err) {
+      // Fallback on Win7 implementation
+      win7_ = true;
+      return readDirWin7();
+    }
   }
 };
 }


### PR DESCRIPTION
On Windows 7, in WinDirHandle::readDir(), a system_error would be thrown
when calling GetFileInformationByHandleEx with FileFullDirectoryInfo.
FileFullDirectoryInfo is not supported before Windows 8
(https://msdn.microsoft.com/en-us/library/windows/desktop/aa364228(v=vs.85).aspx).
To fix this, we use an implementation based on the FindFirstFile and
FindNextFile functions.

Before c2dec83 (refactor w_dir_open, nov 2016), readDir() would simply
return NULL on Win7 which hid the problem.