### PR TITLE
pywatchman: Print stderr if there was an error

### DIFF
--- a/watchman/python/pywatchman/__init__.py
+++ b/watchman/python/pywatchman/__init__.py
@@ -973,6 +973,8 @@ class client(object):
         exitcode = p.poll()
 
         if exitcode:
+            print(stdout, file=sys.stdout)
+            print(stderr, file=sys.stderr)
             raise WatchmanError("watchman exited with code %d" % exitcode)
 
         result = bser.loads(stdout)

--- a/watchman/python/pywatchman_aio/__init__.py
+++ b/watchman/python/pywatchman_aio/__init__.py
@@ -51,6 +51,8 @@ def _resolve_sockname_helper():
     exitcode = p.poll()
 
     if exitcode:
+        print(stdout, file=sys.stdout)
+        print(stderr, file=sys.stderr)
         raise WatchmanError("watchman exited with code %d" % exitcode)
 
     result = bser.loads(stdout)


### PR DESCRIPTION
I was running watchman-make at the command line and getting a backtrace that said "command failed."

It turns out that somehow my terminal process had a `nice` value of 5, and was failing the check that `watchman` has for `nice_value > min_acceptable_nice_value`, but I couldn't see that message because it was getting swallowed.

Seems that if we know we're about to make the process crash by raising an exception, we may as well dump a little extra debugging information on our way out.