### PR TITLE
ci/circle: use up-to-date cmake from apt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,25 +5,12 @@ defaults: &defaults
         name: Install dependencies
         command: |
           apt-get update
-          apt-get install -yq ccache libtool m4 python openssh-client git autoconf-archive bison build-essential curl flex git gperf joe libboost-all-dev libcap-dev libdouble-conversion-dev libevent-dev libgflags-dev libgoogle-glog-dev libkrb5-dev libpcre3-dev libnuma-dev libsasl2-dev libsnappy-dev libsqlite3-dev libssl-dev libtool netcat-openbsd pkg-config sudo unzip wget libpthread-stubs0-dev libidn11
+          apt-get install -yq cmake ccache libtool m4 python openssh-client git autoconf-archive bison build-essential curl flex git gperf joe libboost-all-dev libcap-dev libdouble-conversion-dev libevent-dev libgflags-dev libgoogle-glog-dev libkrb5-dev libpcre3-dev libnuma-dev libsasl2-dev libsnappy-dev libsqlite3-dev libssl-dev libtool netcat-openbsd pkg-config sudo unzip wget libpthread-stubs0-dev libidn11
     - restore_cache:
         keys:
           - build-linux-debug-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
         paths:
           - ~/.ccache
-          - ~/cmake-3.6.2-Linux-x86_64
-    - run:
-        name: Get newer cmake
-        command: |
-            if [ ! -d ~/cmake-3.6.2-Linux-x86_64 ]; then
-              echo "No cache - building CMake"
-              cd ~
-              # Note that this requires libidn.so.11
-              wget --quiet https://cmake.org/files/v3.6/cmake-3.6.2-Linux-x86_64.tar.gz
-              tar -xvf cmake-3.6.2-Linux-x86_64.tar.gz
-            else
-              echo "Cached CMake found"
-            fi
     - checkout
     - run:
         name: Run getdeps.py
@@ -34,7 +21,6 @@ defaults: &defaults
     - run:
         name: Run build
         command: |
-          export PATH=$HOME/cmake-3.6.2-Linux-x86_64/bin:$PATH
           export CCACHE_DIR=$HOME/.ccache
           mkdir -p $CCACHE_DIR
           cmake .
@@ -44,7 +30,6 @@ defaults: &defaults
         key: build-linux-debug-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
         paths:
           - ~/.ccache
-          - ~/cmake-3.6.2-Linux-x86_64
         when: always
 
 version: 2
@@ -52,11 +37,11 @@ jobs:
   build-python27:
     <<: *defaults
     docker:
-      - image: python:2.7-stretch
+      - image: python:2.7-buster
   build-python36:
     <<: *defaults
     docker:
-      - image: python:3.6-stretch
+      - image: python:3.6-buster
   ubuntu-18.04:
     <<: *defaults
     docker:


### PR DESCRIPTION
The ci is failing to build because the self-built "newer cmake" is not new enough. In fact, the cmake in the ubuntu 18.04 apt repository is at 3.10.2. Let's use that one instead.

Bumped debian up to buster because that's the newer stable Debian release with cmake 3.13.