### PR TITLE
regenerate GitHub actions for all projects

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -49,8 +49,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests lz4
     - name: Fetch snappy
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
-    - name: Fetch pcre
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre
+    - name: Fetch pcre2
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre2
     - name: Fetch zlib
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zlib
     - name: Fetch bz2
@@ -61,26 +61,26 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
     - name: Fetch libtool
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
-    - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch libsodium
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
-    - name: Fetch xz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
-    - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
-    - name: Fetch fizz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch libffi
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libffi
     - name: Fetch ncurses
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ncurses
     - name: Fetch python
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests python
+    - name: Fetch xz
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
+    - name: Fetch folly
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+    - name: Fetch fizz
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
     - name: Fetch fbthrift
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fbthrift
+    - name: Fetch edencommon
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests edencommon
     - name: Fetch fb303
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fb303
     - name: Build boost
@@ -111,8 +111,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
     - name: Build snappy
       run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
-    - name: Build pcre
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre
+    - name: Build pcre2
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre2
     - name: Build zlib
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
     - name: Build bz2
@@ -123,26 +123,26 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
     - name: Build libtool
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
-    - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build libsodium
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
-    - name: Build xz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
-    - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
-    - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build libffi
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libffi
     - name: Build ncurses
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ncurses
     - name: Build python
       run: python3 build/fbcode_builder/getdeps.py build --no-tests python
+    - name: Build xz
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
+    - name: Build folly
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+    - name: Build fizz
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build wangle
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
     - name: Build fbthrift
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fbthrift
+    - name: Build edencommon
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests edencommon
     - name: Build fb303
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fb303
     - name: Build watchman

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -49,8 +49,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests openssl
     - name: Fetch snappy
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
-    - name: Fetch pcre
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre
+    - name: Fetch pcre2
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre2
     - name: Fetch libevent
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
     - name: Fetch zlib
@@ -61,8 +61,6 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
     - name: Fetch libtool
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
-    - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch libsodium
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
     - name: Fetch xz
@@ -75,6 +73,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
     - name: Fetch fbthrift
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fbthrift
+    - name: Fetch edencommon
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests edencommon
     - name: Fetch fb303
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fb303
     - name: Build boost
@@ -105,8 +105,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
     - name: Build snappy
       run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
-    - name: Build pcre
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre
+    - name: Build pcre2
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre2
     - name: Build libevent
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
     - name: Build zlib
@@ -117,8 +117,6 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
     - name: Build libtool
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
-    - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build libsodium
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
     - name: Build xz
@@ -131,6 +129,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
     - name: Build fbthrift
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fbthrift
+    - name: Build edencommon
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests edencommon
     - name: Build fb303
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fb303
     - name: Build watchman

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -40,8 +40,6 @@ jobs:
       run: python build/fbcode_builder/getdeps.py fetch --no-tests gflags
     - name: Fetch glog
       run: python build/fbcode_builder/getdeps.py fetch --no-tests glog
-    - name: Fetch bison
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch fmt
       run: python build/fbcode_builder/getdeps.py fetch --no-tests fmt
     - name: Fetch googletest
@@ -60,8 +58,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py fetch --no-tests snappy
     - name: Fetch zlib
       run: python build/fbcode_builder/getdeps.py fetch --no-tests zlib
-    - name: Fetch pcre
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests pcre
+    - name: Fetch pcre2
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests pcre2
     - name: Fetch perl
       run: python build/fbcode_builder/getdeps.py fetch --no-tests perl
     - name: Fetch openssl
@@ -70,6 +68,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py fetch --no-tests libevent
     - name: Fetch folly
       run: python build/fbcode_builder/getdeps.py fetch --no-tests folly
+    - name: Fetch edencommon
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests edencommon
     - name: Fetch fizz
       run: python build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
@@ -90,8 +90,6 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --no-tests gflags
     - name: Build glog
       run: python build/fbcode_builder/getdeps.py build --no-tests glog
-    - name: Build bison
-      run: python build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build fmt
       run: python build/fbcode_builder/getdeps.py build --no-tests fmt
     - name: Build googletest
@@ -110,8 +108,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --no-tests snappy
     - name: Build zlib
       run: python build/fbcode_builder/getdeps.py build --no-tests zlib
-    - name: Build pcre
-      run: python build/fbcode_builder/getdeps.py build --no-tests pcre
+    - name: Build pcre2
+      run: python build/fbcode_builder/getdeps.py build --no-tests pcre2
     - name: Build perl
       run: python build/fbcode_builder/getdeps.py build --no-tests perl
     - name: Build openssl
@@ -120,6 +118,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --no-tests libevent
     - name: Build folly
       run: python build/fbcode_builder/getdeps.py build --no-tests folly
+    - name: Build edencommon
+      run: python build/fbcode_builder/getdeps.py build --no-tests edencommon
     - name: Build fizz
       run: python build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build wangle


### PR DESCRIPTION
Summary:
After D38831140 (https://github.com/facebook/watchman/commit/e14e94b0862e241ec6df12b0f8fcc4bd390ffe49), `bison` no longer needs to be fetched by most
projects.

Differential Revision: D38877152

