### PR TITLE
Fix github package upload being forbidden from ci

### DIFF
--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write  #  to create a release
+  packages: write  #  to upload a package
 
 jobs:
   prepare:


### PR DESCRIPTION
`release` workflow started failing since #1071 as upload was only allowed for github release and not github packages.
Resulting in docker image failing to upload which is required for building linux packages.