### PR TITLE
Fix inconsistent openssl dependency in cmake manifest

### DIFF
--- a/build/fbcode_builder/manifests/cmake
+++ b/build/fbcode_builder/manifests/cmake
@@ -6,6 +6,9 @@ cmake
 
 [dependencies]
 ninja
+
+# We use the system openssl on linux
+[dependencies.not(os=linux)]
 openssl
 
 [download.os=windows]


### PR DESCRIPTION
Fixes https://github.com/facebook/watchman/issues/990

All manifests, except `cmake`, specifies `[dependencies.not(os=linux)]` for `openssl`. The newly added dependency otherwise causes a "project openssl has no builder" error when building on Linux distros.