### PR TITLE
Retry flaky tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
     - os: osx
       env: TRAVIS_PYTHON=python2.6
     - os: osx
-      env: TRAVIS_PYTHON=python2.7 BUILD_JAVA_CLIENT=1
+      env: TRAVIS_PYTHON=python2.7
     - os: osx
       env: TRAVIS_PYTHON=python3.5
     - os: osx

--- a/runtests.py
+++ b/runtests.py
@@ -441,6 +441,14 @@ if 'APPVEYOR' in os.environ:
     subprocess.call(['7z', 'a', 'logs.zip', 'logs'])
     subprocess.call(['appveyor', 'PushArtifact', 'logs.zip'])
 
+if 'CIRCLE_ARTIFACTS' in os.environ:
+    print('Creating %s/logs.zip' % os.environ['CIRCLE_ARTIFACTS'])
+    subprocess.call(['zip',
+                    '-q',
+                     '-r',
+                     '%s/logs.zip' % os.environ['CIRCLE_ARTIFACTS'],
+                     temp_dir.get_dir()])
+
 if tests_failed or (tests_run == 0):
     if args.keep_if_fail:
         temp_dir.set_keep(True)

--- a/runtests.py
+++ b/runtests.py
@@ -76,9 +76,17 @@ parser.add_argument(
     action='append',
     help='specify which python test method names to run')
 
+def default_concurrency():
+    level = min(4, math.ceil(1.5 * multiprocessing.cpu_count()))
+    if 'CIRCLECI' in os.environ:
+        # Use fewer cores in circle CI because the inotify sysctls
+        # are pretty low, and we sometimes hit those limits.
+        level = level / 2
+    return int(level)
+
 parser.add_argument(
     '--concurrency',
-    default=int(min(4, math.ceil(1.5 * multiprocessing.cpu_count()))),
+    default=default_concurrency(),
     type=int,
     help='How many tests to run at once')
 

--- a/runtests.py
+++ b/runtests.py
@@ -373,6 +373,11 @@ def runner():
                         # Facilitate retrying this possibly flaky test
                         continue
 
+            if not result.wasSuccessful() and \
+                    'TRAVIS' in os.environ and \
+                    hasattr(test, 'dumpLogs'):
+                test.dumpLogs()
+
             results_queue.put(result)
 
         finally:

--- a/tests/integration/WatchmanTestCase.py
+++ b/tests/integration/WatchmanTestCase.py
@@ -61,6 +61,7 @@ class WatchmanTestCase(unittest.TestCase):
         super(WatchmanTestCase, self).__init__(methodName)
         self.setDefaultConfiguration()
         self.maxDiff = None
+        self.attempt = 0
 
         if pywatchman.compat.PYTHON3:
             self.assertItemsEqual = self.assertCountEqual
@@ -115,14 +116,20 @@ class WatchmanTestCase(unittest.TestCase):
         os.close(f)
         return name
 
+    def setAttemptNumber(self, attempt):
+        self.attempt = attempt
+
     def run(self, result):
         if result is None:
             raise Exception('MUST be a runtests.py:Result instance')
+
         # Arrange for any temporary stuff we create to go under
         # our global tempdir and put it in a dir named for the test
         id = '%s.%s.%s' % (self.id(), self.transport, self.encoding)
         try:
             self.tempdir = os.path.join(TempDir.get_temp_dir().get_dir(), id)
+            if self.attempt > 0:
+                self.tempdir += "-%d" % self.attempt
             os.mkdir(self.tempdir)
 
             self.__logTestInfo(id, 'BEGIN')

--- a/tests/integration/WatchmanTestCase.py
+++ b/tests/integration/WatchmanTestCase.py
@@ -19,6 +19,7 @@ import time
 import tempfile
 import os.path
 import os
+import subprocess
 import WatchmanInstance
 import TempDir
 
@@ -147,6 +148,19 @@ class WatchmanTestCase(unittest.TestCase):
                 delattr(self, 'client')
 
         return result
+
+    def dumpLogs(self):
+        ''' used in travis CI to show the hopefully relevant log snippets '''
+        inst = WatchmanInstance.getSharedInstance()
+
+        def tail(logstr, n):
+            lines = logstr.split('\n')[-n:]
+            return '\n'.join(lines)
+
+        print('CLI logs')
+        print(tail(inst.getCLILogContents(), 500))
+        print('Server logs')
+        print(tail(inst.getServerLogContents(), 500))
 
     def setConfiguration(self, transport, encoding):
         self.transport = transport

--- a/tests/integration/test_php.py
+++ b/tests/integration/test_php.py
@@ -75,6 +75,11 @@ def find_php_tests(test_class):
 
 @find_php_tests
 class PHPTestCase(unittest.TestCase):
+    attempt = 0
+
+    def setAttemptNumber(self, attempt):
+        ''' enable flaky test retry '''
+        self.attempt = attempt
 
     @unittest.skipIf(php_bin is None, 'php not installed')
     def runTest(self):
@@ -90,6 +95,10 @@ class PHPTestCase(unittest.TestCase):
             return name
 
         dotted = clean_file_name(os.path.normpath(self.id()))
+
+        if self.attempt > 0:
+            dotted += "-%d" % self.attempt
+
         env['TMPDIR'] = os.path.join(TempDir.get_temp_dir().get_dir(), dotted)
         if os.name != 'nt' and len(env['TMPDIR']) > 94:
             self.fail('temp dir name %s is too long for unix domain sockets' %

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -36,9 +36,6 @@ set +e
 rm -rf /tmp/watchman*
 rm -rf /var/tmp/watchmantest*
 TMP=/var/tmp
-if test "$CIRCLECI" = "true" ; then
-  TMP=$CIRCLE_ARTIFACTS
-fi
 TMPDIR=$TMP
 export TMPDIR TMP
 
@@ -47,6 +44,9 @@ if ! make integration ; then
 fi
 
 INST_TEST=/tmp/install-test
+if test "$CIRCLE" = "true" ; then
+  INST_TEST="$CIRCLE_ARTIFACTS/install-test"
+fi
 test -d $INST_TEST && rm -rf $INST_TEST
 make DESTDIR=$INST_TEST install
 find $INST_TEST

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -43,11 +43,6 @@ TMPDIR=$TMP
 export TMPDIR TMP
 
 if ! make integration ; then
-  if test "$CIRCLECI" = "true" ; then
-    # runtests.py already copied the logs to the artifact store
-    exit 1
-  fi
-  find /var/tmp/watchmantest* -name log | xargs tail -n 2000
   exit 1
 fi
 

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -x
 uname -a
-
 # Speculatively fulfil any node deps before we turn on hard errors
 cd node
 npm install
@@ -37,14 +36,14 @@ set +e
 rm -rf /tmp/watchman*
 rm -rf /var/tmp/watchmantest*
 TMP=/var/tmp
-if test "$CIRCLECI" == "true" ; then
+if test "$CIRCLECI" = "true" ; then
   TMP=$CIRCLE_ARTIFACTS
 fi
 TMPDIR=$TMP
 export TMPDIR TMP
 
 if ! make integration ; then
-  if test "$CIRCLECI" == "true" ; then
+  if test "$CIRCLECI" = "true" ; then
     # runtests.py already copied the logs to the artifact store
     exit 1
   fi


### PR DESCRIPTION
Adds an option to the test runner that specifies how many times we
should retry flaky tests.  This defaults to 2.

We don't really know whether a test is flaky or not ahead of time,
so this really just specifies how many times we'll retry a failing
test.

We'll only perform this retry behavior if the test instance has
a method that allows setting the current attempt number.  We do
this because most of our tests derive an output directory from
the current test configuration; we need to augment that path with
the attempt number in order for the subsequent attempt to be able
to run in a clean environment.

I've enabled this for python and php tests.

A failing test will still print out its failure reason on each attempt,
along with the current attempt number, but if it passes on a subsequent
attempt, the overall test run status will reflect only its passing
result.

We could potentialy track a number of flaky tests, but I just want
to get this in so that our OSS CI needs less manual poking.