### PR TITLE
Demonstration: fixes the pywatchman build script and documents how to publish an updated version to pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ buck-cache
 /config.sub
 /config.guess
 /configure.lineno
-/python/build
-/python/dist/
+watchman/python/build
+watchman/python/dist/
 /watchman/python/pywatchman.egg-info/
 *.pyc
 *.pyd

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ buck-cache
 watchman/python/build
 watchman/python/dist/
 /watchman/python/pywatchman.egg-info/
+**/*.egg-info
 *.pyc
 *.pyd
 *.so
@@ -98,3 +99,4 @@ cppclient/watchmanclient.pc
 /external
 /common
 /eden
+wheelhouse

--- a/watchman/python/setup.py
+++ b/watchman/python/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 
 watchman_src_dir = os.environ.get("CMAKE_CURRENT_SOURCE_DIR")
 if watchman_src_dir is None:
-    watchman_src_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+    watchman_src_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../..")
 
 # Setuptools is very picky about the path on Windows. They have to be relative
 # paths, and on Windows that means we have to be on the same drive as the source

--- a/watchman/python/setup.py
+++ b/watchman/python/setup.py
@@ -5,6 +5,19 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Build/Upload Notes:
+# - The build would not run from a personal clone, only from a direct clone of the
+#   facebook repo. All changes were made to that checkout and then pushed to my
+#   clone.
+# - cibuildwheel was used to generate the distributions that were published, from
+#   the top level directory:
+#        cibuildwheel --platform macos watchman/python
+#        cibuildwheel --platform linux watchman/python
+#        pipx run build --sdist watchman/python
+# - twine was used to publish the artefacts:
+#        twine upload wheelhouse/* watchman/python/dist/*
+
+
 
 import os
 

--- a/watchman/python/setup.py
+++ b/watchman/python/setup.py
@@ -27,6 +27,25 @@ if os.name == "nt":
     os.chdir(py_dir)
     py_dir = os.path.relpath(py_dir)
 
+long_description = """Connect and query Watchman to discover file changes.
+
+This is an unofficial release that aims to make a recent version of pywatchman
+available to python projects.
+
+Specifically, Django depends on pywatchman to have a modern autoreload process,
+but recent changes to the core watchman process has meant that the latest offical
+release of pywatchman (2017 - v1.4.2) no longer works. Luckily, Django falls back
+to the slower StatReloader, but we've found that to have unacceptable performance
+in large projects.
+
+The Facebook response to issues, particularly on the pywatchman sub-project, has
+been underwhelming for years. I do not plan to maintain this unofficial release
+for a long period of time, but hopefully seeing that it *is* possible to build
+and publish a release will trigger some renewed interest.
+
+Use at your own risk.
+"""
+
 
 def srcs(names):
     """transform a list of sources to be relative to py_dir"""
@@ -34,16 +53,16 @@ def srcs(names):
 
 
 setup(
-    name="pywatchman",
-    version="1.4.1",
+    name="pywatchman-unofficial",
+    version="1.5.0",
     package_dir={"": py_dir},
-    description="Watchman client for python",
+    description="Watchman client for python (unofficial)",
     author="Wez Furlong, Rain",
     author_email="wez@fb.com",
-    maintainer="Wez Furlong",
-    maintainer_email="wez@fb.com",
-    url="https://github.com/facebook/watchman",
-    long_description="Connect and query Watchman to discover file changes",
+    maintainer="Josh Smeaton",
+    maintainer_email="josh.smeaton@gmail.com",
+    url="https://github.com/jarshwah/watchman",
+    long_description=long_description,
     keywords=("watchman inotify fsevents kevent kqueue portfs filesystem watcher"),
     license="BSD",
     packages=["pywatchman"],


### PR DESCRIPTION
pywatchman hasn't seen a release in 5 years: https://pypi.org/project/pywatchman/1.4.1/

The main watchman project is now incompatible with pywatchman meaning the pywatchman library is effectively dead without a new release.

I spent some time figuring out how to build it and have published an unofficial version from the latest (as of 2022-11-21) checkout. I've included some sparse notes within `setup.py` on how I built and published in case it's useful to anyone wanting to publish or maintain their own version, or to spur some interest from Meta folk that might want to publish an official update.

I don't expect this PR to be merged, particularly since only the first commit (fixing the build dir path) is relevant to the official distribution.


https://github.com/facebook/watchman/issues/1065
https://pypi.org/project/pywatchman-unofficial/1.5.0/