### PR TITLE
Issue #736 Update warnings to add appropriate quotes

### DIFF
--- a/listener-user.cpp
+++ b/listener-user.cpp
@@ -34,11 +34,11 @@ void add_root_warnings_to_response(
           info->warning,
           "\n",
           "To clear this warning, run:\n"
-          "`watchman watch-del ",
+          "`watchman watch-del '",
           root->root_path,
-          " ; watchman watch-project ",
+          "' ; watchman watch-project '",
           root->root_path,
-          "`\n")));
+          "'`\n")));
 }
 
 std::shared_ptr<w_root_t> doResolveOrCreateRoot(


### PR DESCRIPTION
Resolves #736 using suggestion by @wez in the issue comments. Adds single quotes to path appended to warning, so suggested commands can be copied and pasted into the terminal if the root path contains spaces. (`root->root_path`)