### PR TITLE
Improvements to the website

### DIFF
--- a/website/_includes/nav_docs.html
+++ b/website/_includes/nav_docs.html
@@ -1,5 +1,3 @@
-<div>
-</div>
 <nav class='toc' id="doc_nav"></nav>
 <script>
   var docnavData = [

--- a/website/_sass/_base.scss
+++ b/website/_sass/_base.scss
@@ -918,6 +918,7 @@ a.blockButton {
   
   .wrapper {
     max-width: 1100px;
+    width: 1100px;
   }
     
   .homeWrapper {
@@ -944,6 +945,7 @@ a.blockButton {
   
   .wrapper {
     max-width: 1400px;
+    width: 1400px;
   }
     
   .homeWrapper {


### PR DESCRIPTION
This PR introduces some minor improvements to the Watchman website. It
1. Removes a (presumably useless) empty `<div>` that I stumbled upon, and it
2. Fixes a problem with the layout for any doc page (["doc_page.html"](https://github.com/facebook/watchman/blob/78fadf453aee21b49c5a99db1ecad1b61434264d/website/_layouts/doc_page.html)) displayed on Google Chrome running on macOS (full browser details: https://www.whatsmybrowser.org/b/PLIF0; It seems setting only `max_width` is not enough).
Here is how it looks: ![127 0 0 1_4000_watchman_docs_install html](https://user-images.githubusercontent.com/1841652/129522921-0a2fcd05-20a5-4c4e-b69f-6fda3dfc54c3.png)