### PR TITLE
Upgrade Windows build to Windows 2019

### DIFF
--- a/watchman/thirdparty/deelevate_binding/CMakeLists.txt
+++ b/watchman/thirdparty/deelevate_binding/CMakeLists.txt
@@ -2,8 +2,6 @@ if(NOT WIN32)
     message( FATAL_ERROR "deelevate cannot be used on platforms other than Windows" )
 endif()
 
-find_package(Python COMPONENTS Interpreter)
-
 rust_executable(deelevate BINARY_NAME eledo-pty-bridge)
 
 rust_static_library(rust_deelevate CRATE deelevate)


### PR DESCRIPTION
Experimenting to see if this fixes setuptools's ability to find MSVC.