### PR TITLE
WIP: Adopt new getdeps for posix oss builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ defaults: &defaults
         command: python -V && env
     - run:
         name: Run build
+        no_output_timeout: 86400
         command: |
           export CCACHE_DIR=$HOME/.ccache
           mkdir -p $CCACHE_DIR
@@ -58,6 +59,7 @@ jobs:
           command: python -V && env
       - run:
           name: Run build
+          no_output_timeout: 86400
           command: |
             GETDEPS="build/fbcode_builder/getdeps.py"
             "$GETDEPS" build watchman

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - image: ubuntu:18.04
   mac:
     macos:
-      - xcode: "10.0.0"
+      xcode: 10.2.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,40 +11,27 @@ defaults: &defaults
           - build-linux-debug-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
         paths:
           - ~/.ccache
-          - ~/cmake-3.6.2-Linux-x86_64
-    - run:
-        name: Get newer cmake
-        command: |
-            if [ ! -d ~/cmake-3.6.2-Linux-x86_64 ]; then
-              echo "No cache - building CMake"
-              cd ~
-              # Note that this requires libidn.so.11
-              wget --quiet https://cmake.org/files/v3.6/cmake-3.6.2-Linux-x86_64.tar.gz
-              tar -xvf cmake-3.6.2-Linux-x86_64.tar.gz
-            else
-              echo "Cached CMake found"
-            fi
     - checkout
-    - run:
-        name: Run getdeps.py
-        command: python ./getdeps.py --install-deps -j2
     - run:
         name: Python version
         command: python -V && env
     - run:
         name: Run build
         command: |
-          export PATH=$HOME/cmake-3.6.2-Linux-x86_64/bin:$PATH
           export CCACHE_DIR=$HOME/.ccache
           mkdir -p $CCACHE_DIR
-          cmake .
-          make VERBOSE=1 -j2
-          make integration VERBOSE=1 -j2
+          GETDEPS="build/fbcode_builder/getdeps.py"
+          "$GETDEPS" build --enable-tests watchman
+          "$GETDEPS" test watchman
+          inst_dir=$("$GETDEPS" show-inst-dir watchman)
+          src_dir=$("$GETDEPS" show-source-dir watchman)
+          python "${src_dir}/runtests.py" \
+            --pybuild-dir="${inst_dir}/../../build/watchman/python/build" \
+            --watchman-path="${inst_dir}/bin/watchman"
     - save_cache:
         key: build-linux-debug-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
         paths:
           - ~/.ccache
-          - ~/cmake-3.6.2-Linux-x86_64
         when: always
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ defaults: &defaults
           export CCACHE_DIR=$HOME/.ccache
           mkdir -p $CCACHE_DIR
           GETDEPS="build/fbcode_builder/getdeps.py"
-          "$GETDEPS" build --enable-tests watchman
+          "$GETDEPS" build watchman
           "$GETDEPS" test watchman
           inst_dir=$("$GETDEPS" show-inst-dir watchman)
           src_dir=$("$GETDEPS" show-source-dir watchman)
@@ -48,6 +48,11 @@ jobs:
     <<: *defaults
     docker:
       - image: ubuntu:18.04
+  mac:
+    <<: *defaults
+    macos:
+      - image: "10.0.0"
+
 
 workflows:
   version: 2
@@ -56,3 +61,4 @@ workflows:
       #- build-python27
       #- build-python36
       - ubuntu-18.04
+      - mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,24 @@ jobs:
     docker:
       - image: ubuntu:18.04
   mac:
-    <<: *defaults
     macos:
-      - image: "10.0.0"
+      - xcode: "10.0.0"
+    steps:
+      - checkout
+      - run:
+          name: Python version
+          command: python -V && env
+      - run:
+          name: Run build
+          command: |
+            GETDEPS="build/fbcode_builder/getdeps.py"
+            "$GETDEPS" build watchman
+            "$GETDEPS" test watchman
+            inst_dir=$("$GETDEPS" show-inst-dir watchman)
+            src_dir=$("$GETDEPS" show-source-dir watchman)
+            python "${src_dir}/runtests.py" \
+              --pybuild-dir="${inst_dir}/../../build/watchman/python/build" \
+              --watchman-path="${inst_dir}/bin/watchman"
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ defaults: &defaults
           inst_dir=$("$GETDEPS" show-inst-dir watchman)
           src_dir=$("$GETDEPS" show-source-dir watchman)
           python "${src_dir}/runtests.py" \
+            --num-jobs=4 \
             --pybuild-dir="${inst_dir}/../../build/watchman/python/build" \
             --watchman-path="${inst_dir}/bin/watchman"
     - save_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,4 +78,4 @@ matrix:
 
 before_script: ./travis/deps.sh
 
-script: travis_wait 60 ./travis/run.sh
+script: ./travis/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,4 +78,4 @@ matrix:
 
 before_script: ./travis/deps.sh
 
-script: ./travis/run.sh
+script: travis_wait 60 ./travis/run.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
 install:
   - python -V
 
-build:
+build_script:
   - cmd: python build/fbcode_builder/getdeps.py build watchman -j2
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,45 +15,30 @@ init:
 install:
   - python -V
 
-before_build:
-  - cmd: git clean -dfx
-  - cmd: cd c:\tools\vcpkg
-  - cmd: git pull
-  # don't spend time and energy building debug builds
-  - echo.set(VCPKG_BUILD_TYPE release)>> triplets\x64-windows.cmake
-  - .\bootstrap-vcpkg.bat
-  - cmd: vcpkg version
-  - cmd: cd c:\projects\watchman
-  - cmd: python getdeps.py --install-deps -j2
-  - cmd: cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake .
-
 build:
-  project: ALL_BUILD.vcxproj
-  parallel: true
-
-cache:
-  - c:\tools\vcpkg\installed\
+  - cmd: python build/fbcode_builder/getdeps.py build watchman -j2
 
 test_script:
   - "cd node && npm install"
-  - cmd: mkdir Watchman
-  - cmd: copy Release\watchman.exe Watchman
-  - cmd: copy Release\watchman.pdb Watchman
-  - cmd: copy LICENSE Watchman/LICENSE.txt
-  - cmd: copy README.markdown Watchman
-  - cmd: python winbuild\copy-dyn-deps.py Release\watchman.exe Watchman c:\tools\vcpkg\installed\x64-windows\bin external\install\bin external\install\lib
-  - cmd: python runtests.py --watchman-path Release\watchman.exe --concurrency=1
-  - cmd: ctest -C Release --output-on-failure
-  - cmd: python runtests.py --watchman-path Release\watchman.exe --concurrency=1 --win7
+  - cmd: python build/fbcode_builder/getdeps.py test watchman -j2
+#  - cmd: mkdir Watchman
+#  - cmd: copy Release\watchman.exe Watchman
+#  - cmd: copy Release\watchman.pdb Watchman
+#  - cmd: copy LICENSE Watchman/LICENSE.txt
+#  - cmd: copy README.markdown Watchman
+#  - cmd: python winbuild\copy-dyn-deps.py Release\watchman.exe Watchman c:\tools\vcpkg\installed\x64-windows\bin external\install\bin external\install\lib
+#  - cmd: python runtests.py --watchman-path Release\watchman.exe --concurrency=1
+#  - cmd: ctest -C Release --output-on-failure
+#  - cmd: python runtests.py --watchman-path Release\watchman.exe --concurrency=1 --win7
 
-artifacts:
-  - path: watchman
-    name: watchman
-    type: zip
+#artifacts:
+#  - path: watchman
+#    name: watchman
+#    type: zip
 
 environment:
-  global:
-    WATCHMAN_BINARY: Release/watchman.exe
+  #global:
+  #  WATCHMAN_BINARY: Release/watchman.exe
     #BOOST_ROOT: C:/Libraries/boost_1_67_0
     #LIBEVENT_INCLUDE_DIR: C:/projects/watchman/external/install/include
     #LIBEVENT_LIB: C:/projects/watchman/external/install/lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - python -V
 
 build_script:
-  - cmd: python build/fbcode_builder/getdeps.py build watchman --num_jobs=2
+  - cmd: python build/fbcode_builder/getdeps.py build watchman --num-jobs=2
 
 test_script:
   - "cd node && npm install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,11 @@ install:
   - python -V
 
 build_script:
-  - cmd: python build/fbcode_builder/getdeps.py build watchman -j2
+  - cmd: python build/fbcode_builder/getdeps.py build watchman --num_jobs=2
 
 test_script:
   - "cd node && npm install"
-  - cmd: python build/fbcode_builder/getdeps.py test watchman -j2
+  - cmd: python build/fbcode_builder/getdeps.py test watchman --num-jobs=2
 #  - cmd: mkdir Watchman
 #  - cmd: copy Release\watchman.exe Watchman
 #  - cmd: copy Release\watchman.pdb Watchman

--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -51,7 +51,7 @@ class BuilderBase(object):
                 return [vcvarsall, "amd64", "&&"]
         return []
 
-    def _run_cmd(self, cmd, cwd=None, env=None):
+    def _run_cmd(self, cmd, cwd=None, env=None, log_file_name=None):
         if env:
             e = self.env.copy()
             e.update(env)
@@ -63,7 +63,7 @@ class BuilderBase(object):
         if cmd_prefix:
             cmd = cmd_prefix + cmd
 
-        run_cmd(cmd=cmd, env=env, cwd=cwd or self.build_dir)
+        run_cmd(cmd=cmd, env=env, cwd=cwd or self.build_dir, log_file_name=log_file_name)
 
     def build(self, install_dirs, reconfigure):
         print("Building %s..." % self.manifest.name)
@@ -596,7 +596,7 @@ class OpenSSLBuilder(BuilderBase):
                 "no-tests",
             ]
         )
-        self._run_cmd([make, "install_sw", "install_ssldirs"])
+        self._run_cmd([make, "install_sw", "install_ssldirs"], log_file_name=os.path.join(self.build_dir, "build.log"))
 
 
 class Boost(BuilderBase):
@@ -646,6 +646,7 @@ class Boost(BuilderBase):
                     "install",
                 ],
                 cwd=self.src_dir,
+                log_file_name=os.path.join(self.build_dir, "build.log"),
             )
 
 

--- a/build/fbcode_builder/manifests/watchman
+++ b/build/fbcode_builder/manifests/watchman
@@ -25,7 +25,7 @@ fbcode/eden/fs = eden/fs
 [shipit.strip]
 ^fbcode/eden/fs/(?!.*\.thrift|service/shipit_test_file\.txt)
 
-[cmake.defines]
+[cmake.defines.fb=on]
 ENABLE_EDEN_SUPPORT=ON
 
 # FB macos specific settings

--- a/travis/deps.sh
+++ b/travis/deps.sh
@@ -12,18 +12,7 @@ case "$OSTYPE" in
     # so let's force nodejs to be reinstalled and see if that helps.
     brew install nodejs || brew upgrade nodejs || true
 
-    # avoid snafu with OS X and python builds
-    #ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
-    #CFLAGS="$CFLAGS $ARCHFLAGS"
-    #export ARCHFLAGS CFLAGS
     case "$TRAVIS_PYTHON" in
-      python2.6)
-        pyenv install 2.6.9
-        eval "$(pyenv init -)"
-        pyenv global 2.6.9
-        # install some other required dependencies
-        pip2.6 install unittest2==1.1.0 argparse
-        ;;
       python2.7)
         pyenv install 2.7.11
         pyenv global 2.7.11
@@ -37,7 +26,8 @@ case "$OSTYPE" in
         pyenv global 3.6.1
     esac
 
-    HOMEBREW_NO_AUTO_UPDATE=1 ./getdeps.py --install-deps
+    #HOMEBREW_NO_AUTO_UPDATE=1 ./getdeps.py --install-deps
+    ./build/fbcode_builder/getdeps.py build watchman
     ;;
   *)
     ./getdeps.py

--- a/travis/deps.sh
+++ b/travis/deps.sh
@@ -25,12 +25,7 @@ case "$OSTYPE" in
         pyenv install 3.6.1
         pyenv global 3.6.1
     esac
-
-    #HOMEBREW_NO_AUTO_UPDATE=1 ./getdeps.py --install-deps
-    ./build/fbcode_builder/getdeps.py build watchman
     ;;
   *)
-    ./getdeps.py
     ;;
 esac
-cmake .

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -37,14 +37,17 @@ export TMPDIR TMP
 
 set +e
 
-make VERBOSE=1
+GETDEPS="build/fbcode_builder/getdeps.py"
 
-if ! make integration VERBOSE=1 ; then
-  exit 1
-fi
+"$GETDEPS" build --enable-tests watchman
+"$GETDEPS" test watchman
 
-make DESTDIR=$INST_TEST install
-find $INST_TEST
+inst_dir=$("$GETDEPS" show-inst-dir watchman)
+src_dir=$("$GETDEPS" show-source-dir watchman)
+
+python "${src_dir}/runtests.py" \
+  --pybuild-dir="${inst_dir}/../../build/watchman/python/build" \
+  --watchman-path="${inst_dir}/bin/watchman"
 
 exit 0
 

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -39,7 +39,7 @@ set +e
 
 GETDEPS="build/fbcode_builder/getdeps.py"
 
-"$GETDEPS" build --enable-tests watchman
+"$GETDEPS" build watchman
 "$GETDEPS" test watchman
 
 inst_dir=$("$GETDEPS" show-inst-dir watchman)


### PR DESCRIPTION
Try cutting the CI over to the new build runner.
I'm deliberately avoiding appveyor for the moment because we
need to wrangle some dynamic deps as part of its artifact build
and we're not ready for that.  It's better to leave it broken
for the time being so that the download link continues to point
to the last successful build.