### PR TITLE
Fix build with fmt 10

### DIFF
--- a/watchman/PDU.h
+++ b/watchman/PDU.h
@@ -23,6 +23,11 @@ enum PduType : uint32_t {
   is_bser_v2
 };
 
+// Required for fmt 10
+inline uint32_t format_as(PduType type) {
+  return static_cast<uint32_t>(type);
+}
+
 /**
  * Specifies the wire encoding of a Watchman request or response.
  *

--- a/watchman/thirdparty/jansson/jansson.h
+++ b/watchman/thirdparty/jansson/jansson.h
@@ -34,6 +34,11 @@ enum json_type : char {
   JSON_NULL
 };
 
+// Required for fmt 10
+inline char format_as(json_type type) {
+  return static_cast<char>(type);
+}
+
 struct json_t {
   json_type type;
   std::atomic<size_t> refcount;

--- a/watchman/watcher/eden.cpp
+++ b/watchman/watcher/eden.cpp
@@ -680,7 +680,7 @@ std::vector<NameAndDType> globNameAndDType(
           "Thrift exception raised from EdenFS when globbing files: {} (errno {}, type {})\n",
           ex.what(),
           ex.getErrno(),
-          ex.getType());
+          fmt::underlying(ex.getType()));
       throw;
     } catch (const std::exception& ex) {
       logf(

--- a/watchman/watchman_string.h
+++ b/watchman/watchman_string.h
@@ -35,6 +35,11 @@ enum w_string_type_t : uint8_t {
 // 32-bit flag next to the reference count.
 static_assert(sizeof(size_t) == 8);
 
+// Required for fmt 10
+inline uint8_t format_as(w_string_type_t type) {
+  return static_cast<uint8_t>(type);
+}
+
 namespace watchman {
 
 /**


### PR DESCRIPTION
Fixes #1140 

Starting version 10, fmt requires enums to be explicitly casted to their underlying type or have a `format_as` overload.

This PR addresses this issue by:
- defining `format_as` overloads for enums declared within the project, since all enums have type specifier, they can be directly casted to the underlying type.
- using `fmt::underlying` for `apache::thrift::transport::TTransportException` since it is provided by a dependency.