### PR TITLE
Update README due to contributing link change

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,4 +38,4 @@ Please submit a [GitHub issue](https://github.com/facebook/watchman/issues/) to 
 
 ## Contributing
 
-Please see the [contributing guide](https://facebook.github.io/watchman/contributing.html).
+Please see the [contributing guide](https://facebook.github.io/watchman/docs/contributing).


### PR DESCRIPTION
The original link url is not valid anymore.

![CleanShot 2023-12-19 at 22 54 11](https://github.com/facebook/watchman/assets/3753893/75d6c4c3-3942-482c-8612-9a2d8c060327)

Change to https://facebook.github.io/watchman/docs/contributing