### PR TITLE
List all the boost components used to silence CMake errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,10 @@ find_package(
   Boost 1.54.0 REQUIRED #1.54.0 or greater
   COMPONENTS
     context
+    filesystem
+    program_options
+    regex
+    system
     thread
 )
 


### PR DESCRIPTION
TravisCI cmake is failing due to these things. Shut it up.