### PR TITLE
Release bser v2.1.0

### DIFF
--- a/node/bser/package.json
+++ b/node/bser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bser",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "JavaScript implementation of the BSER Binary Serialization",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This creates a new bser version that fixes a deprecation warning for `new Buffer(size)` calls.