### PR TITLE
getdeps: maybe fix artifact generation

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Build watchman
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/linux --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/linux  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@master
       with:
         name: watchman

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Build watchman
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/mac --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/mac  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@master
       with:
         name: watchman

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Build watchman
       run: python build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman 
     - name: Copy artifacts
-      run: python build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/windows --final-install-prefix /usr/local
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/windows  --final-install-prefix /usr/local
     - uses: actions/upload-artifact@master
       with:
         name: watchman

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -759,7 +759,7 @@ jobs:
             out.write("    - name: Copy artifacts\n")
             out.write(
                 f"      run: {getdeps} fixup-dyn-deps "
-                f"--src-dir=. {manifest.name} _artifacts/{job_name} --final-install-prefix /usr/local\n"
+                f"--src-dir=. {manifest.name} _artifacts/{job_name} {project_prefix} --final-install-prefix /usr/local\n"
             )
 
             out.write("    - uses: actions/upload-artifact@master\n")


### PR DESCRIPTION
I believe that the mismatched project output settings are causing
the dyndeps fixup to fail to find any objects and thus none of
the artifacts are populated for posix platforms.

Let's see.