### PR TITLE
WIP - Implement `maximum_results` option

### DIFF
--- a/watchman/InMemoryView.cpp
+++ b/watchman/InMemoryView.cpp
@@ -588,6 +588,10 @@ void InMemoryView::timeGenerator(const Query* query, QueryContext* ctx) const {
       continue;
     }
 
+    if (ctx->num_results_over_maximum > 0) {
+      continue;
+    }
+
     w_query_process_file(
         query, ctx, std::make_unique<InMemoryFileResult>(f, caches_));
   }
@@ -896,6 +900,10 @@ void InMemoryView::allFilesGenerator(const Query* query, QueryContext* ctx)
   for (f = view->getLatestFile(); f; f = f->next) {
     ctx->bumpNumWalked();
     if (!ctx->fileMatchesRelativeRoot(f)) {
+      continue;
+    }
+
+    if (ctx->num_results_over_maximum > 0) {
       continue;
     }
 

--- a/watchman/cmds/query.cpp
+++ b/watchman/cmds/query.cpp
@@ -40,6 +40,9 @@ static UntypedResponse cmd_query(Client* client, const json_ref& args) {
   if (res.savedStateInfo) {
     response.set("saved-state-info", std::move(*res.savedStateInfo));
   }
+  if (res.exceededMaximumResults) {
+    response.set("exceededMaximumResults", json_boolean(res.exceededMaximumResults));
+  }
 
   add_root_warnings_to_response(response, root);
 

--- a/watchman/cmds/since.cpp
+++ b/watchman/cmds/since.cpp
@@ -45,6 +45,10 @@ static UntypedResponse cmd_since(Client* client, const json_ref& args) {
   if (res.savedStateInfo) {
     response.set("saved-state-info", std::move(*res.savedStateInfo));
   }
+  if (res.exceededMaximumResults) {
+    response.set("exceededMaximumResults", json_boolean(res.exceededMaximumResults));
+  }
+
 
   add_root_warnings_to_response(response, root);
   return response;

--- a/watchman/query/Query.h
+++ b/watchman/query/Query.h
@@ -49,6 +49,16 @@ struct Query {
   uint32_t bench_iterations = 0;
 
   /**
+   * If provided, queries with more than `maximum_results` results will
+   * return an empty results list and a flag indicating the response
+   * has been truncated.
+   *
+   * This is similar to the `empty_on_fresh_instance` option, but for
+   * all back-ends and responses.
+   */
+  std::optional<uint32_t> maximum_results = std::nullopt;
+
+  /**
    * Optional full path to relative root, without and with trailing slash.
    */
   std::optional<w_string> relative_root;

--- a/watchman/query/QueryContext.h
+++ b/watchman/query/QueryContext.h
@@ -69,6 +69,13 @@ struct QueryContext : QueryContextBase {
 
   // How many times we suppressed a result due to dedup checking
   uint32_t num_deduped{0};
+  /**
+   * How many results were dropped due to `maximum_results` being exceeded.
+   *
+   * Note this may be at most 1 due to generators short-circuiting work once the limit
+   * is exceeded.
+   */
+  uint32_t num_results_over_maximum{0};
 
   // Disable fresh instance queries
   bool disableFreshInstance{false};

--- a/watchman/query/QueryResult.h
+++ b/watchman/query/QueryResult.h
@@ -37,6 +37,10 @@ struct QueryResult {
   uint32_t stateTransCountAtStartOfQuery;
   std::optional<json_ref> savedStateInfo;
   QueryDebugInfo debugInfo;
+  /**
+   * True if the result has been truncated due to the `maximum_results` query option.
+   */
+  bool exceededMaximumResults = false;
 };
 
 } // namespace watchman


### PR DESCRIPTION
When working on large mono-repos some queries might take a very long time due to listing all files on the project.

This waiting time is a combination of building the results array and serialising it back.

This commit adds a query option `maximum_results`, which allows clients to ask the server to truncate results above a certain threshold number.

On that case, a flag is sent back indicating to the client results have been truncated.