### PR TITLE
[watchman] add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  prepare:
+    runs-on: ubuntu-18.04
+    outputs:
+      release: ${{ steps.info.outputs.name }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+    - name: Prepare release info
+      id: info
+      env:
+        TAG: ${{ github.ref }}
+      run: python -c "print('::set-output name=name::' + '$TAG'.lstrip('refs/tags/'))"
+    - name: Create release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
+
+  linux-build:
+    continue-on-error: true
+    needs: prepare
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build watchman
+      run: python3 build/fbcode_builder/getdeps.py build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
+    - name: Copy artifacts
+      run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --strip --src-dir=. watchman _artifacts/linux  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
+    - name: Test watchman
+      run: python3 build/fbcode_builder/getdeps.py test --src-dir=. watchman  --project-install-prefix watchman:/usr/local
+    - name: Package watchman
+      run: mv _artifacts/linux "watchman-${{ needs.prepare.outputs.release }}-linux" && zip -r watchman-${{ needs.prepare.outputs.release }}-linux.zip "watchman-${{ needs.prepare.outputs.release }}-linux/"
+    - name: Upload Linux release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ needs.prepare.outputs.upload_url }}
+        asset_path: ./watchman-${{ needs.prepare.outputs.release }}-linux.zip
+        asset_name: watchman-${{ needs.prepare.outputs.release }}-linux.zip
+        asset_content_type: application/zip
+
+  mac-build:
+    continue-on-error: true
+    needs: prepare
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build watchman
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
+    - name: Copy artifacts
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/mac  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
+    - name: Test watchman
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. watchman  --project-install-prefix watchman:/usr/local
+    - name: Package watchman
+      run: mv _artifacts/mac "watchman-${{ needs.prepare.outputs.release }}-macos" && zip -r watchman-${{ needs.prepare.outputs.release }}-macos.zip "watchman-${{ needs.prepare.outputs.release }}-macos/"
+    - name: Upload macOS release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ needs.prepare.outputs.upload_url }}
+        asset_path: ./watchman-${{ needs.prepare.outputs.release }}-macos.zip
+        asset_name: watchman-${{ needs.prepare.outputs.release }}-macos.zip
+        asset_content_type: application/zip
+
+  windows-build:
+    continue-on-error: true
+    needs: prepare
+    runs-on: windows-2016
+    steps:
+    - uses: actions/checkout@v1
+    - name: Export boost environment
+      run: "echo ::set-env name=BOOST_ROOT::%BOOST_ROOT_1_69_0%"
+      shell: cmd
+    - name: Fix Git config
+      run: git config --system core.longpaths true
+    - name: Build watchman
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman
+    - name: Copy artifacts
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/windows  --final-install-prefix /usr/local
+    - name: Test watchman
+      run: python build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. watchman
+    - name: Package watchman
+      run: mv _artifacts/windows "watchman-${{ needs.prepare.outputs.release }}-windows" && Compress-Archive -DestinationPath "watchman-${{ needs.prepare.outputs.release }}-windows.zip" -Path "watchman-${{ needs.prepare.outputs.release }}-windows/"
+    - name: Upload Windows release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ needs.prepare.outputs.upload_url }}
+        asset_path: ./watchman-${{ needs.prepare.outputs.release }}-windows.zip
+        asset_name: watchman-${{ needs.prepare.outputs.release }}-windows.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
This diff adds a release workflow to our GitHub actions. 

The release workflow will be publishing a weekly release whenever tagit create a tag. 

It will attempts to build for all three platforms and upload the binary to that release. It only uploads when the build is succeeded and pass the tests (3 times retry chance).

Test Plan:

Check: https://github.com/fanzeyi/watchman/actions/runs/161353508 
https://github.com/fanzeyi/watchman/releases/tag/v39492

This run has made releases for all platforms.