### PR TITLE
use otime rather than timestamps for symlink cache

### DIFF
--- a/InMemoryView.cpp
+++ b/InMemoryView.cpp
@@ -74,8 +74,7 @@ Future<w_string> InMemoryFileResult::readLink() {
   }
 
   SymlinkTargetCacheKey key{w_string::pathCat({dir, baseName()}),
-                            size_t(file_->stat.size),
-                            file_->stat.mtime};
+                            file_->otime};
 
   return caches_.symlinkTargetCache.get(key).then(
       [](Result<std::shared_ptr<const SymlinkTargetCache::Node>>&& result)

--- a/SymlinkTargets.cpp
+++ b/SymlinkTargets.cpp
@@ -12,15 +12,12 @@ using Node = typename SymlinkTargetCache::Node;
 
 bool SymlinkTargetCacheKey::operator==(
     const SymlinkTargetCacheKey& other) const {
-  return fileSize == other.fileSize && mtime.tv_sec == other.mtime.tv_sec &&
-      mtime.tv_nsec == other.mtime.tv_nsec &&
+  return otime.ticks == other.otime.ticks &&
       relativePath == other.relativePath;
 }
 
 std::size_t SymlinkTargetCacheKey::hashValue() const {
-  return hash_128_to_64(
-      w_string_hval(relativePath),
-      hash_128_to_64(fileSize, hash_128_to_64(mtime.tv_sec, mtime.tv_nsec)));
+  return hash_128_to_64(w_string_hval(relativePath), otime.ticks);
 }
 
 SymlinkTargetCache::SymlinkTargetCache(

--- a/SymlinkTargets.h
+++ b/SymlinkTargets.h
@@ -3,15 +3,15 @@
 #include <string>
 #include "LRUCache.h"
 #include "watchman_string.h"
+#include "thirdparty/jansson/jansson.h"
+#include "watchman_clockspec.h"
 
 namespace watchman {
 struct SymlinkTargetCacheKey {
   // Path relative to the watched root
   w_string relativePath;
-  // file size in bytes
-  size_t fileSize;
   // The modification time
-  struct timespec mtime;
+  w_clock_t otime;
 
   // Computes a hash value for use in the cache map
   std::size_t hashValue() const;


### PR DESCRIPTION
While timestamps seemed to work reliably on our internal CI, they're
pretty flaky on the open source CI and also on my laptop.

Switch the cache key to use the `otime` field instead; this holds
the watchman clock value from the last time we observed a change
for a given file node and isn't subject to timestamp granularity
or clock drift concerns.

Test Plan: test_symlink.py would pretty consistently (about 80% of the
time) repro a failure when using bser over a a unix socket.  With
this change we're pretty solid.

Let's see what the OSS CI makes of it.