### PR TITLE
Update links in state-enter docs

### DIFF
--- a/website/docs/state-enter.md
+++ b/website/docs/state-enter.md
@@ -5,9 +5,9 @@ title: state-enter
 
 _Since 4.4_
 
-The `state-enter` command works in conjunction with [state-leave](state-leave)
+The `state-enter` command works in conjunction with [state-leave](../state-leave/)
 to facilitate
-[advanced settling in subscriptions](subscribe#advanced-settling).
+[advanced settling in subscriptions](../subscribe/#advanced-settling).
 
 `state-enter` causes a watch to be marked as being in a particular named
 state. The state is asserted until a corresponding `state-leave` command is
@@ -15,7 +15,7 @@ issued or _until the watchman client session that entered the state
 disconnects_. This automatic cleanup helps to avoid breaking subscribers if
 the tooling that initiated a state terminates unexpectedly.
 
-Subscriptions can use the [defer](subscribe#defer) and [drop](subscribe#drop)
+Subscriptions can use the [defer](../subscribe/#defer) and [drop](../subscribe/#drop)
 fields to defer or drop notifications generated while the watch is in a
 particular named state.
 
@@ -82,7 +82,7 @@ possible for subscribers to reason about when files changed with respect to
 the state.
 
 This means that issuing a `state-enter` command will
-[perform query synchronization](cookies#how-cookies-work) to ensure that
+[perform query synchronization](../cookies/#how-cookies-work) to ensure that
 things are in sync.
 
 The `state-enter` command will use a default `sync_timeout` of 60 seconds. If


### PR DESCRIPTION
all the links on https://facebook.github.io/watchman/docs/state-enter/ are broken because of the trailing slash.