### PR TITLE
[node] Use error.code instead of error.errno

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -158,10 +158,10 @@ Client.prototype.connect = function() {
       return;
     }
     spawnFailed = true;
-    if (error.errno === 'EACCES') {
+    if (error.code === 'EACCES') {
       error.message = 'The Watchman CLI is installed but cannot ' +
                       'be spawned because of a permission problem';
-    } else if (error.errno === 'ENOENT') {
+    } else if (error.code === 'ENOENT') {
       error.message = 'Watchman was not found in PATH.  See ' +
           'https://facebook.github.io/watchman/docs/install.html ' +
           'for installation instructions';


### PR DESCRIPTION
At some point between NodeJS 12, and NodeJS 14, the `error.errno` used
in the `spawnError` function was changed from being a Number, or String,
to always being a Number.

The `spawnError` function was looking for an error code in the errno
field, and since NodeJS 14 was no longer emitting appropriate events
upon failure.

Node.js 12 docs for error.errno: https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_error_errno
Node.js 14 docs for error.errno: https://nodejs.org/docs/latest-v14.x/api/errors.html#errors_error_errno

I've been unable to find the exact changelog reference at which this
happened, however the `error.code` has been providing the relevant ENO
since at least version 4.9.1 of Node.js.