### PR TITLE
use a different mirror for pcre

### DIFF
--- a/build/fbcode_builder/manifests/pcre
+++ b/build/fbcode_builder/manifests/pcre
@@ -9,7 +9,7 @@ pcre-static
 libpcre3-dev
 
 [download]
-url = https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz
+url = https://sourceforge.net/projects/pcre/files/pcre/8.43/pcre-8.43.tar.gz/download
 sha256 = 0b8e7465dc5e98c757cc3650a20a7843ee4c3edf50aaf60bb33fd879690d2c73
 
 [build]


### PR DESCRIPTION
ftp.pcre.org is down( has been for a few weeks, it seems).