### PR TITLE
fix(pywatchman): remove unreachable statement

### DIFF
--- a/watchman/python/pywatchman/__init__.py
+++ b/watchman/python/pywatchman/__init__.py
@@ -931,9 +931,6 @@ class client(object):
                 '"bser" or omit the sendEncoding and recvEncoding '
                 "arguments"
             )
-            if self.useImmutableBser:
-                return self._makeBSERCodec(ImmutableBserCodec)
-            return self._makeBSERCodec(BserCodec)
         elif enc == "json":
             return JsonCodec
         else:


### PR DESCRIPTION
In the _parseEncoding() function, if the encoding is set to "bser-v1", only a WatchmanError is raised, not the return statements below it, which are unreachable due to the hierarchy of return and raise in Python. The inclusion of these return statements seems like a mistake.