### PR TITLE
Fix formatters for `w_string` and `w_string_piece`

### DIFF
--- a/watchman/watchman_string.h
+++ b/watchman/watchman_string.h
@@ -551,7 +551,7 @@ struct formatter<w_string> {
   }
 
   template <typename FormatContext>
-  auto format(const w_string& s, FormatContext& ctx) {
+  auto format(const w_string& s, FormatContext& ctx) const {
     return format_to(ctx.out(), "{}", s.view());
   }
 };
@@ -564,7 +564,7 @@ struct formatter<w_string_piece> {
   }
 
   template <typename FormatContext>
-  auto format(const w_string_piece& s, FormatContext& ctx) {
+  auto format(const w_string_piece& s, FormatContext& ctx) const {
     return format_to(ctx.out(), "{}", s.view());
   }
 };


### PR DESCRIPTION
This is needed for fmt 9+. [1]

This fixes a build failure seen while building Watchman 2022.10.10 for Homebrew at Homebrew/homebrew-core#112788 (against fmt 9.1.0). Without this, the build fails with

      /opt/homebrew/include/fmt/format.h:3973:30: error: no matching member function for call to 'format'
        out = value_formatter_.format(map(*it), ctx);
              ~~~~~~~~~~~~~~~~~^~~~~~

Full build logs available [2]. Errors for the arm64 Monterey runner start at [3].

[1] https://fmt.dev/9.0.0/api.html#formatting-user-defined-types
[2] https://github.com/Homebrew/homebrew-core/actions/runs/3220853975
[3] https://github.com/Homebrew/homebrew-core/actions/runs/3220853975/jobs/5276286644#step:6:704