### PR TITLE
Re-enable watchmanctl on Windows

### DIFF
--- a/watchman/cli/CMakeLists.txt
+++ b/watchman/cli/CMakeLists.txt
@@ -12,9 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The watchman_client build was broken by a Tokio upgrade:
-# See https://github.com/facebook/watchman/issues/898
-if(NOT WIN32)
-  rust_executable(watchmanctl)
-  install_rust_executable(watchmanctl)
-endif()
+rust_executable(watchmanctl)
+install_rust_executable(watchmanctl)


### PR DESCRIPTION
The tokio issues that caused the Windows build to fail were fixed in
commit 7ba69af251fcb9b8bf6f2bdf401e8548629f82d5.

This reverts commit 4d21cafbe8032d754630387798ef1d12d6b79a4f.

Fixes: #898
Fixes: #910
Fixes: #935