### PR TITLE
watchman: rust: update tokio to 0.2.1

### DIFF
--- a/rust/watchman_client/Cargo.toml
+++ b/rust/watchman_client/Cargo.toml
@@ -17,12 +17,12 @@ serde = { version = "1", features = ["derive"] }
 serde_bser = { version = "0.2", path = "../serde_bser" }
 thiserror = ">=1.0.6"
 tokio = { version = "0.2.1", features = [
+    "io-util",
     "macros",
     "process",
+    "rt-core",
     "sync",
     "uds",
-    "io-util",
-    "rt-core",
 ] }
 serde_with_macros = "1.0"
 

--- a/rust/watchman_client/Cargo.toml
+++ b/rust/watchman_client/Cargo.toml
@@ -16,9 +16,14 @@ maplit = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_bser = { version = "0.2", path = "../serde_bser" }
 thiserror = ">=1.0.6"
-tokio = {version="0.2.0-alpha.6", features=["process"]}
-tokio-net = {version="0.2.0-alpha.6"}
-tokio-io = {version="0.2.0-alpha.6"}
+tokio = { version = "0.2.1", features = [
+    "macros",
+    "process",
+    "sync",
+    "uds",
+    "io-util",
+    "rt-core",
+] }
 serde_with_macros = "1.0"
 
 [target."cfg(windows)".dependencies]


### PR DESCRIPTION
watchman_client version 0.2.0 is pretty broken for me on rust 1.39.0.

I'm not sure how this was working before, but this at least fixes the compilation and 2 examples for me.

NOTE: I'm a rust noob, and the updated methods/imports are best guesses by what was available.

Test Plan:
Using rust 1.39.0 on macos:
- `cargo run --example glob` prints a list of files
- `cargo run --example subscribe` prints files and updates on file oprations
- `cargo test` passes fully
- Use `watchman_client = { path = "../watchman/rust/watchman_client" }` from a test project and see that compile now (it didn't with 0.2.0)