### PR TITLE
turn off strict symlink check in OpenFileHandleOptions.openDir().

### DIFF
--- a/FileSystem.h
+++ b/FileSystem.h
@@ -63,6 +63,7 @@ struct OpenFileHandleOptions {
   static inline OpenFileHandleOptions openDir() {
     OpenFileHandleOptions opts;
     opts.readContents = 1;
+    opts.strictNameChecks = false;
     opts.followSymlinks = 1;
     return opts;
   }


### PR DESCRIPTION
Use OpenFileHandleOptions.strictOpenDir() to enable the strict symlink
rules explicitly.

Before this change, `watchman::openFileHandle()` always enforces strict
symlink rules because `strictNameChecks` is true even in
`OpenFileHandleOptions.openDir()`.