### PR TITLE
Quick fixes for gcc-9.3.0

### DIFF
--- a/scm/Mercurial.cpp
+++ b/scm/Mercurial.cpp
@@ -13,7 +13,8 @@ namespace watchman {
 using Options = ChildProcess::Options;
 
 Mercurial::infoCache::infoCache(std::string path) : dirStatePath(path) {
-  memset(&dirstate, 0, sizeof(dirstate));
+  //memset(&dirstate, 0, sizeof(dirstate));
+  dirstate = decltype(dirstate)();
 }
 
 w_string Mercurial::infoCache::lookupMergeBase(const std::string& commitId) {

--- a/thirdparty/jansson/load.cpp
+++ b/thirdparty/jansson/load.cpp
@@ -92,6 +92,8 @@ static void error_set(json_error_t *error, const lex_t *lex,
     msg_text[JSON_ERROR_TEXT_LENGTH - 1] = '\0';
     va_end(ap);
 
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+    
     if(lex)
     {
         const char *saved_text = strbuffer_value(&lex->saved_text);
@@ -124,6 +126,8 @@ static void error_set(json_error_t *error, const lex_t *lex,
         }
     }
 
+#pragma GCC diagnostic pop
+    
     jsonp_error_set(error, line, col, pos, "%s", result);
 }
 


### PR DESCRIPTION
This is a quick fix that shows where the issues happens on gcc 3.9.0, and how to work-around them quickly.
Not the finest way to fix, however.
