### PR TITLE
upgrade getdeps GitHub actions to Ubuntu 20 (#1842)

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Fetch boost

--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -49,8 +49,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests lz4
     - name: Fetch snappy
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
-    - name: Fetch pcre
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre
+    - name: Fetch pcre2
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre2
     - name: Fetch zlib
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests zlib
     - name: Fetch bz2
@@ -61,26 +61,26 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
     - name: Fetch libtool
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
-    - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch libsodium
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
-    - name: Fetch xz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
-    - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
-    - name: Fetch fizz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch libffi
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libffi
     - name: Fetch ncurses
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ncurses
     - name: Fetch python
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests python
+    - name: Fetch xz
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
+    - name: Fetch folly
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+    - name: Fetch fizz
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
     - name: Fetch fbthrift
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fbthrift
+    - name: Fetch edencommon
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests edencommon
     - name: Fetch fb303
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fb303
     - name: Build boost
@@ -111,8 +111,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests lz4
     - name: Build snappy
       run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
-    - name: Build pcre
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre
+    - name: Build pcre2
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre2
     - name: Build zlib
       run: python3 build/fbcode_builder/getdeps.py build --no-tests zlib
     - name: Build bz2
@@ -123,26 +123,26 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
     - name: Build libtool
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
-    - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build libsodium
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
-    - name: Build xz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
-    - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
-    - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build libffi
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libffi
     - name: Build ncurses
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ncurses
     - name: Build python
       run: python3 build/fbcode_builder/getdeps.py build --no-tests python
+    - name: Build xz
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
+    - name: Build folly
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+    - name: Build fizz
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build wangle
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
     - name: Build fbthrift
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fbthrift
+    - name: Build edencommon
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests edencommon
     - name: Build fb303
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fb303
     - name: Build watchman

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -49,8 +49,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests openssl
     - name: Fetch snappy
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests snappy
-    - name: Fetch pcre
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre
+    - name: Fetch pcre2
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests pcre2
     - name: Fetch libevent
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libevent
     - name: Fetch zlib
@@ -61,8 +61,6 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
     - name: Fetch libtool
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
-    - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch libsodium
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
     - name: Fetch xz
@@ -75,6 +73,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
     - name: Fetch fbthrift
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fbthrift
+    - name: Fetch edencommon
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests edencommon
     - name: Fetch fb303
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fb303
     - name: Build boost
@@ -105,8 +105,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests openssl
     - name: Build snappy
       run: python3 build/fbcode_builder/getdeps.py build --no-tests snappy
-    - name: Build pcre
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre
+    - name: Build pcre2
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests pcre2
     - name: Build libevent
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libevent
     - name: Build zlib
@@ -117,8 +117,6 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
     - name: Build libtool
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
-    - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build libsodium
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
     - name: Build xz
@@ -131,6 +129,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
     - name: Build fbthrift
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fbthrift
+    - name: Build edencommon
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests edencommon
     - name: Build fb303
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fb303
     - name: Build watchman

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -40,8 +40,6 @@ jobs:
       run: python build/fbcode_builder/getdeps.py fetch --no-tests gflags
     - name: Fetch glog
       run: python build/fbcode_builder/getdeps.py fetch --no-tests glog
-    - name: Fetch bison
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch fmt
       run: python build/fbcode_builder/getdeps.py fetch --no-tests fmt
     - name: Fetch googletest
@@ -60,8 +58,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py fetch --no-tests snappy
     - name: Fetch zlib
       run: python build/fbcode_builder/getdeps.py fetch --no-tests zlib
-    - name: Fetch pcre
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests pcre
+    - name: Fetch pcre2
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests pcre2
     - name: Fetch perl
       run: python build/fbcode_builder/getdeps.py fetch --no-tests perl
     - name: Fetch openssl
@@ -70,6 +68,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py fetch --no-tests libevent
     - name: Fetch folly
       run: python build/fbcode_builder/getdeps.py fetch --no-tests folly
+    - name: Fetch edencommon
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests edencommon
     - name: Fetch fizz
       run: python build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
@@ -90,8 +90,6 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --no-tests gflags
     - name: Build glog
       run: python build/fbcode_builder/getdeps.py build --no-tests glog
-    - name: Build bison
-      run: python build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build fmt
       run: python build/fbcode_builder/getdeps.py build --no-tests fmt
     - name: Build googletest
@@ -110,8 +108,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --no-tests snappy
     - name: Build zlib
       run: python build/fbcode_builder/getdeps.py build --no-tests zlib
-    - name: Build pcre
-      run: python build/fbcode_builder/getdeps.py build --no-tests pcre
+    - name: Build pcre2
+      run: python build/fbcode_builder/getdeps.py build --no-tests pcre2
     - name: Build perl
       run: python build/fbcode_builder/getdeps.py build --no-tests perl
     - name: Build openssl
@@ -120,6 +118,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --no-tests libevent
     - name: Build folly
       run: python build/fbcode_builder/getdeps.py build --no-tests folly
+    - name: Build edencommon
+      run: python build/fbcode_builder/getdeps.py build --no-tests edencommon
     - name: Build fizz
       run: python build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build wangle

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -1115,7 +1115,7 @@ jobs:
             help="Allow CI to fire on all branches - Handy for testing",
         )
         parser.add_argument(
-            "--ubuntu-version", default="18.04", help="Version of Ubuntu to use"
+            "--ubuntu-version", default="20.04", help="Version of Ubuntu to use"
         )
         parser.add_argument(
             "--main-branch",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/folly/pull/1842

X-link: https://github.com/facebook/fboss/pull/117

Sadly, even though Ubuntu 18.04 is still in LTS, GitHub is deprecating
its runner image.

Migrate the generated GitHub Actions to 20.04.

https://github.com/actions/runner-images/issues/6002

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Reviewed By: fanzeyi

Differential Revision: D38877286

