### PR TITLE
[rust] upgrade to tokio 1.0

### DIFF
--- a/rust/watchman_client/Cargo.toml
+++ b/rust/watchman_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "watchman_client"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Wez Furlong"]
 edition = "2018"
 repository = "https://github.com/facebook/watchman/"
@@ -16,13 +16,13 @@ maplit = "1.0"
 serde = { version = "1.0.102", features = ["derive"] }
 serde_bser = { version = "0.2", path = "../serde_bser" }
 thiserror = ">=1.0.6"
-tokio = { version = "0.2", features = [
+tokio = { version = "1.0", features = [
     "io-util",
     "macros",
+    "net",
     "process",
-    "rt-core",
+    "rt",
     "sync",
-    "uds",
 ] }
 
 [target."cfg(windows)".dependencies]

--- a/rust/watchman_client/examples/glob.rs
+++ b/rust/watchman_client/examples/glob.rs
@@ -10,7 +10,7 @@ struct Opt {
     path: PathBuf,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Err(err) = run().await {
         // Print a prettier error than the default

--- a/rust/watchman_client/examples/since.rs
+++ b/rust/watchman_client/examples/since.rs
@@ -22,7 +22,7 @@ struct Opt {
     path: PathBuf,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Err(err) = run().await {
         // Print a prettier error than the default

--- a/rust/watchman_client/examples/subscribe.rs
+++ b/rust/watchman_client/examples/subscribe.rs
@@ -11,7 +11,7 @@ struct Opt {
     path: PathBuf,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Err(err) = run().await {
         // Print a prettier error than the default

--- a/rust/watchman_client/src/lib.rs
+++ b/rust/watchman_client/src/lib.rs
@@ -38,9 +38,9 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 #[cfg(unix)]
 use tokio::net::UnixStream;
-use tokio::prelude::*;
 use tokio::process::Command;
 use tokio::sync::mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender};
 use tokio::sync::Mutex;
@@ -935,7 +935,7 @@ impl Client {
         let (tx, responses) = tokio::sync::mpsc::unbounded_channel();
 
         {
-            let mut inner = self.inner.lock().await;
+            let inner = self.inner.lock().await;
             inner
                 .request_tx
                 .send(TaskItem::RegisterSubscription(name.clone(), tx))


### PR DESCRIPTION
Upgrade the Rust crate to tokio 1.0.

Uses the `current_thread` flavor for examples to avoid adding the `rt-multi-threaded` feature to the tokio dependency.

Test Plan:
- `cargo test`
- `cargo run --example since`
- `cargo run --example glob`
- `cargo run --example subscribe`