### PR TITLE
Enable Python client to be used as a context manager

### DIFF
--- a/python/pywatchman/__init__.py
+++ b/python/pywatchman/__init__.py
@@ -920,6 +920,13 @@ class client(object):
     def __del__(self):
         self.close()
 
+    def __enter__(self):
+        self._connect()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+
     def close(self):
         if self.tport:
             self.tport.close()


### PR DESCRIPTION
Currently, the Python client relies on __del__ to clean up
the active transport. Although, callers can explicitly call
close() if they want.

__del__ in Python is fundamentally dangerous for many reasons
and should not be used lightly. For example, exceptions during
__del__ are ignored and circular references on objects with
__del__ may result in deferred garbage collection. In some
scenarios, this can lead to resource "leaks."

Python's context managers are the preferred mechanism to
manage lifetimes of primitives. So this commit teaches the
"client" class to work as a context manager. When the context
manager is entered, the transport is activated. When it exits,
the transport is destroyed.