### PR TITLE
docs: s/OS X/macOS

### DIFF
--- a/opendir.cpp
+++ b/opendir.cpp
@@ -76,7 +76,7 @@ class DirHandle : public watchman_dir_handle {
 static DIR* opendir_nofollow(const char* path) {
   auto fd = openFileHandle(path, OpenFileHandleOptions::strictOpenDir());
 #if !defined(HAVE_FDOPENDIR) || defined(__APPLE__)
-  /* fdopendir doesn't work on earlier versions OS X, and we don't
+  /* fdopendir doesn't work on earlier versions macOS, and we don't
    * use this function since 10.10, as we prefer to use getattrlistbulk
    * in that case */
   return opendir(path);

--- a/travis/deps.sh
+++ b/travis/deps.sh
@@ -12,7 +12,7 @@ case "$OSTYPE" in
     # so let's force nodejs to be reinstalled and see if that helps.
     brew install nodejs || brew upgrade nodejs || true
 
-    # avoid snafu with OS X and python builds
+    # avoid snafu with macOS and python builds
     #ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
     #CFLAGS="$CFLAGS $ARCHFLAGS"
     #export ARCHFLAGS CFLAGS

--- a/watcher/kqueue.cpp
+++ b/watcher/kqueue.cpp
@@ -310,7 +310,7 @@ void KQueueWatcher::signalThreads() {
 
 static RegisterWatcher<KQueueWatcher> reg(
     "kqueue",
-    -1 /* last resort on OS X */);
+    -1 /* last resort on macOS */);
 
 #endif // HAVE_KQUEUE
 

--- a/watchman_ignore.h
+++ b/watchman_ignore.h
@@ -16,10 +16,10 @@ struct watchman_ignore {
   std::unordered_set<w_string> ignore_vcs;
   std::unordered_set<w_string> ignore_dirs;
   /* radix tree containing the same information as the ignore
-   * entries above.  This is used only on OS X and Windows because
+   * entries above.  This is used only on macOS and Windows because
    * we cannot exclude these dirs using the kernel watching APIs */
   art_tree<uint8_t, w_string> tree;
-  /* On OS X, we need to preserve the order of the ignore list so
+  /* On macOS, we need to preserve the order of the ignore list so
    * that we can exclude things deterministically and fit within
    * system limits. */
   std::vector<w_string> dirs_vec;

--- a/website/_docs/casefolding.markdown
+++ b/website/_docs/casefolding.markdown
@@ -8,7 +8,7 @@ permalink: docs/casefolding.html
 
 Watchman is currently completely unaware of case-insensitivity in file systems,
 and does not attempt to do any case-folding of file names. On a case-insensitive
-file system like Mac OS X's [HFS+](https://en.wikipedia.org/wiki/HFS_Plus), this
+file system like Mac macOS's [HFS+](https://en.wikipedia.org/wiki/HFS_Plus), this
 can manifest itself in different ways:
 
 * If a file `foo.txt` is renamed to `FOO.txt`, Watchman will report `FOO.txt` as

--- a/website/_docs/cmd.query.markdown
+++ b/website/_docs/cmd.query.markdown
@@ -200,7 +200,7 @@ effective value of infinity.
 *Since 2.9.9.*
 
 On systems where the watched root is a case insensitive filesystem (this is the
-common case for OS X and Windows), various name matching operations default to
+common case for macOS and Windows), various name matching operations default to
 case insensitive.
 
 *Since 4.7.*

--- a/website/_docs/cmd.watch.markdown
+++ b/website/_docs/cmd.watch.markdown
@@ -43,7 +43,7 @@ across a process restart.
 ## Case-Insensitivity
 
 Watchman has the following level of support for case-insensitive filesystems,
-starting in version 2.9.9 on OS X only:
+starting in version 2.9.9 on macOS only:
 
  * each watched root is queried to determine if it is case-insensitive.
    This is the common default for most Mac systems running HFS+.

--- a/website/_docs/configuration.markdown
+++ b/website/_docs/configuration.markdown
@@ -229,7 +229,7 @@ this to `0` to disable the periodic pruning operation.
 
 ### fsevents_latency
 
-Controls the latency parameter that is passed to `FSEventStreamCreate` on OS X.
+Controls the latency parameter that is passed to `FSEventStreamCreate` on macOS.
 The value is measured in seconds.  The fixed value of this parameter prior to
 version 3.2 of watchman was `0.0001` seconds.  Starting in version 3.2 of
 watchman, the default is now `0.01` seconds and can be controlled on a

--- a/website/_docs/contributing.markdown
+++ b/website/_docs/contributing.markdown
@@ -32,7 +32,7 @@ You will need:
 * automake
 * autoconf
 * cmake
-* libtool (or glibtool on OS X)
+* libtool (or glibtool on macOS)
 * libpcre
 * libfolly (only needed if building the cppclient library)
 * nodejs (for fb-watchman)

--- a/website/_docs/expr.match.md
+++ b/website/_docs/expr.match.md
@@ -30,7 +30,7 @@ case.
 *Since 2.9.9.*
 
 On systems where the watched root is a case insensitive filesystem (this is the
-common case for OS X and Windows), `match` is equivalent to `imatch`.
+common case for macOS and Windows), `match` is equivalent to `imatch`.
 
 *Since 4.7.*
 

--- a/website/_docs/expr.name.md
+++ b/website/_docs/expr.name.md
@@ -29,8 +29,8 @@ of `name`.
 
 *Since 2.9.9.*
 
-Starting in version 2.9.9, on OS X systems where the watched root is a case
-insensitive filesystem (this is the common case for OS X), `name` is equivalent
+Starting in version 2.9.9, on macOS systems where the watched root is a case
+insensitive filesystem (this is the common case for macOS), `name` is equivalent
 to `iname`.
 
 *Since 4.7.*

--- a/website/_docs/expr.pcre.md
+++ b/website/_docs/expr.pcre.md
@@ -26,8 +26,8 @@ case.
 
 *Since 2.9.9.*
 
-Starting in version 2.9.9, on OS X systems where the watched root is a case
-insensitive filesystem (this is the common case for OS X), `pcre` is equivalent
+Starting in version 2.9.9, on macOS systems where the watched root is a case
+insensitive filesystem (this is the common case for macOS), `pcre` is equivalent
 to `ipcre`.
 
 *Since 4.7.*

--- a/website/_docs/install.markdown
+++ b/website/_docs/install.markdown
@@ -70,7 +70,7 @@ this time, so you will need to follow these steps to download the binaries:
 
 ## Build/Install
 
-### Installing on macOS via Homebrew
+### Installing on macOS or Linux via Homebrew
 
 To build the most recent release currently tracked by
 [Homebrew](http://brew.sh/):

--- a/website/_docs/install.markdown
+++ b/website/_docs/install.markdown
@@ -11,7 +11,7 @@ permalink: docs/install.html
 Watchman is known to compile and pass its test suite on:
 
  * <i class="fa fa-linux"></i> Linux systems with `inotify`
- * <i class="fa fa-apple"></i> OS X (uses `FSEvents` on 10.7+,
+ * <i class="fa fa-apple"></i> macOS (uses `FSEvents` on 10.7+,
    `kqueue(2)` on earlier versions)
  * <i class="fa fa-windows"></i> Windows x64 on Windows 7,
    Windows Server 2012 R2 and later is currently in **beta** status.
@@ -70,7 +70,7 @@ this time, so you will need to follow these steps to download the binaries:
 
 ## Build/Install
 
-### Installing on OS X via Homebrew
+### Installing on macOS via Homebrew
 
 To build the most recent release currently tracked by
 [Homebrew](http://brew.sh/):
@@ -86,7 +86,7 @@ To install the latest build from github:
 $ brew install --HEAD watchman
 ```
 
-### Installing on OS X via macports
+### Installing on macOS via macports
 
 To install the package maintained by [MacPorts](https://www.macports.org):
 
@@ -97,7 +97,7 @@ $ sudo port install watchman
 ### Installing from source
 
 You can use these steps below to get watchman built.  You will need `libssl-dev`,
-`autoconf`, `automake` and `libtool` (or `glibtool` on OS X).
+`autoconf`, `automake` and `libtool` (or `glibtool` on macOS).
 
 You may optionally build watchman without `pcre` and `python` support (see
 configuration options below).
@@ -204,9 +204,9 @@ haven't actually changed.
 
 ### Mac OS File Descriptor Limits
 
-*Only applicable on OS X 10.6 and earlier*
+*Only applicable on macOS 10.6 and earlier*
 
-The default per-process descriptor limit on OS X is extremely low (256!).
+The default per-process descriptor limit on macOS is extremely low (256!).
 
 Watchman will attempt to raise its descriptor limit to match
 `kern.maxfilesperproc` when it starts up, so you shouldn't need to mess with
@@ -220,7 +220,7 @@ $ sudo sysctl -w kern.maxfiles=10485760
 $ sudo sysctl -w kern.maxfilesperproc=1048576
 ```
 
-Putting the following into a file named `/etc/sysctl.conf` on OS X will cause
+Putting the following into a file named `/etc/sysctl.conf` on macOS will cause
 these values to persist across reboots:
 
 ```

--- a/website/_docs/release-notes.markdown
+++ b/website/_docs/release-notes.markdown
@@ -189,7 +189,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 ### Watchman 4.3.0 (2015-12-14)
 
 * Improved handling of case insensitive renames; halved the memory usage
-  and doubled crawl speed on OS X.
+  and doubled crawl speed on macOS.
 
 ### Watchman 4.2.0 (2015-12-08)
 
@@ -197,7 +197,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
   whether the leaf of a directory tree is a symlink, we now check each
   component down from the root of the watch.  This improves detection
   and processing for directory-to-symlink (and vice versa) transitions.
-* Increased priority of the watchman process on OS X.
+* Increased priority of the watchman process on macOS.
 
 ### pywatchman 1.3.0 (2015-10-22)
 
@@ -206,7 +206,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 
 ### Watchman 4.1.0 (2015-10-20)
 
-* Fixed an issue where symlink size was always reported as 0 on OS X
+* Fixed an issue where symlink size was always reported as 0 on macOS
   using the new bulkstat functionality
 
 ### Watchman 4.0.0 (2015-10-19)
@@ -219,17 +219,17 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 
 ### Watchman 3.9.0 (2015-10-12)
 
-* Fixed an issue where dir renames on OS X could cause us to lose track of
+* Fixed an issue where dir renames on macOS could cause us to lose track of
   the files inside the renamed dir
 * Fixed an issue where dir deletes and replacements on Linux could cause us
-  to lose track of the files inside the replaced dir (similar to the OS X issue
+  to lose track of the files inside the replaced dir (similar to the macOS issue
   above in manifestation, but a different root cause).
 * Improved (re)crawl speed for dirs with more than a couple of entries on average
   (improvement can be up to 5x for dirs with up to 64 entries on average).
   You may now tune the `hint_num_files_per_dir` setting in your
   `.watchmanconfig` to better match your tree.  [More details](
   /watchman/docs/config.html#hint_num_files_per_dir)
-* Improved (re)crawl speed on OS X 10.10 and later by using `getattrlistbulk`.
+* Improved (re)crawl speed on macOS 10.10 and later by using `getattrlistbulk`.
   This allows us to improve the data:syscall ratio during crawling and can
   improve throughput by up to 40% for larger trees.
 * Add optional `sync_timeout` to the `clock` command
@@ -238,7 +238,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 * Fixed a race condition where we could start two sets of watcher threads
   for the same dir if two clients issue a `watch` or `watch-project` at
   the same time
-* Added a helpful error for a tmux + launchd issue on OS X
+* Added a helpful error for a tmux + launchd issue on macOS
 
 ### Watchman 3.8.0 (2015-09-14)
 

--- a/website/_docs/release-notes.markdown
+++ b/website/_docs/release-notes.markdown
@@ -99,7 +99,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 	BSERv2 can carry information about string encoding over the wire. This lets
 	pywatchman convert to Unicode strings on Python 3. Clients and servers know how
 	to  transparently fall back to BSERv1.
-* macOS: we no longer use socket activation when registering with launchd.
+* OS X: we no longer use socket activation when registering with launchd.
   This was the source of some upgrade problems for mac Homebrew users.
 
 ### Watchman 4.7.0 (2016-09-10)
@@ -128,13 +128,13 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 
 * Improved I/O scheduling when processing recursive deletes and deep directory
   rename operations.
-* Improved performance of the `ignore_dirs` configuration option on macOS and
+* Improved performance of the `ignore_dirs` configuration option on OS X and
   Windows systems.  We take advantage of an undocumented (but supported!)
   API to further accelerate this for the first 8 entries in the `ignore_dirs`
-  on macOS.  Users that depend on this configuration to avoid recrawls will
+  on OS X.  Users that depend on this configuration to avoid recrawls will
   want to review and prioritize their most active build dirs to the front
   of the `ignore_dirs` specified in their `.watchmanconfig` file.
-* Added an optional recrawl recovery strategy for macOS that will attempt to
+* Added an optional recrawl recovery strategy for OS X that will attempt to
   resync from the fseventsd journal rather than performing a full filesystem
   walk.  This is currently disabled by default but will likely be enabled
   by default in the next Watchman release.  You can enable this by setting
@@ -144,7 +144,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
   large trees.
 * Fixed accidental exponential time complexity issue with recursive deletes
   and deep directory rename operations on case-insensitive filesystems (such as
-  macOS).  This manifested as high CPU utilization for extended periods of time.
+  OS X).  This manifested as high CPU utilization for extended periods of time.
 * Added support for allowing non-owner access to a Watchman instance.  Only
   the owner is authorized to create or delete watches.  Non-owners can view
   information about existing watches.  Access control is based on unix domain
@@ -189,7 +189,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 ### Watchman 4.3.0 (2015-12-14)
 
 * Improved handling of case insensitive renames; halved the memory usage
-  and doubled crawl speed on macOS.
+  and doubled crawl speed on OS X.
 
 ### Watchman 4.2.0 (2015-12-08)
 
@@ -197,7 +197,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
   whether the leaf of a directory tree is a symlink, we now check each
   component down from the root of the watch.  This improves detection
   and processing for directory-to-symlink (and vice versa) transitions.
-* Increased priority of the watchman process on macOS.
+* Increased priority of the watchman process on OS X.
 
 ### pywatchman 1.3.0 (2015-10-22)
 
@@ -206,7 +206,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 
 ### Watchman 4.1.0 (2015-10-20)
 
-* Fixed an issue where symlink size was always reported as 0 on macOS
+* Fixed an issue where symlink size was always reported as 0 on OS X
   using the new bulkstat functionality
 
 ### Watchman 4.0.0 (2015-10-19)
@@ -219,17 +219,17 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 
 ### Watchman 3.9.0 (2015-10-12)
 
-* Fixed an issue where dir renames on macOS could cause us to lose track of
+* Fixed an issue where dir renames on OS X could cause us to lose track of
   the files inside the renamed dir
 * Fixed an issue where dir deletes and replacements on Linux could cause us
-  to lose track of the files inside the replaced dir (similar to the macOS issue
+  to lose track of the files inside the replaced dir (similar to the OS X issue
   above in manifestation, but a different root cause).
 * Improved (re)crawl speed for dirs with more than a couple of entries on average
   (improvement can be up to 5x for dirs with up to 64 entries on average).
   You may now tune the `hint_num_files_per_dir` setting in your
   `.watchmanconfig` to better match your tree.  [More details](
   /watchman/docs/config.html#hint_num_files_per_dir)
-* Improved (re)crawl speed on macOS 10.10 and later by using `getattrlistbulk`.
+* Improved (re)crawl speed on OS X 10.10 and later by using `getattrlistbulk`.
   This allows us to improve the data:syscall ratio during crawling and can
   improve throughput by up to 40% for larger trees.
 * Add optional `sync_timeout` to the `clock` command
@@ -238,7 +238,7 @@ Whoops, we never got around to tagging this beyond a release candidate tag!
 * Fixed a race condition where we could start two sets of watcher threads
   for the same dir if two clients issue a `watch` or `watch-project` at
   the same time
-* Added a helpful error for a tmux + launchd issue on macOS
+* Added a helpful error for a tmux + launchd issue on OS X
 
 ### Watchman 3.8.0 (2015-09-14)
 

--- a/website/_docs/troubleshooting.markdown
+++ b/website/_docs/troubleshooting.markdown
@@ -57,7 +57,7 @@ accordingly.
 
 ### kFSEventStreamEventFlagUserDropped
 
-OS X has a similar internal limit and behavior when that limit is exceeded.
+macOS has a similar internal limit and behavior when that limit is exceeded.
 If you're encountering a message like:
 
 ```
@@ -185,7 +185,7 @@ limits.
 
 ## FSEvents
 
-FSEvents is the file watching facility on OS X.  There are few diagnostics
+FSEvents is the file watching facility on macOS.  There are few diagnostics
 that can help diagnose issues with FSEvents; the API itself gives little
 feedback on a number of error cases and instead emits rather cryptic error
 messages to the log file.
@@ -229,7 +229,7 @@ progressively more invasive:
 * Restart the fsevents service: `sudo pkill -9 -x fseventsd`
 * Restart your computer
 
-## Triggers/Subscriptions don't fire on OS X
+## Triggers/Subscriptions don't fire on macOS
 
 There is a rare fsevents bug that can prevent any notifications from working
 in directories where the case of the name of a directory in the kernel has


### PR DESCRIPTION
This is a documentation change only to use the preferred name for the macOS operating system.

Justification:
It has been four years since Apple renamed **OS X** to **macOS**.
Also note that the bottle Homebrew now only supports [macOS Sierra](https://github.com/Homebrew/homebrew-core/blob/ff9bd877e442f32790267f114234413b9ee540a5/Formula/watchman.rb#L19-L22) and later (which is when Apple made the change to the new name). A Linux Homebrew formula is [also available from core](https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/watchman.rb#L22-L23) so I made that change as well.


