### PR TITLE
Add openssl to dependencies for watchman

### DIFF
--- a/build/fbcode_builder/manifests/watchman
+++ b/build/fbcode_builder/manifests/watchman
@@ -20,6 +20,7 @@ folly
 pcre2
 googletest
 python-setuptools
+openssl
 
 [dependencies.fbsource=on]
 rust


### PR DESCRIPTION
Summary:
`openssl` manifest does not show up as a dependency when running ./install-system-packages.sh. Users will have to manually install `openssl` on Debian and Fedora. If the system does not have the appropriate `openssl` package, it should be installed.

Issues:
https://github.com/facebook/watchman/issues/1225
https://github.com/facebook/watchman/issues/1222
