### PR TITLE
Speculative fix for failing test on travis

### DIFF
--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -62,4 +62,5 @@ class TestRemove(WatchmanTestCase.WatchmanTestCase):
         shutil.rmtree(root)
         retry_makedirs(os.path.join(root, 'notme'))
 
-        self.assertWaitFor(lambda: not self.rootIsWatched(root))
+        self.assertWaitFor(lambda: not self.rootIsWatched(root),
+            message="%s should be cancelled" % root)

--- a/watcher/fsevents.cpp
+++ b/watcher/fsevents.cpp
@@ -542,6 +542,13 @@ bool FSEventsWatcher::consumeNotify(
       break;
     }
 
+    if ((item.flags & kFSEventStreamEventFlagItemRemoved) &&
+        item.path == root->root_path) {
+      log(ERR, "Root directory removed, cancel watch\n");
+      root->cancel();
+      break;
+    }
+
     if (item.flags & kFSEventStreamEventFlagRootChanged) {
       w_log(
           W_LOG_ERR,


### PR DESCRIPTION
This seems to affect the mac only and appears to be a race condition
wrt. removing and recreating the directory tree.

test_remove.py exercises this