### PR TITLE
docs: fixup link to scm aware query

### DIFF
--- a/website/docs/subscribe.md
+++ b/website/docs/subscribe.md
@@ -215,4 +215,4 @@ and the `state-leave` commands.
 
 _Since 4.9_
 
-[Read more about these here](scm-query)
+[Read more about these here](/watchman/docs/scm-query)


### PR DESCRIPTION
This was a casualty of the recent doc migration

Test Plan: eyes