### PR TITLE
Fix synthesize arg in pywatchman.client.capabilityCheck

### DIFF
--- a/watchman/python/pywatchman/__init__.py
+++ b/watchman/python/pywatchman/__init__.py
@@ -1164,14 +1164,13 @@ class client(object):
 
     def capabilityCheck(self, optional=None, required=None):
         """Perform a server capability check"""
-        res = self.query(
-            "version", {"optional": optional or [], "required": required or []}
-        )
+        opts = {"optional": optional or [], "required": required or []}
+        res = self.query("version", opts)
 
         if not self._hasprop(res, "capabilities"):
             # Server doesn't support capabilities, so we need to
             # synthesize the results based on the version
-            capabilities.synthesize(res, optional)
+            capabilities.synthesize(res, opts)
             if "error" in res:
                 raise CommandError(res["error"])
 


### PR DESCRIPTION
`pywatchman.capabilities.synthesize` expects an `opts` dict of the shape `{"required": list[str], "optional": list[str]}`.

`pywatchman.client.capabilityCheck` is incorrectly passing an optional `list[str]` as the `opts` arg,