### PR TITLE
Avoid upgrading brew on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ matrix:
     - os: osx
       env: TRAVIS_PYTHON=python3.5
     - os: osx
-      env: TRAVIS_PYTHON=python3.6
-    - os: osx
       osx_image: xcode7.3
       env: TRAVIS_PYTHON=python2.7 ENABLE_ASAN=1
     - os: osx

--- a/travis/deps.sh
+++ b/travis/deps.sh
@@ -2,11 +2,8 @@
 set -x
 case `uname` in
   Darwin)
-    brew update
     brew tap facebook/fb
     brew install wget pcre ruby openssl readline buck pyenv
-    # reinstall to get the latest versions
-    brew upgrade
     # avoid snafu with OS X and python builds
     ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
     CFLAGS="$CFLAGS $ARCHFLAGS"


### PR DESCRIPTION
This is seemingly causing some of our builds to fail due to missing
tools in the environment, and recompiles some stuff, making our
builds take longer.