### PR TITLE
getdeps: GH actions: strip artifacts before capturing them

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Build watchman
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/linux --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/linux  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@master
       with:
         name: watchman

--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Build watchman
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/linux  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps  --strip --src-dir=. watchman _artifacts/linux  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@master
       with:
         name: watchman

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Build watchman
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/mac --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/mac  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@master
       with:
         name: watchman

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Build watchman
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/mac  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps  --src-dir=. watchman _artifacts/mac  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@master
       with:
         name: watchman

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Build watchman
       run: python build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman 
     - name: Copy artifacts
-      run: python build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/windows  --final-install-prefix /usr/local
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps  --src-dir=. watchman _artifacts/windows  --final-install-prefix /usr/local
     - uses: actions/upload-artifact@master
       with:
         name: watchman

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Build watchman
       run: python build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman 
     - name: Copy artifacts
-      run: python build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/windows --final-install-prefix /usr/local
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/windows  --final-install-prefix /usr/local
     - uses: actions/upload-artifact@master
       with:
         name: watchman

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -759,7 +759,7 @@ jobs:
             out.write("    - name: Copy artifacts\n")
             out.write(
                 f"      run: {getdeps} fixup-dyn-deps "
-                f"--src-dir=. {manifest.name} _artifacts/{job_name} --final-install-prefix /usr/local\n"
+                f"--src-dir=. {manifest.name} _artifacts/{job_name} {project_prefix} --final-install-prefix /usr/local\n"
             )
 
             out.write("    - uses: actions/upload-artifact@master\n")

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -572,13 +572,21 @@ class FixupDeps(ProjectCmdBase):
             install_dirs.append(inst_dir)
 
             if m == manifest:
-                dep_munger = create_dyn_dep_munger(loader.build_opts, install_dirs)
+                dep_munger = create_dyn_dep_munger(
+                    loader.build_opts, install_dirs, args.strip
+                )
                 dep_munger.process_deps(args.destdir, args.final_install_prefix)
 
     def setup_project_cmd_parser(self, parser):
         parser.add_argument("destdir", help=("Where to copy the fixed up executables"))
         parser.add_argument(
             "--final-install-prefix", help=("specify the final installation prefix")
+        )
+        parser.add_argument(
+            "--strip",
+            action="store_true",
+            default=False,
+            help="Strip debug info while processing executables",
         )
 
 
@@ -757,8 +765,17 @@ jobs:
             )
 
             out.write("    - name: Copy artifacts\n")
+            if build_opts.is_linux():
+                # Strip debug info from the binaries, but only on linux.
+                # While the `strip` utility is also available on macOS,
+                # attempting to strip there results in an error.
+                # The `strip` utility is not available on Windows.
+                strip = " --strip"
+            else:
+                strip = ""
+
             out.write(
-                f"      run: {getdeps} fixup-dyn-deps "
+                f"      run: {getdeps} fixup-dyn-deps {strip} "
                 f"--src-dir=. {manifest.name} _artifacts/{job_name} {project_prefix} --final-install-prefix /usr/local\n"
             )
 


### PR DESCRIPTION
On Linux the debug info sections in projects downstream from folly and
thrift are huge due to a lot of C++ template usage.

We build in RelWithDebInfo mode as that is most useful when debugging
locally and because the build times are long, but most casual consumers
of the binaries via GH actions really don't care about debug info,
and this should save ~180MB of size in (for example) the watchman
executables.

Test Plan: review the artifact size on the linux build in this PR
and confirm that it is a bit smaller than 180MB.

Refs: https://github.com/facebook/watchman/issues/804