### PR TITLE
[docs][contributing] Add note for minimum python3 version for Apple silicon

### DIFF
--- a/website/_docs/contributing.markdown
+++ b/website/_docs/contributing.markdown
@@ -29,7 +29,7 @@ Please [read the full text](https://code.facebook.com/codeofconduct) so that you
 You need to be able to build watchman from source and run its test suite.
 You will need:
 
-* python
+* python (>=3.9.2 to build on Apple silicon - M1, etc)
 * automake
 * autoconf
 * cmake


### PR DESCRIPTION
M1 macbooks appear to have a default system Python3 version of 3.8.x, with a "universal" executable that incorrectly reports the platform (`platform.machine()`) as `x86_64`. This causes Watchman's `./autogen.sh` to try to build for `x86_64`, which eventually causes linker errors with pre-installed dependencies eg `building for macOS-x86_64 but attempting to link with file built for macOS-arm64`. See also https://github.com/pyinstaller/pyinstaller/issues/5315

Updating python fixes this issue, as noted in linked issue above:
```
$ python3
Python 3.10.8 (main, Dec 12 2022, 22:56:05) [Clang 14.0.0 (clang-1400.0.29.102)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> platform.machine()
'arm64'
```

We may want more robust auto-detection here, but I'm filing this partly as an RFC and because a note in the docs is better than nothing.