### PR TITLE
[GitHub Action] automatically bump Watchman version in homebrew-fb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,18 @@ jobs:
         asset_path: ./watchman-${{ needs.prepare.outputs.release }}-windows.zip
         asset_name: watchman-${{ needs.prepare.outputs.release }}-windows.zip
         asset_content_type: application/zip
+
+  homebrew-bump:
+    needs: [prepare, mac-build]
+    runs-on: ubuntu-latest
+     steps:
+      - uses: mislav/bump-homebrew-formula-action@1.11
+        with:
+          formula-name: watchman
+          formula-path: watchman.rb
+          homebrew-tap: facebook/homebrew-fb
+          base-branch: master
+          download-url: https://github.com/facebook/watchman/releases/download/${{ needs.prepare.outputs.release }}/watchman-${{ needs.prepare.outputs.release }}-macos.zip
+          commit-message: bump watchman to ${{ needs.prepare.outputs.release }}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
     needs: [prepare, mac-build]
     runs-on: ubuntu-latest
      steps:
-      - uses: mislav/bump-homebrew-formula-action@1.11
+      - uses: fanzeyi/bump-homebrew-formula-action@1.11
         with:
           formula-name: watchman
           formula-path: watchman.rb


### PR DESCRIPTION
#851 

---

In my local testing it generated https://github.com/facebook/homebrew-fb/pull/56