### PR TITLE
Fix build with GCC 13 (add missing <cstdint> include)

### DIFF
--- a/watchman/Errors.h
+++ b/watchman/Errors.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <cstdint>
 #include <string>
 #include <system_error>
 


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so <cstdint> is no longer transitively included.

Explicitly include <cstdint> for uint32_t.

Signed-off-by: Sam James <sam@gentoo.org>