### PR TITLE
Allow state directory based in `$HOME`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,11 @@ if(NOT WIN32)
     target.  Disabling this is useful in the case where the CMAKE_INSTALL_PREFIX
     is owned by a non-privileged user but where the WATCHMAN_STATE_DIR requires
     administrative rights to create and set its permissions.")
+  option(WATCHMAN_USE_XDG_STATE_HOME
+    "If enabled, use $XDG_STATE_HOME/watchman as the Watchman state directory. \
+    XDG_STATE_HOME defaults to $HOME/.local/state."
+    OFF
+  )
 else()
   set(WATCHMAN_STATE_DIR)
   set(INSTALL_WATCHMAN_STATE_DIR)
@@ -189,6 +194,9 @@ if(BUILD_INFO)
   config_h("#define WATCHMAN_BUILD_INFO \"${BUILD_INFO}\"")
 endif ()
 
+if(WATCHMAN_USE_XDG_STATE_HOME)
+  config_h("#define WATCHMAN_USE_XDG_STATE_HOME 1")
+endif()
 
 # While most of these tests are not strictly needed on windows, it is vital
 # that we probe for and find strtoll in order for the jansson build to use


### PR DESCRIPTION
The reasoning for this is already outlined well in #1092.

This would be useful for us in Homebrew, and would probably limit the
number of bug reports you get from Homebrew users that get tripped up by
our hard-coded `WATCHMAN_STATE_DIR`. (See, e.g., #963.)

It should also reduce the number of users who end up with `brew`
building Watchman from source because they're using a non-default
prefix, and hopefully issues from them too (e.g. #1132).

Closes #1092.
