### PR TITLE
Fix return type in `get_linux_type()`

### DIFF
--- a/build/fbcode_builder/getdeps/platform.py
+++ b/build/fbcode_builder/getdeps/platform.py
@@ -20,7 +20,7 @@ def get_linux_type():
         with open("/etc/os-release") as f:
             data = f.read()
     except EnvironmentError:
-        return (None, None)
+        return (None, None, None)
 
     os_vars = {}
     for line in data.splitlines():


### PR DESCRIPTION
This function is expected to return a tuple of 3 elements. This doesn't happen when it fails opening the `/etc/os-release` file.