### PR TITLE
Add more help to libtoolize fail in autogen.sh to make consistent with pkg-config help

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,7 +8,7 @@ if test -d config.status ; then
 fi
 
 for p in libtoolize glibtoolize FAIL; do
-  test "$p" = FAIL && { echo "your system lacks libtoolize" 1>&2; exit 1; } || :
+  test "$p" = FAIL && { echo -e "your system lacks libtoolize\nplease install the libtool package for your system. " 1>&2; exit 1; } || :
   ( $p --version ) > /dev/null 2>&1 && { eval "libtoolize() { env $p; }"; break; } || :
 done
 libtoolize --no-warn -i -f


### PR DESCRIPTION
Ran into this tonight, figure this minor change could save some other users two minutes when building from source on a new system.

On missing `libtool` dependency, expanded output from `autogen.sh` from..

```bash
your system lacks libtoolize
```

to..

```bash
your system lacks libtoolize
please install the libtool package for your system.
```

This is borrowed from the same format used for missing `pkg-config` dependency, where output from `autogen.sh` helpfully states..

```bash
pkg-config appears to be missing (not available to autoconf tools)
please install the pkg-config package for your system.
```