### PR TITLE
Rust: exclude examples/ from published crate

### DIFF
--- a/rust/watchman_client/Cargo.toml
+++ b/rust/watchman_client/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/facebook/watchman/"
 description = "a client for the Watchman file watching service"
 license = "Apache-2.0"
 documentation = "https://docs.rs/watchman_client"
+exclude = [
+    "examples/*",
+]
 
 [dev-dependencies]
 structopt = "0.3"


### PR DESCRIPTION
I don't think theres a reason to include these in the published crate.

Test Plan:
- `cargo package --list` no longer shows the example files.
- `cargo run --example glob` still runs the example locally.