### PR TITLE
Add a -0/--null NUL byte separator option to watchman-wait

### DIFF
--- a/watchman/python/bin/watchman-wait
+++ b/watchman/python/bin/watchman-wait
@@ -69,6 +69,14 @@ parser.add_argument(
     help="String to use as field separator for event output.",
 )
 parser.add_argument(
+    "-0",
+    "--null",
+    action="store_true",
+    help="""
+Use a NUL byte as a field separator, takes precedence over --separator.
+""",
+)
+parser.add_argument(
     "-m",
     "--max-events",
     type=int,
@@ -117,6 +125,8 @@ value is 100 seconds.
 """,
 )
 args = parser.parse_args()
+if args.null:
+    args.separator = "\0"
 
 
 # We parse the list of paths into a set of subscriptions

--- a/watchman/python/bin/watchman-wait-aio
+++ b/watchman/python/bin/watchman-wait-aio
@@ -202,6 +202,13 @@ https://facebook.github.io/watchman/docs/cmd/query.html#available-fields.""",
         help="String to use as field separator for event output.",
     )
     parser.add_argument(
+        "-0",
+        "--null",
+        action="store_true",
+        help="""
+Use a NUL byte as a field separator, takes precedence over --separator.""",
+    )
+    parser.add_argument(
         "-m",
         "--max-events",
         type=int,
@@ -252,7 +259,7 @@ def main():
             args.path,
             args.pattern,
             args.fields,
-            args.separator,
+            "\0" if args.null else args.separator,
             args.relative,
             args.max_events,
         )


### PR DESCRIPTION
This has to be a separate option because you cannot use a NUL byte in an
exec call because it indicates string termination in C.