### PR TITLE
Fix OpenSSL building on Apple Silicon M1 (ARM)

### DIFF
--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -969,7 +969,7 @@ class OpenSSLBuilder(BuilderBase):
         elif self.build_opts.is_darwin():
             make = "make"
             make_j_args = ["-j%s" % self.num_jobs]
-            args = ["darwin64-x86_64-cc"]
+            args = ["darwin64-x86_64-cc"] if not self.build_opts.is_arm() else ["darwin64-arm64-cc"]
         elif self.build_opts.is_linux():
             make = "make"
             make_j_args = ["-j%s" % self.num_jobs]


### PR DESCRIPTION
Before the change:
```
% uname -m -s
Darwin arm64

% ./autogen.sh
...
ld: warning: ignoring file /private/var/.../installed/openssl-OovnrH2WrHG18y7xi0irAegZLOlNsDyeOGb8BBEcoGw/lib/libssl.dylib, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
ld: warning: ignoring file /private/var/.../installed/openssl-OovnrH2WrHG18y7xi0irAegZLOlNsDyeOGb8BBEcoGw/lib/libcrypto.dylib, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
...
```

After the change build succeeds.