### PR TITLE
watchman: attempt to pickup versioned python executable on GitHub Actions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,7 +361,7 @@ endif()
 # python3, python3.6 and python3.7 that will select 3.7,
 # even though python3 -> python3.6.  On such a system we
 # want the python3/python3.6 selection, not the 3.7 selection
-find_program(PYTHON3 python3)
+find_program(PYTHON3 NAMES python3 python3.7 python3.6 python3.8)
 if(PYTHON3)
   set(PYOUT "${CMAKE_CURRENT_BINARY_DIR}/build/pytimestamp")
   set(SETUP_PY "${CMAKE_CURRENT_SOURCE_DIR}/python/setup.py")


### PR DESCRIPTION
Summary: I noticed that the aux utilities are not being built by the
GitHub CI which has `python.exe` mapped to `python3` by default,
but no `python3` in the path.

This commit attempts to find one of the explicit python3 versions
that is present, preferring python3.7 which is the default on
those systems for the sake of consistency.

Test Plan: review GH actions status on this PR