### PR TITLE
Rust: fix windows build

### DIFF
--- a/watchman/rust/watchman_client/Cargo.toml
+++ b/watchman/rust/watchman_client/Cargo.toml
@@ -26,8 +26,6 @@ tokio = { version = "1.5", features = ["full", "test-util"] }
 tokio-util = { version = "0.6", features = ["full"] }
 
 [target."cfg(windows)".dependencies]
-mio-named-pipes = "0.1"
-mio = "0.6"
 winapi = { version = "0.3", features = [
     "handleapi",
     "winuser",


### PR DESCRIPTION
- Usage of `mio` was removed in 7ba69af251fcb9b8bf6f2bdf401e8548629f82d5, so we no longer need the dependencies.
- The error type was changed in 425f7289c21b8b26483fcab1beabadbf84836b9b and broke windows build.

Test Plan:
Windows build using:
  cargo build --target x86_64-pc-windows-gnu
macOS build using
  cargo build