### PR TITLE
Fix test_restrictions with Python 2.6

### DIFF
--- a/tests/integration/test_restrictions.py
+++ b/tests/integration/test_restrictions.py
@@ -53,11 +53,11 @@ class TestWatchRestrictions(WatchmanTestCase.WatchmanTestCase):
         with self.assertRaises(pywatchman.WatchmanError) as ctx:
             client.query("watch", path)
         message = str(ctx.exception)
-        self.assertIn("unable to resolve root {}".format(path), message)
+        self.assertIn("unable to resolve root {0}".format(path), message)
         self.assertIn(
             (
                 "Your watchman administrator has configured watchman to "
-                + "prevent watching path `{}`"
+                + "prevent watching path `{0}`"
             ).format(path),
             message,
         )


### PR DESCRIPTION
Commit ef6948ba5b added some uses of str.format, but the format strings
don't work with Python 2.6. This causes the test_restrictions test to
fail on Travis CI. Make the format strings compatible with Python 2.6 to
make the build green again.