### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,4 +38,4 @@ Please submit a [GitHub issue](https://github.com/facebook/watchman/issues/) to 
 
 ## Contributing
 
-Please see the [contributing guide](https://facebook.github.io/watchman/contributing.html).
+Please see the [contributing guide](https://facebook.github.io/watchman/docs/contributing).


### PR DESCRIPTION
In the Readme file, the contributing guidelines link redirects to an empty page with the error "page not found".
 Now, I updated it's path.