### PR TITLE
task/add command to cd into extracted release

### DIFF
--- a/website/_docs/install.markdown
+++ b/website/_docs/install.markdown
@@ -75,6 +75,7 @@ You can find the binary downloads in the [latest release](https://github.com/fac
 ```
 $ unzip watchman-*-linux.zip
 $ sudo mkdir -p /usr/local/{bin,lib} /usr/local/var/run/watchman
+$ cd watchman-vYYYY.MM.DD.00-linux
 $ sudo cp bin/* /usr/local/bin
 $ sudo cp lib/* /usr/local/lib
 $ sudo chmod 755 /usr/local/bin/watchman


### PR DESCRIPTION
Hi there,

A user raised this suggestion and I think it is a useful improvement and, therefore, decided to add it. In the "Installation" section of the contributing guide, it is not stated that the last four commands are to be executed in the directory of the extracted release with the name format: **watchman-vYYYY.MM.DD.00-linux**. Meanwhile, including will prevent users from getting unnecessarily stuck, especially users with little or no familiarity with the command line.

My changes include the command to change directory into the extracted release folder just before the commands that need to be run within the directory.

Warm regards.
**_Mudathir Lawal_**