### PR TITLE
skip aio dead socket tests on windows

### DIFF
--- a/tests/async/test_dead_socket.py
+++ b/tests/async/test_dead_socket.py
@@ -12,6 +12,7 @@ import WatchmanInstance
 # Note this does not extend AsyncWatchmanTestCase as it wants to start its
 # own Watchman server instances per test.
 class TestDeadSocket(unittest.TestCase):
+    @unittest.skipIf(os.name == "nt", "not supported on windows")
     def test_query_dead_socket(self):
         async def test_core(wminst):
             with await pywatchman_aio.AIOClient.from_socket(
@@ -23,6 +24,7 @@ class TestDeadSocket(unittest.TestCase):
 
         self._async_runner(test_core)
 
+    @unittest.skipIf(os.name == "nt", "not supported on windows")
     def test_subscription_dead_socket(self):
         async def test_core(wminst):
             with await pywatchman_aio.AIOClient.from_socket(


### PR DESCRIPTION
pywatchman_aio currently only works on unix systems.