### PR TITLE
Fix boost related build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,112 +250,112 @@ jobs:
     - name: Fix Git config
       run: git config --system core.longpaths true
     - name: Fetch boost
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests boost
     - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch flex
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests flex
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests flex
     - name: Fetch libsodium
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests libsodium
     - name: Fetch ninja
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ninja
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests ninja
     - name: Fetch cmake
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests cmake
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests cmake
     - name: Fetch googletest
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests googletest
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests googletest
     - name: Fetch pcre
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests pcre
     - name: Fetch fmt
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fmt
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests fmt
     - name: Fetch python-six
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests python-six
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests python-six
     - name: Fetch zstd
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zstd
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests zstd
     - name: Fetch double-conversion
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
     - name: Fetch gflags
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gflags
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests gflags
     - name: Fetch glog
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests glog
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests glog
     - name: Fetch snappy
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests snappy
     - name: Fetch zlib
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zlib
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests zlib
     - name: Fetch perl
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests perl
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests perl
     - name: Fetch openssl
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests openssl
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests openssl
     - name: Fetch libevent
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests libevent
     - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests folly
     - name: Fetch fizz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch rsocket-cpp
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests rsocket-cpp
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests rsocket-cpp
     - name: Fetch wangle
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests wangle
     - name: Fetch fbthrift
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fbthrift
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests fbthrift
     - name: Fetch fb303
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fb303
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests fb303
     - name: Build boost
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
+      run: python build/fbcode_builder/getdeps.py build --no-tests boost
     - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
+      run: python build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build flex
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests flex
+      run: python build/fbcode_builder/getdeps.py build --no-tests flex
     - name: Build libsodium
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
+      run: python build/fbcode_builder/getdeps.py build --no-tests libsodium
     - name: Build ninja
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
+      run: python build/fbcode_builder/getdeps.py build --no-tests ninja
     - name: Build cmake
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
+      run: python build/fbcode_builder/getdeps.py build --no-tests cmake
     - name: Build googletest
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
+      run: python build/fbcode_builder/getdeps.py build --no-tests googletest
     - name: Build pcre
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre
+      run: python build/fbcode_builder/getdeps.py build --no-tests pcre
     - name: Build fmt
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
+      run: python build/fbcode_builder/getdeps.py build --no-tests fmt
     - name: Build python-six
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests python-six
+      run: python build/fbcode_builder/getdeps.py build --no-tests python-six
     - name: Build zstd
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
+      run: python build/fbcode_builder/getdeps.py build --no-tests zstd
     - name: Build double-conversion
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
+      run: python build/fbcode_builder/getdeps.py build --no-tests double-conversion
     - name: Build gflags
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
+      run: python build/fbcode_builder/getdeps.py build --no-tests gflags
     - name: Build glog
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
+      run: python build/fbcode_builder/getdeps.py build --no-tests glog
     - name: Build snappy
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
+      run: python build/fbcode_builder/getdeps.py build --no-tests snappy
     - name: Build zlib
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
+      run: python build/fbcode_builder/getdeps.py build --no-tests zlib
     - name: Build perl
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests perl
+      run: python build/fbcode_builder/getdeps.py build --no-tests perl
     - name: Build openssl
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
+      run: python build/fbcode_builder/getdeps.py build --no-tests openssl
     - name: Build libevent
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
+      run: python build/fbcode_builder/getdeps.py build --no-tests libevent
     - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+      run: python build/fbcode_builder/getdeps.py build --no-tests folly
     - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
+      run: python build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build rsocket-cpp
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests rsocket-cpp
+      run: python build/fbcode_builder/getdeps.py build --no-tests rsocket-cpp
     - name: Build wangle
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
+      run: python build/fbcode_builder/getdeps.py build --no-tests wangle
     - name: Build fbthrift
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fbthrift
+      run: python build/fbcode_builder/getdeps.py build --no-tests fbthrift
     - name: Build fb303
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fb303
+      run: python build/fbcode_builder/getdeps.py build --no-tests fb303
     - name: Build watchman
-      run: python3 build/fbcode_builder/getdeps.py build --src-dir=. watchman
+      run: python build/fbcode_builder/getdeps.py build --src-dir=. watchman
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. watchman _artifacts/windows
+      run: python build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. watchman _artifacts/windows
     - uses: actions/upload-artifact@master
       with:
         name: watchman
         path: _artifacts
     - name: Test watchman
-      run: python3 build/fbcode_builder/getdeps.py test --src-dir=. watchman
+      run: python build/fbcode_builder/getdeps.py test --src-dir=. watchman

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -251,6 +251,8 @@ jobs:
     runs-on: windows-2016
     steps:
     - uses: actions/checkout@v1
+    - name: Show environment
+      run: gci env:* | sort-object name
     - name: Fix Git config
       run: git config --system core.longpaths true
     - name: Fetch boost

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,347 +15,353 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
+    - name: Install system deps
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive watchman
     - name: Fetch boost
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch ninja
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch googletest
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch pcre
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests pcre
     - name: Fetch fmt
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch python-six
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests python-six
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-six
     - name: Fetch zstd
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch double-conversion
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch gflags
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch libevent
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch snappy
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch rsocket-cpp
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests rsocket-cpp
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rsocket-cpp
     - name: Fetch autoconf
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests bison
     - name: Fetch libsodium
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch fizz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch flex
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests flex
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests flex
     - name: Fetch wangle
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fbthrift
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fbthrift
     - name: Fetch fb303
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fb303
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Build boost
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
     - name: Build ninja
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Build cmake
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
     - name: Build googletest
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
     - name: Build pcre
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests pcre
     - name: Build fmt
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
     - name: Build python-six
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests python-six
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-six
     - name: Build zstd
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
     - name: Build double-conversion
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
     - name: Build gflags
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
     - name: Build glog
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
     - name: Build libevent
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
     - name: Build snappy
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
     - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Build rsocket-cpp
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests rsocket-cpp
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests rsocket-cpp
     - name: Build autoconf
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
     - name: Build automake
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests automake
     - name: Build libtool
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
     - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests bison
     - name: Build libsodium
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
     - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
     - name: Build flex
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests flex
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests flex
     - name: Build wangle
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
     - name: Build fbthrift
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fbthrift
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fbthrift
     - name: Build fb303
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fb303
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fb303
     - name: Build watchman
-      run: python3 build/fbcode_builder/getdeps.py build --src-dir=. watchman
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. watchman _artifacts/linux
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/linux
     - uses: actions/upload-artifact@master
       with:
         name: watchman
         path: _artifacts
     - name: Test watchman
-      run: python3 build/fbcode_builder/getdeps.py test --src-dir=. watchman
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. watchman
   mac:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Install system deps
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive watchman
     - name: Fetch boost
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch openssl
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests openssl
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch ninja
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch googletest
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch pcre
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests pcre
     - name: Fetch fmt
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch python-six
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests python-six
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-six
     - name: Fetch zstd
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch double-conversion
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch gflags
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch libevent
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch snappy
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch rsocket-cpp
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests rsocket-cpp
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rsocket-cpp
     - name: Fetch autoconf
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests bison
     - name: Fetch libsodium
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch fizz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch flex
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests flex
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests flex
     - name: Fetch wangle
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fbthrift
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fbthrift
     - name: Fetch fb303
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fb303
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Build boost
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
     - name: Build openssl
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests openssl
     - name: Build ninja
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Build cmake
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
     - name: Build googletest
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
     - name: Build pcre
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests pcre
     - name: Build fmt
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
     - name: Build python-six
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests python-six
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-six
     - name: Build zstd
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
     - name: Build double-conversion
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
     - name: Build gflags
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
     - name: Build glog
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
     - name: Build libevent
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
     - name: Build snappy
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
     - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Build rsocket-cpp
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests rsocket-cpp
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests rsocket-cpp
     - name: Build autoconf
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
     - name: Build automake
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests automake
     - name: Build libtool
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
     - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests bison
     - name: Build libsodium
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
     - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
     - name: Build flex
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests flex
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests flex
     - name: Build wangle
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
     - name: Build fbthrift
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fbthrift
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fbthrift
     - name: Build fb303
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fb303
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fb303
     - name: Build watchman
-      run: python3 build/fbcode_builder/getdeps.py build --src-dir=. watchman
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. watchman _artifacts/mac
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/mac
     - uses: actions/upload-artifact@master
       with:
         name: watchman
         path: _artifacts
     - name: Test watchman
-      run: python3 build/fbcode_builder/getdeps.py test --src-dir=. watchman
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. watchman
   windows:
     runs-on: windows-2016
     steps:
     - uses: actions/checkout@v1
     - name: Fix Git config
       run: git config --system core.longpaths true
+    - name: Install system deps
+      run: sudo python build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive watchman
     - name: Fetch boost
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests boost
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch bison
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests bison
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests bison
     - name: Fetch flex
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests flex
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests flex
     - name: Fetch libsodium
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests libsodium
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch ninja
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests ninja
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests cmake
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch googletest
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests googletest
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch pcre
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests pcre
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests pcre
     - name: Fetch fmt
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests fmt
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch python-six
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests python-six
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-six
     - name: Fetch zstd
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests zstd
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch double-conversion
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch gflags
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests gflags
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests glog
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch snappy
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests snappy
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch zlib
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests zlib
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch perl
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests perl
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests perl
     - name: Fetch openssl
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests openssl
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch libevent
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests libevent
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch folly
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests folly
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests fizz
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch rsocket-cpp
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests rsocket-cpp
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rsocket-cpp
     - name: Fetch wangle
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests wangle
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests fbthrift
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fbthrift
     - name: Fetch fb303
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests fb303
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Build boost
-      run: python build/fbcode_builder/getdeps.py build --no-tests boost
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
     - name: Build bison
-      run: python build/fbcode_builder/getdeps.py build --no-tests bison
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests bison
     - name: Build flex
-      run: python build/fbcode_builder/getdeps.py build --no-tests flex
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests flex
     - name: Build libsodium
-      run: python build/fbcode_builder/getdeps.py build --no-tests libsodium
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
     - name: Build ninja
-      run: python build/fbcode_builder/getdeps.py build --no-tests ninja
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Build cmake
-      run: python build/fbcode_builder/getdeps.py build --no-tests cmake
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
     - name: Build googletest
-      run: python build/fbcode_builder/getdeps.py build --no-tests googletest
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
     - name: Build pcre
-      run: python build/fbcode_builder/getdeps.py build --no-tests pcre
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests pcre
     - name: Build fmt
-      run: python build/fbcode_builder/getdeps.py build --no-tests fmt
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
     - name: Build python-six
-      run: python build/fbcode_builder/getdeps.py build --no-tests python-six
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-six
     - name: Build zstd
-      run: python build/fbcode_builder/getdeps.py build --no-tests zstd
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
     - name: Build double-conversion
-      run: python build/fbcode_builder/getdeps.py build --no-tests double-conversion
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
     - name: Build gflags
-      run: python build/fbcode_builder/getdeps.py build --no-tests gflags
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
     - name: Build glog
-      run: python build/fbcode_builder/getdeps.py build --no-tests glog
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
     - name: Build snappy
-      run: python build/fbcode_builder/getdeps.py build --no-tests snappy
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
     - name: Build zlib
-      run: python build/fbcode_builder/getdeps.py build --no-tests zlib
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zlib
     - name: Build perl
-      run: python build/fbcode_builder/getdeps.py build --no-tests perl
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests perl
     - name: Build openssl
-      run: python build/fbcode_builder/getdeps.py build --no-tests openssl
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests openssl
     - name: Build libevent
-      run: python build/fbcode_builder/getdeps.py build --no-tests libevent
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
     - name: Build folly
-      run: python build/fbcode_builder/getdeps.py build --no-tests folly
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Build fizz
-      run: python build/fbcode_builder/getdeps.py build --no-tests fizz
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
     - name: Build rsocket-cpp
-      run: python build/fbcode_builder/getdeps.py build --no-tests rsocket-cpp
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests rsocket-cpp
     - name: Build wangle
-      run: python build/fbcode_builder/getdeps.py build --no-tests wangle
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
     - name: Build fbthrift
-      run: python build/fbcode_builder/getdeps.py build --no-tests fbthrift
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fbthrift
     - name: Build fb303
-      run: python build/fbcode_builder/getdeps.py build --no-tests fb303
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fb303
     - name: Build watchman
-      run: python build/fbcode_builder/getdeps.py build --src-dir=. watchman
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman
     - name: Copy artifacts
-      run: python build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. watchman _artifacts/windows
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/windows
     - uses: actions/upload-artifact@master
       with:
         name: watchman
         path: _artifacts
     - name: Test watchman
-      run: python build/fbcode_builder/getdeps.py test --src-dir=. watchman
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. watchman

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -253,8 +253,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Fix Git config
       run: git config --system core.longpaths true
-    - name: Install system deps
-      run: sudo python build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive watchman
     - name: Fetch boost
       run: python build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch bison

--- a/.projectid
+++ b/.projectid
@@ -1,0 +1,1 @@
+watchman

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -693,9 +693,9 @@ jobs:
             # that we want it to use them!
             out.write("    - name: Fix Git config\n")
             out.write("      run: git config --system core.longpaths true\n")
-
-        out.write("    - name: Install system deps\n")
-        out.write(f"      run: sudo {getdeps} install-system-deps --recursive {manifest.name}\n")
+        else:
+            out.write("    - name: Install system deps\n")
+            out.write(f"      run: sudo {getdeps} install-system-deps --recursive {manifest.name}\n")
 
         projects = loader.manifests_in_dependency_order()
 

--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -393,6 +393,13 @@ def setup_build_options(args, host_type=None):
                     temp = tempfile.gettempdir()
 
                 scratch_dir = os.path.join(temp, "fbcode_builder_getdeps-%s" % munged)
+                if not is_windows() and os.geteuid() == 0:
+                    # Running as root; in the case where someone runs
+                    # sudo getdeps.py install-system-deps
+                    # and then runs as build without privs, we want to avoid creating
+                    # a scratch dir that the second stage cannot write to.
+                    # So we generate a different path if we are root.
+                    scratch_dir += "-root"
 
         if not os.path.exists(scratch_dir):
             os.makedirs(scratch_dir)

--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -65,6 +65,7 @@ class BuildOptions(object):
         num_jobs=0,
         use_shipit=False,
         vcvars_path=None,
+        allow_system_packages=False,
     ):
         """ fbcode_builder_dir - the path to either the in-fbsource fbcode_builder dir,
                                  or for shipit-transformed repos, the build dir that
@@ -118,6 +119,7 @@ class BuildOptions(object):
         self.fbcode_builder_dir = fbcode_builder_dir
         self.host_type = host_type
         self.use_shipit = use_shipit
+        self.allow_system_packages = allow_system_packages
         if vcvars_path is None and is_windows():
 
             # On Windows, the compiler is not available in the PATH by
@@ -420,4 +422,5 @@ def setup_build_options(args, host_type=None):
         num_jobs=args.num_jobs,
         use_shipit=args.use_shipit,
         vcvars_path=args.vcvars_path,
+        allow_system_packages=args.allow_system_packages,
     )

--- a/build/fbcode_builder/getdeps/fetcher.py
+++ b/build/fbcode_builder/getdeps/fetcher.py
@@ -185,17 +185,7 @@ class SystemPackageFetcher(object):
 
 class PreinstalledNopFetcher(SystemPackageFetcher):
     def __init__(self):
-        pass
-
-    def update(self):
-        assert self.installed
-        return ChangeStatus(all_changed=False)
-
-    def hash(self):
-        return "0" * 40
-
-    def get_src_dir(self):
-        return None
+        self.installed = True
 
 
 class GitFetcher(Fetcher):

--- a/build/fbcode_builder/getdeps/fetcher.py
+++ b/build/fbcode_builder/getdeps/fetcher.py
@@ -183,6 +183,21 @@ class SystemPackageFetcher(object):
         return None
 
 
+class PreinstalledNopFetcher(SystemPackageFetcher):
+    def __init__(self):
+        pass
+
+    def update(self):
+        assert self.installed
+        return ChangeStatus(all_changed=False)
+
+    def hash(self):
+        return "0" * 40
+
+    def get_src_dir(self):
+        return None
+
+
 class GitFetcher(Fetcher):
     DEFAULT_DEPTH = 100
 

--- a/build/fbcode_builder/getdeps/fetcher.py
+++ b/build/fbcode_builder/getdeps/fetcher.py
@@ -148,6 +148,41 @@ class LocalDirFetcher(object):
         return self.path
 
 
+class SystemPackageFetcher(object):
+    def __init__(self, build_options, packages):
+        self.manager = build_options.host_type.get_package_manager()
+        self.packages = packages.get(self.manager)
+        if self.packages:
+            self.installed = None
+        else:
+            self.installed = False
+
+    def packages_are_installed(self):
+        if self.installed is not None:
+            return self.installed
+
+        if self.manager == "rpm":
+            result = run_cmd(["rpm", "-q"] + self.packages, allow_fail=True)
+            self.installed = result == 0
+        elif self.manager == "deb":
+            result = run_cmd(["dpkg", "-s"] + self.packages, allow_fail=True)
+            self.installed = result == 0
+        else:
+            self.installed = False
+
+        return self.installed
+
+    def update(self):
+        assert self.installed
+        return ChangeStatus(all_changed=False)
+
+    def hash(self):
+        return "0" * 40
+
+    def get_src_dir(self):
+        return None
+
+
 class GitFetcher(Fetcher):
     DEFAULT_DEPTH = 100
 

--- a/build/fbcode_builder/getdeps/manifest.py
+++ b/build/fbcode_builder/getdeps/manifest.py
@@ -336,6 +336,7 @@ class ManifestParser(object):
             return False
         for key in envs:
             val = os.environ.get(key, None)
+            print(f"Testing ENV[{key}]: {repr(val)}")
             if val is None:
                 return False
             if len(val) == 0:

--- a/build/fbcode_builder/getdeps/platform.py
+++ b/build/fbcode_builder/getdeps/platform.py
@@ -87,6 +87,15 @@ class HostType(object):
             self.distrovers or "none",
         )
 
+    def get_package_manager(self):
+        if not self.is_linux():
+            return None
+        if self.distro in ("fedora", "centos"):
+            return "rpm"
+        if self.distro in ("debian", "ubuntu"):
+            return "deb"
+        return None
+
     @staticmethod
     def from_tuple_string(s):
         ostype, distro, distrovers = s.split("-")

--- a/build/fbcode_builder/getdeps/runcmd.py
+++ b/build/fbcode_builder/getdeps/runcmd.py
@@ -54,9 +54,9 @@ def run_cmd(cmd, env=None, cwd=None, allow_fail=False, log_file=None):
                 log.write(msg)
                 sys.stdout.write(msg)
 
-            _run_cmd(cmd, env=env, cwd=cwd, allow_fail=allow_fail, log_fn=log_function)
+            return _run_cmd(cmd, env=env, cwd=cwd, allow_fail=allow_fail, log_fn=log_function)
     else:
-        _run_cmd(cmd, env=env, cwd=cwd, allow_fail=allow_fail, log_fn=sys.stdout.write)
+        return _run_cmd(cmd, env=env, cwd=cwd, allow_fail=allow_fail, log_fn=sys.stdout.write)
 
 
 def _run_cmd(cmd, env, cwd, allow_fail, log_fn):

--- a/build/fbcode_builder/manifests/autoconf
+++ b/build/fbcode_builder/manifests/autoconf
@@ -1,6 +1,12 @@
 [manifest]
 name = autoconf
 
+[rpms]
+autoconf
+
+[debs]
+autoconf
+
 [download]
 url = http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
 sha256 = 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969

--- a/build/fbcode_builder/manifests/automake
+++ b/build/fbcode_builder/manifests/automake
@@ -1,6 +1,12 @@
 [manifest]
 name = automake
 
+[rpms]
+automake
+
+[debs]
+automake
+
 [download]
 url = http://ftp.gnu.org/gnu/automake/automake-1.16.1.tar.gz
 sha256 = 608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8

--- a/build/fbcode_builder/manifests/bison
+++ b/build/fbcode_builder/manifests/bison
@@ -1,6 +1,12 @@
 [manifest]
 name = bison
 
+[rpms]
+bison
+
+[debs]
+bison
+
 [download.not(os=windows)]
 url = https://mirrors.kernel.org/gnu/bison/bison-3.3.tar.gz
 sha256 = fdeafb7fffade05604a61e66b8c040af4b2b5cbb1021dcfe498ed657ac970efd

--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -2,11 +2,11 @@
 name = boost
 
 [download.not(os=windows)]
-url = https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2
+url = https://versaweb.dl.sourceforge.net/project/boost/boost/1.69.0/boost_1_69_0.tar.bz2
 sha256 = 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
 
 [download.os=windows]
-url = https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.zip
+url = https://versaweb.dl.sourceforge.net/project/boost/boost/1.69.0/boost_1_69_0.zip
 sha256 = d074bcbcc0501c4917b965fc890e303ee70d8b01ff5712bae4a6c54f2b6b4e52
 
 [build]

--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -9,6 +9,42 @@ sha256 = 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
 url = https://versaweb.dl.sourceforge.net/project/boost/boost/1.69.0/boost_1_69_0.zip
 sha256 = d074bcbcc0501c4917b965fc890e303ee70d8b01ff5712bae4a6c54f2b6b4e52
 
+[debs]
+libboost-all-dev
+
+[rpms]
+boost
+boost-math
+boost-test
+boost-fiber
+boost-graph
+boost-log
+boost-openmpi
+boost-timer
+boost-chrono
+boost-locale
+boost-thread
+boost-atomic
+boost-random
+boost-static
+boost-contract
+boost-date-time
+boost-iostreams
+boost-container
+boost-coroutine
+boost-filesystem
+boost-system
+boost-stacktrace
+boost-regex
+boost-devel
+boost-context
+boost-python3-devel
+boost-type_erasure
+boost-wave
+boost-python3
+boost-serialization
+boost-program-options
+
 [build]
 builder = boost
 

--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -9,6 +9,9 @@ sha256 = 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
 url = https://versaweb.dl.sourceforge.net/project/boost/boost/1.69.0/boost_1_69_0.zip
 sha256 = d074bcbcc0501c4917b965fc890e303ee70d8b01ff5712bae4a6c54f2b6b4e52
 
+[preinstalled.env]
+BOOST_ROOT
+
 [debs]
 libboost-all-dev
 

--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -10,7 +10,7 @@ url = https://versaweb.dl.sourceforge.net/project/boost/boost/1.69.0/boost_1_69_
 sha256 = d074bcbcc0501c4917b965fc890e303ee70d8b01ff5712bae4a6c54f2b6b4e52
 
 [preinstalled.env]
-BOOST_ROOT
+BOOST_ROOT_1_69_0
 
 [debs]
 libboost-all-dev

--- a/build/fbcode_builder/manifests/cmake
+++ b/build/fbcode_builder/manifests/cmake
@@ -1,6 +1,13 @@
 [manifest]
 name = cmake
 
+[rpms]
+cmake
+
+# All current deb based distros have a cmake that is too old
+#[debs]
+#cmake
+
 [dependencies]
 ninja
 

--- a/build/fbcode_builder/manifests/fboss
+++ b/build/fbcode_builder/manifests/fboss
@@ -32,7 +32,7 @@ libnl
 libsai
 OpenNSA
 re2
-Python-3.7.6
+python
 
 [shipit.pathmap]
 fbcode/fboss/github = .

--- a/build/fbcode_builder/manifests/flex
+++ b/build/fbcode_builder/manifests/flex
@@ -1,6 +1,12 @@
 [manifest]
 name = flex
 
+[rpms]
+flex
+
+[debs]
+flex
+
 [download.not(os=windows)]
 url = https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
 sha256 = e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995

--- a/build/fbcode_builder/manifests/libcurl
+++ b/build/fbcode_builder/manifests/libcurl
@@ -1,6 +1,13 @@
 [manifest]
 name = libcurl
 
+[rpms]
+libcurl-devel
+libcurl
+
+[debs]
+libcurl4-openssl-dev
+
 [download]
 url = https://curl.haxx.se/download/curl-7.65.1.tar.gz
 sha256 = 821aeb78421375f70e55381c9ad2474bf279fc454b791b7e95fc83562951c690

--- a/build/fbcode_builder/manifests/libelf
+++ b/build/fbcode_builder/manifests/libelf
@@ -1,6 +1,12 @@
 [manifest]
 name = libelf
 
+[rpms]
+elfutils-libelf-devel-static
+
+[debs]
+libelf-dev
+
 [download]
 url = https://ftp.osuosl.org/pub/blfs/conglomeration/libelf/libelf-0.8.13.tar.gz
 sha256 = 591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d

--- a/build/fbcode_builder/manifests/libevent
+++ b/build/fbcode_builder/manifests/libevent
@@ -1,6 +1,12 @@
 [manifest]
 name = libevent
 
+[rpms]
+libevent-devel
+
+[debs]
+libevent-dev
+
 # Note that the CMakeLists.txt file is present only in
 # git repo and not in the release tarball, so take care
 # to use the github generated source tarball rather than

--- a/build/fbcode_builder/manifests/libgit2
+++ b/build/fbcode_builder/manifests/libgit2
@@ -1,6 +1,12 @@
 [manifest]
 name = libgit2
 
+[rpms]
+libgit2-devel
+
+[debs]
+libgit2-dev
+
 [download]
 url = https://github.com/libgit2/libgit2/archive/v0.28.1.tar.gz
 sha256 = 0ca11048795b0d6338f2e57717370208c2c97ad66c6d5eac0c97a8827d13936b

--- a/build/fbcode_builder/manifests/libmnl
+++ b/build/fbcode_builder/manifests/libmnl
@@ -1,6 +1,13 @@
 [manifest]
 name = libmnl
 
+[rpms]
+libmnl-devel
+libmnl-static
+
+[debs]
+libmnl-dev
+
 [download]
 url = http://www.lg.ps.pl/mirrors/ftp.netfilter.org/libmnl/libmnl-1.0.4.tar.bz2
 sha256 = 171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81

--- a/build/fbcode_builder/manifests/libnl
+++ b/build/fbcode_builder/manifests/libnl
@@ -1,6 +1,13 @@
 [manifest]
 name = libnl
 
+[rpms]
+libnl3-devel
+libnl3
+
+[debs]
+libnl-3-dev
+
 [download]
 url = https://www.infradead.org/~tgr/libnl/files/libnl-3.2.25.tar.gz
 sha256 = 8beb7590674957b931de6b7f81c530b85dc7c1ad8fbda015398bc1e8d1ce8ec5

--- a/build/fbcode_builder/manifests/libsodium
+++ b/build/fbcode_builder/manifests/libsodium
@@ -1,6 +1,13 @@
 [manifest]
 name = libsodium
 
+[rpms]
+libsodium-devel
+libsodium-static
+
+[debs]
+libsodium-dev
+
 [download.not(os=windows)]
 url = https://github.com/jedisct1/libsodium/releases/download/1.0.17/libsodium-1.0.17.tar.gz
 sha256 = 0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1

--- a/build/fbcode_builder/manifests/libtool
+++ b/build/fbcode_builder/manifests/libtool
@@ -1,6 +1,12 @@
 [manifest]
 name = libtool
 
+[rpms]
+libtool
+
+[debs]
+libtool
+
 [download]
 url = http://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz
 sha256 = e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3

--- a/build/fbcode_builder/manifests/libusb
+++ b/build/fbcode_builder/manifests/libusb
@@ -1,6 +1,13 @@
 [manifest]
 name = libusb
 
+[rpms]
+libusb-devel
+libusb
+
+[debs]
+libusb-1.0-0-dev
+
 [download]
 url = https://github.com/libusb/libusb/releases/download/v1.0.22/libusb-1.0.22.tar.bz2
 sha256 = 75aeb9d59a4fdb800d329a545c2e6799f732362193b465ea198f2aa275518157

--- a/build/fbcode_builder/manifests/libzmq
+++ b/build/fbcode_builder/manifests/libzmq
@@ -1,6 +1,13 @@
 [manifest]
 name = libzmq
 
+[rpms]
+zeromq-devel
+zeromq
+
+[debs]
+libzmq-dev
+
 [download]
 url = https://github.com/zeromq/libzmq/releases/download/v4.3.1/zeromq-4.3.1.tar.gz
 sha256 = bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb

--- a/build/fbcode_builder/manifests/lz4
+++ b/build/fbcode_builder/manifests/lz4
@@ -1,6 +1,13 @@
 [manifest]
 name = lz4
 
+[rpms]
+lz4-devel
+lz4-static
+
+[debs]
+liblz4-dev
+
 [download]
 url = https://github.com/lz4/lz4/archive/v1.8.3.tar.gz
 sha256 = 33af5936ac06536805f9745e0b6d61da606a1f8b4cc5c04dd3cbaca3b9b4fc43

--- a/build/fbcode_builder/manifests/nghttp2
+++ b/build/fbcode_builder/manifests/nghttp2
@@ -1,6 +1,13 @@
 [manifest]
 name = nghttp2
 
+[rpms]
+libnghttp2-devel
+libnghttp2
+
+[debs]
+libnghttp2-dev
+
 [download]
 url = https://github.com/nghttp2/nghttp2/releases/download/v1.39.2/nghttp2-1.39.2.tar.gz
 sha256 = fc820a305e2f410fade1a3260f09229f15c0494fc089b0100312cd64a33a38c0

--- a/build/fbcode_builder/manifests/ninja
+++ b/build/fbcode_builder/manifests/ninja
@@ -1,6 +1,12 @@
 [manifest]
 name = ninja
 
+[rpms]
+ninja-build
+
+[debs]
+ninja-build
+
 [download.os=windows]
 url = https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-win.zip
 sha256 = 2d70010633ddaacc3af4ffbd21e22fae90d158674a09e132e06424ba3ab036e9

--- a/build/fbcode_builder/manifests/openssl
+++ b/build/fbcode_builder/manifests/openssl
@@ -1,6 +1,13 @@
 [manifest]
 name = openssl
 
+[rpms]
+openssl-devel
+openssl
+
+[debs]
+libssl-dev
+
 [download]
 url = https://www.openssl.org/source/openssl-1.1.1b.tar.gz
 sha256 = 5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b

--- a/build/fbcode_builder/manifests/patchelf
+++ b/build/fbcode_builder/manifests/patchelf
@@ -1,6 +1,12 @@
 [manifest]
 name = patchelf
 
+[rpms]
+patchelf
+
+[debs]
+patchelf
+
 [download]
 url = https://github.com/NixOS/patchelf/archive/0.10.tar.gz
 sha256 = b3cb6bdedcef5607ce34a350cf0b182eb979f8f7bc31eae55a93a70a3f020d13

--- a/build/fbcode_builder/manifests/pcre
+++ b/build/fbcode_builder/manifests/pcre
@@ -1,6 +1,13 @@
 [manifest]
 name = pcre
 
+[rpms]
+pcre-devel
+pcre-static
+
+[debs]
+libpcre3-dev
+
 [download]
 url = https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz
 sha256 = 0b8e7465dc5e98c757cc3650a20a7843ee4c3edf50aaf60bb33fd879690d2c73

--- a/build/fbcode_builder/manifests/python
+++ b/build/fbcode_builder/manifests/python
@@ -1,5 +1,12 @@
 [manifest]
-name = Python-3.7.6
+name = python
+
+[rpms]
+python3
+python3-devel
+
+[debs]
+python3-all-dev
 
 [download.os=linux]
 url = https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz

--- a/build/fbcode_builder/manifests/re2
+++ b/build/fbcode_builder/manifests/re2
@@ -1,6 +1,13 @@
 [manifest]
 name = re2
 
+[rpms]
+re2
+re2-devel
+
+[debs]
+libre2-dev
+
 [download]
 url = https://github.com/google/re2/archive/2019-06-01.tar.gz
 sha256 = 02b7d73126bd18e9fbfe5d6375a8bb13fadaf8e99e48cbb062e4500fc18e8e2e

--- a/build/fbcode_builder/manifests/snappy
+++ b/build/fbcode_builder/manifests/snappy
@@ -1,6 +1,13 @@
 [manifest]
 name = snappy
 
+[rpms]
+snappy
+snappy-devel
+
+[debs]
+libsnappy-dev
+
 [download]
 url = https://github.com/google/snappy/archive/1.1.7.tar.gz
 sha256 = 3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4

--- a/build/fbcode_builder/manifests/sqlite3
+++ b/build/fbcode_builder/manifests/sqlite3
@@ -1,6 +1,13 @@
 [manifest]
 name = sqlite3
 
+[rpms]
+sqlite-devel
+sqlite-libs
+
+[debs]
+libsqlite3-dev
+
 [download]
 url = https://sqlite.org/2019/sqlite-amalgamation-3280000.zip
 sha256 = d02fc4e95cfef672b45052e221617a050b7f2e20103661cda88387349a9b1327

--- a/build/fbcode_builder/manifests/zlib
+++ b/build/fbcode_builder/manifests/zlib
@@ -1,6 +1,13 @@
 [manifest]
 name = zlib
 
+[rpms]
+zlib-devel
+zlib-static
+
+[debs]
+zlib1g-dev
+
 [download]
 url = http://www.zlib.net/zlib-1.2.11.tar.gz
 sha256 = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1

--- a/build/fbcode_builder/manifests/zstd
+++ b/build/fbcode_builder/manifests/zstd
@@ -1,6 +1,13 @@
 [manifest]
 name = zstd
 
+[rpms]
+libzstd-devel
+libzstd
+
+[debs]
+libzstd1-dev
+
 [git]
 repo_url = https://github.com/facebook/zstd.git
 rev = v1.3.8


### PR DESCRIPTION
Not sure if this is a transient issue, but the URL we've been using to obtain boost has started to return 403 errors.
Switch to a sourceforge download link instead.

In addition, my recent change to ensure that we were using python3 to launch everything failed on windows: the GH actions environment has `python.exe` in the path and it is python version 3.  There is no such thing as `python3` in that environment, although there is a `python2`.   This commit includes a fixup for the action generator command.

Test Plan:

Regenerate action via:

```
./build/fbcode_builder/getdeps.py generate-github-actions watchman --output-file .github/workflows/main.yml
```

and then wait until we see green for the check status on this PR