### PR TITLE
enable retrying for nodejs tests

### DIFF
--- a/tests/integration/case.js
+++ b/tests/integration/case.js
@@ -20,7 +20,7 @@ if (platform == 'darwin' || platform == 'win32') {
       assert.equal(err_mk_dir_bar, null, 'no errors');
 
       client.command(['watch', bar], function (error, resp) {
-        assert.equal('unable to resolve root ' + bar
+        assert.equal('RootResolveError: unable to resolve root ' + bar
                       + ": \"" + bar + "\" resolved to \"" + BAR
                       + "\" but we were unable to examine \""
                       + bar + "\" using strict "


### PR DESCRIPTION
I observed that we're not kicking in with the flaky test retry
machinery and that this is causing travis to report some builds
as failed.

This diff enables retrying, and also allows for picking up `nodejs`
from the PATH which is how my Ubuntu 16.04 system installs the node
binary.