### PR TITLE
fix: update watchman_client version

### DIFF
--- a/watchman/cli/Cargo.toml
+++ b/watchman/cli/Cargo.toml
@@ -19,7 +19,7 @@ structopt = "0.3.26"
 sysinfo = "0.30.11"
 tabular = "0.2.0"
 tokio = { version = "1.37.0", features = ["full", "test-util", "tracing"] }
-watchman_client = { version = "0.8.0", path = "../rust/watchman_client" }
+watchman_client = { version = "0.9.0", path = "../rust/watchman_client" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.25"


### PR DESCRIPTION
Seeing some build error as below:

```
error: failed to select a version for the requirement `watchman_client = "^0.8.0"`
candidate versions found which didn't match: 0.9.0
```

relates to https://github.com/Homebrew/homebrew-core/pull/175551