### PR TITLE
Use a wheel format when publishing the watchman pypi package

### DIFF
--- a/python/publish-pypi.sh
+++ b/python/publish-pypi.sh
@@ -20,4 +20,4 @@
 #    password: <pypi_password>
 #
 
-python setup.py sdist upload -r pypi
+python setup.py sdist bdist_wheel upload -r pypi


### PR DESCRIPTION
The Python wheel format is the preferred way of distributing Python packages with C extensions. This just adds the `bdist_wheel` step to the build script.

The `wheel` package needs to be installed on any development machine this is being run on.