### PR TITLE
handle readdir errors in the iothread

### DIFF
--- a/error_category.cpp
+++ b/error_category.cpp
@@ -72,6 +72,7 @@ bool error_category::equivalent(const std::error_code& code, int condition)
       return
 #ifdef _WIN32
           code == windows_error_code(ERROR_PATH_NOT_FOUND) ||
+          code == windows_error_code(ERROR_DIRECTORY) ||
 #endif
           code == std::errc::not_a_directory;
 


### PR DESCRIPTION
Summary: these don't seem to be possible, or at least vanishingly rare,
on posix systems, but crop up in the git test suite on windows
(https://github.com/facebook/watchman/issues/461)

Uncaught exceptions in the IO thread result in the watch being
cancelled, so we need to do better.

This diff catches exceptions raised by readDir and adds the path
back to the pending list.   The theory is that these exceptions
can only happen if the directory has been removed while we were
reading it, so the subsequent stat should get an ENOENT equivalent.
The danger here is that we get stuck in a loop trying to stat these
forever, so we may need to do some immediate processing here instead.

I've also added ERROR_DIRECTORY to the error category stuff so that
we recognize it as being equivalent to ENOTDIR.