### PR TITLE
Changes for building in Debian

### DIFF
--- a/build/fbcode_builder/getdeps/platform.py
+++ b/build/fbcode_builder/getdeps/platform.py
@@ -101,7 +101,7 @@ class HostType(object):
             return None
         if self.distro in ("fedora", "centos"):
             return "rpm"
-        if self.distro in ("debian", "ubuntu"):
+        if self.distro.startswith(("debian", "ubuntu")):
             return "deb"
         return None
 

--- a/build/fbcode_builder/manifests/cmake
+++ b/build/fbcode_builder/manifests/cmake
@@ -4,9 +4,8 @@ name = cmake
 [rpms]
 cmake
 
-# All current deb based distros have a cmake that is too old
-#[debs]
-#cmake
+[debs]
+cmake
 
 [dependencies]
 ninja

--- a/build/fbcode_builder/manifests/fb303
+++ b/build/fbcode_builder/manifests/fb303
@@ -6,6 +6,7 @@ shipit_fbcode_builder = true
 
 [git]
 repo_url = https://github.com/facebookincubator/fb303.git
+rev = main
 
 [build]
 builder = cmake


### PR DESCRIPTION
Some changes that had to be done in Debian for the build to work:

* Installation of system deps failed as it was not detecting the OS correctly
* Updated the CMake manifest to uncomment the deb dependency as the CMake versions are newer
* fb303 was not getting cloned as it was looking for a non-existent master branch