### PR TITLE
Check CreateFileW() return value correctly

### DIFF
--- a/watcher/win32.cpp
+++ b/watcher/win32.cpp
@@ -68,7 +68,7 @@ WinWatcher::WinWatcher(w_root_t* root)
       OPEN_EXISTING,
       FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
       nullptr);
-  if (!dir_handle) {
+  if (dir_handle == INVALID_HANDLE_VALUE) {
     throw std::runtime_error(
         std::string("failed to open dir ") + root->root_path.c_str() + ": " +
         win32_strerror(GetLastError()));

--- a/watcher/win32.cpp
+++ b/watcher/win32.cpp
@@ -32,7 +32,7 @@ struct Item {
 
 struct WinWatcher : public Watcher {
   HANDLE ping{INVALID_HANDLE_VALUE}, olapEvent{INVALID_HANDLE_VALUE};
-  HANDLE dir_handle{INVALID_HANDLE_VALUE};
+  FileDescriptor dir_handle(INVALID_HANDLE_VALUE);
 
   std::condition_variable cond;
   watchman::Synchronized<std::list<Item>, std::mutex> changedItems;
@@ -63,7 +63,7 @@ WinWatcher::WinWatcher(w_root_t* root)
 
   // Create an overlapped handle so that we can avoid blocking forever
   // in ReadDirectoryChangesW
-  FileDescriptor dir_handle(intptr_t(CreateFileW(
+  dir_handle = intptr_t(CreateFileW(
     wpath.c_str(),
     GENERIC_READ,
     FILE_SHARE_READ | FILE_SHARE_DELETE | FILE_SHARE_WRITE,
@@ -71,7 +71,7 @@ WinWatcher::WinWatcher(w_root_t* root)
     OPEN_EXISTING,
     FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
     nullptr
-  )));
+  ));
 
   if (!dir_handle) {
     throw std::runtime_error(

--- a/watcher/win32.cpp
+++ b/watcher/win32.cpp
@@ -70,7 +70,7 @@ WinWatcher::WinWatcher(w_root_t* root)
     nullptr
   )));
 
-  if (dir_handle == INVALID_HANDLE_VALUE) {
+  if (!dir_handle) {
     throw std::runtime_error(
         std::string("failed to open dir ") + root->root_path.c_str() + ": " +
         win32_strerror(GetLastError()));

--- a/watcher/win32.cpp
+++ b/watcher/win32.cpp
@@ -3,6 +3,7 @@
 
 #include "watchman.h"
 #include "InMemoryView.h"
+#include "FileDescriptor.h"
 #include "watchman_synchronized.h"
 
 #include <algorithm>
@@ -11,6 +12,8 @@
 #include <iterator>
 #include <tuple>
 #include <mutex>
+
+using watchman::FileDescriptor;
 
 #ifdef _WIN32
 


### PR DESCRIPTION
CreateFileW() returns "INVALID_HANDLE_VALUE" if the handle is invalid.  Using the `if(!dir_handle)` does not correctly check for invalid handle value.

Code that reproduces this behaviour:
````
HANDLE x = INVALID_HANDLE_VALUE;
if (x == INVALID_HANDLE_VALUE)
{
	std::cerr << "Comparison with INVALID_HANDLE_VALUE." << std::endl;
}

if (!x)
{
	std::cerr << "Using the '!' operator." << std::endl;
}

````

Output for the above code: `Comparison with INVALID_HANDLE_VALUE`.