### PR TITLE
Fix builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,11 @@ jobs:
   build-python27:
     <<: *defaults
     docker:
-      - image: python:2.7
+      - image: python:2.7-jessie
   build-python36:
     <<: *defaults
     docker:
-      - image: python:3.6
+      - image: python:3.6-jessie
 
 workflows:
   version: 2


### PR DESCRIPTION
Recently, the python:2.7 Docker image upgraded from Debian 8 Jessie to
Debian 9 Stretch. This upgrade broke installing the `npm` package;
Debian 9 Stretch doesn't have a package called `npm`. This means
Watchman's CircleCI builds are failing.

Fix the `npm` installation issue for CircleCI builds by reverting back
to a known good state (Debian 8 Jessie).