### PR TITLE
chore: upgrade from structopt to clap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,8 @@ libtool
 ltmain.sh
 cppclient/watchmanclient.pc
 /website/.jekyll-metadata
-/rust/**/Cargo.lock
-/rust/**/target/
+/**/rust/**/Cargo.lock
+/**/rust/**/target/
 /CMakeCache.txt
 /CMakeFiles
 /*.cmake

--- a/watchman/rust/watchman_client/Cargo.toml
+++ b/watchman/rust/watchman_client/Cargo.toml
@@ -20,8 +20,8 @@ thiserror = "1.0"
 tokio = { version = "1.7.1", features = ["full", "test-util"] }
 tokio-util = { version = "0.6", features = ["full"] }
 
-[dev-dependencies]
-structopt = "0.3"
-
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["handleapi", "winuser"] }
+
+[dev-dependencies]
+clap = { version = "4.5.7", features = ["derive"] }

--- a/watchman/rust/watchman_client/examples/glob.rs
+++ b/watchman/rust/watchman_client/examples/glob.rs
@@ -5,16 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::path::PathBuf;
-
+use clap::Parser;
 use serde::Deserialize;
-use structopt::StructOpt;
+use std::path::PathBuf;
 use watchman_client::prelude::*;
 
-#[derive(Debug, StructOpt)]
-#[structopt(about = "Perform a glob query for a path, using watchman")]
-struct Opt {
-    #[structopt(default_value = ".")]
+/// Perform a glob query for a path, using watchman
+#[derive(Debug, Parser)]
+struct Cli {
+    #[arg(default_value = ".")]
     path: PathBuf,
 }
 
@@ -29,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let opt = Opt::from_args();
+    let opt = Cli::parse();
     let client = Connector::new().connect().await?;
     let resolved = client
         .resolve_root(CanonicalPath::canonicalize(opt.path)?)

--- a/watchman/rust/watchman_client/examples/since.rs
+++ b/watchman/rust/watchman_client/examples/since.rs
@@ -8,24 +8,22 @@
 //! This example shows how to send a query to watchman and print out the files
 //! changed since the given timestamp.
 
+use clap::Parser;
 use std::path::PathBuf;
-
-use structopt::StructOpt;
 use watchman_client::prelude::*;
 
-#[derive(Debug, StructOpt)]
-#[structopt(about = "Query files changed since a timestamp")]
-struct Opt {
-    #[structopt()]
-    /// Specifies the clock. Use `watchman clock <PATH>` to retrieve the current clock of a watched
-    /// directory
+/// Query files changed since a timestamp
+#[derive(Debug, Parser)]
+struct Cli {
+    /// Specifies the clock. Use `watchman clock <PATH>` to retrieve the current
+    /// clock of a watched directory
     clock: String,
 
-    #[structopt(short, long)]
+    #[arg(short, long)]
     /// [not recommended] Uses Unix timestamp as clock
     unix_timestamp: bool,
 
-    #[structopt(short, long, default_value = ".")]
+    #[arg(short, long, default_value = ".")]
     /// Specifies the path to watched directory
     path: PathBuf,
 }
@@ -41,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let opt = Opt::from_args();
+    let opt = Cli::parse();
     let client = Connector::new().connect().await?;
     let resolved = client
         .resolve_root(CanonicalPath::canonicalize(opt.path)?)

--- a/watchman/rust/watchman_client/examples/state.rs
+++ b/watchman/rust/watchman_client/examples/state.rs
@@ -5,15 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use clap::Parser;
 use std::path::PathBuf;
-
-use structopt::StructOpt;
 use watchman_client::prelude::*;
 
-#[derive(Debug, StructOpt)]
-#[structopt(about = "Exercise the state-enter and state-leave commands")]
-struct Opt {
-    #[structopt(default_value = ".")]
+/// Exercise the state-enter and state-leave commands
+#[derive(Debug, Parser)]
+struct Cli {
+    #[arg(default_value = ".")]
     path: PathBuf,
 }
 
@@ -28,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let opt = Opt::from_args();
+    let opt = Cli::parse();
     let client = Connector::new().connect().await?;
     let resolved = client
         .resolve_root(CanonicalPath::canonicalize(opt.path)?)

--- a/watchman/rust/watchman_client/examples/subscribe.rs
+++ b/watchman/rust/watchman_client/examples/subscribe.rs
@@ -7,15 +7,15 @@
 
 //! This example shows how to initiate a subscription and print out
 //! file changes as they are reported
+use clap::Parser;
 use std::path::PathBuf;
-
-use structopt::StructOpt;
 use watchman_client::prelude::*;
 
-#[derive(Debug, StructOpt)]
-#[structopt(about = "Subscribe to watchman and stream file changes for a path")]
-struct Opt {
-    #[structopt(default_value = ".")]
+
+/// Subscribe to watchman and stream file changes for a path
+#[derive(Debug, Parser)]
+struct Cli {
+    #[arg(default_value = ".")]
     path: PathBuf,
 }
 
@@ -29,7 +29,7 @@ async fn main() {
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let opt = Opt::from_args();
+    let opt = Cli::parse();
     let client = Connector::new().connect().await?;
     let resolved = client
         .resolve_root(CanonicalPath::canonicalize(opt.path)?)


### PR DESCRIPTION
structopt is in maintence mode and explicitly refers to clap as the successor.  Modernize examples a bit and switch names to match the clap examples.