### PR TITLE
Fix pluralization

### DIFF
--- a/watchman/root/threading.cpp
+++ b/watchman/root/threading.cpp
@@ -28,7 +28,9 @@ void Root::scheduleRecrawl(const char* why) {
         info->warning = w_string::build(
             "Recrawled this watch ",
             info->recrawlCount,
-            " times, most recently because:\n",
+            " time",
+            info->recrawlCount != 1 ? "s" : "",
+            ", most recently because:\n",
             why,
             "To resolve, please review the information on\n",
             cfg_get_trouble_url(),

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -56,7 +56,7 @@ macOS has a similar internal limit and behavior when that limit is exceeded. If
 you're encountering a message like:
 
 ```
-Recrawled this watch 1 times, most recently because:
+Recrawled this watch 1 time, most recently because:
 /some/path: kFSEventStreamEventFlagUserDropped
 ```
 


### PR DESCRIPTION
This replaces "Recrawled this watch 1 times" with "Recrawled this watch 1 time".