### PR TITLE
Add Linux Mint to `getdeps` Debian package manager options

### DIFF
--- a/build/fbcode_builder/getdeps/platform.py
+++ b/build/fbcode_builder/getdeps/platform.py
@@ -272,7 +272,7 @@ class HostType(object):
             return "homebrew"
         if self.distro in ("fedora", "centos", "centos_stream", "rocky"):
             return "rpm"
-        if self.distro.startswith(("debian", "ubuntu", "pop!_os")):
+        if self.distro.startswith(("debian", "ubuntu", "pop!_os", "mint")):
             return "deb"
         return None
 


### PR DESCRIPTION
Linux Mint is based on Ubuntu and installs correctly with the same options. This adds it to the supported versions so that running `sudo ./install-system-packages.sh` succeeds.