### PR TITLE
Add support for KDE neon

### DIFF
--- a/getdeps.py
+++ b/getdeps.py
@@ -453,7 +453,7 @@ def install_platform_deps():
         ).split()
         run_cmd(["yum", "install"] + pkgs)
         raise Exception("implement me")
-    elif os_name == "Ubuntu" or os_name.startswith("Debian"):
+    elif os_name == "Ubuntu" or os_name.startswith("Debian") or os_name.startswith("KDE neon"):
         # These dependencies have been tested on Ubuntu 16.04
         print("Installing necessary Ubuntu packages...")
         ubuntu_pkgs = (


### PR DESCRIPTION
KDE neon is based on the latest Ubuntu LTS version (currently 18.04), therefore Debian and Ubuntu dependency installation works here, too.

`./autogen.sh`, `make` and `make install` work fine on KDE neon with this modification. Tested on "KDE neon User Edition 5.16"