### PR TITLE
CMakeLists.txt: Fix build with CMake 3.25.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,10 +237,10 @@ foreach(wat_header
     sys/vfs.h
     valgrind/valgrind.h
 )
-  CHECK_INCLUDE_FILES(${wat_header} have_${wat_header})
-  if (have_${wat_header})
-    string(TOUPPER have_${wat_header} sym)
-    string(REGEX REPLACE [./] _ sym ${sym})
+  string(TOUPPER have_${wat_header} sym)
+  string(REGEX REPLACE [./] _ sym ${sym})
+  CHECK_INCLUDE_FILES(${wat_header} ${sym})
+  if (${sym})
     config_h("#define ${sym} 1")
   endif()
 endforeach(wat_header)


### PR DESCRIPTION
A change in CMake 3.25.0 makes `CHECK_INCLUDE_FILES` refuse a second argument that contains slashes, because it will eventually be passed to `try_compile` as a `SOURCE_FROM_VAR` argument, which cannot contain path components [^1]:

```plaintext
CMake Error at /opt/homebrew/Cellar/cmake/3.25.0/share/cmake/Modules/CheckIncludeFiles.cmake:136 (try_compile):
  SOURCE_FROM_VAR given invalid filename "have_CoreServices/CoreServices.h.c"
Call Stack (most recent call first):
  CMakeLists.txt:240 (CHECK_INCLUDE_FILES)
```

While this has already been reported to CMake [^2], this patch is still necessary to fix build with the already-released version.

[^1]: https://cmake.org/cmake/help/latest/command/try_compile.html
[^2]: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7960
