### PR TITLE
Install LICENSE

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS = watchman
 # ensure that we have a reasonable default for the python install
 DESTDIR ?= /
 
-doc_DATA = README.markdown
+doc_DATA = README.markdown LICENSE
 docdir = ${prefix}/share/doc/watchman-$(VERSION)
 
 THIRDPARTY_CPPFLAGS = -I$(top_srcdir)/thirdparty/jansson -I$(top_builddir)/thirdparty/jansson


### PR DESCRIPTION
Install LICENSE to make sure that binary packages comply with the Apache license.
See section 4.1 of the Apache version 2 license.