### PR TITLE
copy appveyor deps to artifact zip file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ test_script:
   - cmd: copy Release\watchman.pdb Watchman
   - cmd: copy LICENSE Watchman/LICENSE.txt
   - cmd: copy README.markdown Watchman
-  - cmd: python winbuild\copy-dyn-deps.py Release\watchman.exe Release c:\tools\vcpkg\installed\x64-windows\bin external\install\bin external\install\lib
+  - cmd: python winbuild\copy-dyn-deps.py Release\watchman.exe Watchman c:\tools\vcpkg\installed\x64-windows\bin external\install\bin external\install\lib
   - cmd: python runtests.py --watchman-path Release\watchman.exe --concurrency=1
   - cmd: ctest -C Release --output-on-failure
   - cmd: python runtests.py --watchman-path Release\watchman.exe --concurrency=1 --win7


### PR DESCRIPTION
I misread this and thought that they should go in the Release dir,
but really they should go into the Watchman dir so that they get
included in the zip file.