### PR TITLE
Fix link about binary protocol

### DIFF
--- a/ruby/ruby-watchman/README.md
+++ b/ruby/ruby-watchman/README.md
@@ -1,7 +1,7 @@
 # RubyWatchman
 
 RubyWatchman is a gem that implements the [Watchman binary
-protocol](https://github.com/facebook/watchman/blob/master/BSER.markdown). It is
+protocol](https://facebook.github.io/watchman/docs/bser.html). It is
 implemented in C for speed, and is much faster than talking to
 [Watchman](https://github.com/facebook/watchman) using the JSON protocol.
 

--- a/ruby/ruby-watchman/ext/ruby-watchman/watchman.c
+++ b/ruby/ruby-watchman/ext/ruby-watchman/watchman.c
@@ -404,7 +404,7 @@ VALUE watchman_load_hash(char **ptr, char *end) {
  * Templated arrays are arrays of hashes which have repetitive key information
  * pulled out into a separate "headers" prefix.
  *
- * @see https://github.com/facebook/watchman/blob/master/BSER.markdown
+ * @see https://facebook.github.io/watchman/docs/bser.html
  */
 VALUE watchman_load_template(char **ptr, char *end) {
     int64_t header_items_count, i, row_count;

--- a/ruby/ruby-watchman/ext/ruby-watchman/watchman.h
+++ b/ruby/ruby-watchman/ext/ruby-watchman/watchman.h
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Methods for working with the Watchman binary protocol
  *
- * @see https://github.com/facebook/watchman/blob/master/BSER.markdown
+ * @see https://facebook.github.io/watchman/docs/bser.html
  */
 extern VALUE mRubyWatchman;
 


### PR DESCRIPTION
Hi!
`BSER.markdown` does not exist.
It seems https://facebook.github.io/watchman/docs/bser.html is correct doc.