### PR TITLE
python: fix on readme warning + remove import os from setup.py

### DIFF
--- a/watchman/python/README.md
+++ b/watchman/python/README.md
@@ -1,0 +1,9 @@
+# Watchman client for Python
+
+This directory contains the Watchman client for Python.
+
+## Build
+
+```sh
+python -m build
+```

--- a/watchman/python/pyproject.toml
+++ b/watchman/python/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Watchman client for Python"
 license = { file = "LICENSE" }
-readme = "../README.md"
+readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/watchman/python/setup.py
+++ b/watchman/python/setup.py
@@ -6,8 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import os
-
 from setuptools import Extension, setup
 
 setup(


### PR DESCRIPTION
- Remove unnecessary import from `setup.py`
- Add `README.md` under python directory.
- Fix readme location in `pyproject.toml` to silence the warning below:
```txt
* Installing packages in isolated environment... (wheel)
* Building wheel...
/tmp/user/1000/build-env-8lb52uj7/lib/python3.10/site-packages/setuptools/config/expand.py:133: SetuptoolsWarning: File '/tmp/user/1000/build-via-sdist-6yl9pr_s/pywatchman-2.0.0/../README.md' cannot be found
```