### PR TITLE
[Rust] Fix `cclock` / `oclock` typo

### DIFF
--- a/watchman/rust/watchman_client/src/fields.rs
+++ b/watchman/rust/watchman_client/src/fields.rs
@@ -118,7 +118,7 @@ define_field!(
     /// change in this file or its metadata.
     ObservedClockField,
     ClockSpec,
-    "cclock"
+    "oclock"
 );
 
 define_field!(


### PR DESCRIPTION
This field was incorrectly reading the Created clock rather than the Observed clock