### PR TITLE
Change Read Timeout For Windows

### DIFF
--- a/python/bin/watchman-make
+++ b/python/bin/watchman-make
@@ -260,7 +260,12 @@ while True:
     try:
         # Wait for changes to start to occur.  We're happy to wait
         # quite some time for this
-        client.setTimeout(600)
+        if sys.platform == "win32":
+            # On Windows the way the socket is read a CTRL-C it takes this much
+            # time for a CTRL+C to get back out to us.
+            client.setTimeout(3)
+        else:
+            client.setTimeout(600)
 
         result = client.receive()
         for _, t in targets.items():


### PR DESCRIPTION
watchman-make's 10 minute client timeout, when running on Windows, means that after a CTRL+C a user may have to wait up to 10 minutes for the watchman-make script to exit.

This PR changes the timeout for Windows clients only to a default of 3 seconds. This should be high enough that the code isn't spamming excessively, but short enough that there's a reasonable response time   for script exit with CTRL+C.