### PR TITLE
Remove always true check

### DIFF
--- a/watchman/thirdparty/libart/src/art-inl.h
+++ b/watchman/thirdparty/libart/src/art-inl.h
@@ -58,7 +58,7 @@ inline unsigned char art_tree<ValueType, KeyType>::keyAt(
 #if !ART_SANITIZE_ADDRESS
     // If we were built with -fsanitize=address, let ASAN catch this,
     // otherwise, make sure we blow up if the input depth is out of bounds.
-    assert(idx >= 0 && idx <= key_len);
+    assert(idx <= key_len);
 #endif
     return key[idx];
 }


### PR DESCRIPTION
`idx` is unsigned so it's always non-negative. This change removes a warning.