### PR TITLE
buckconfig: remove all Watchman exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,10 +143,10 @@ include(RustStaticLibrary)
 # roll the checks in together with writing out the features to config.h
 # ourselves here.
 function(config_h LINE)
-  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/config.h.new" "${LINE}\n")
+  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/watchman/config.h.new" "${LINE}\n")
 endfunction()
 
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/config.h.new" "#pragma once\n")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/watchman/config.h.new" "#pragma once\n")
 
 if(NOT WIN32)
   set(WATCHMAN_STATE_DIR "${CMAKE_INSTALL_PREFIX}/var/run/watchman" CACHE STRING
@@ -270,16 +270,16 @@ endif()
 
 # Now close out config.h.  We only want to touch the file if the contents are
 # different, so do a little dance to figure that out.
-if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/config.h")
-  file(MD5 "${CMAKE_CURRENT_BINARY_DIR}/config.h" orig_hash)
-  file(MD5 "${CMAKE_CURRENT_BINARY_DIR}/config.h.new" this_hash)
+if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/watchman/config.h")
+  file(MD5 "${CMAKE_CURRENT_BINARY_DIR}/watchman/config.h" orig_hash)
+  file(MD5 "${CMAKE_CURRENT_BINARY_DIR}/watchman/config.h.new" this_hash)
   if(NOT orig_hash STREQUAL this_hash)
-    file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/config.h.new"
-      "${CMAKE_CURRENT_BINARY_DIR}/config.h")
+    file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/watchman/config.h.new"
+      "${CMAKE_CURRENT_BINARY_DIR}/watchman/config.h")
   endif()
 else()
-  file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/config.h.new"
-    "${CMAKE_CURRENT_BINARY_DIR}/config.h")
+  file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/watchman/config.h.new"
+    "${CMAKE_CURRENT_BINARY_DIR}/watchman/config.h")
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/watchman/thirdparty/libart/src/art.h
+++ b/watchman/thirdparty/libart/src/art.h
@@ -1,6 +1,6 @@
 #ifndef ART_H
 #define ART_H
-#include "config.h" // @manual
+#include "watchman/config.h"
 #include <array>
 #include <cstdint>
 #include <functional>

--- a/watchman/watchman_system.h
+++ b/watchman/watchman_system.h
@@ -14,7 +14,7 @@
 #define __STDC_LIMIT_MACROS
 #define __STDC_FORMAT_MACROS
 #include <folly/portability/SysTypes.h>
-#include "config.h" // @manual=//watchman:config_h
+#include "watchman/config.h"
 
 // This header plays tricks with posix IO functions and
 // can result in ambiguous overloads on Windows if io.h


### PR DESCRIPTION
Summary:
A few of the exceptions for Watchman inn the buckconfig were out of date, but
some were still legit. Since there is an effort to remove all these exceptions,
let's fix the ones that were legit so we can remove all the exceptions.

Reviewed By: fanzeyi

Differential Revision: D38984208

