### PR TITLE
Extend `gtest_discover_tests` timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,7 +754,7 @@ function(t_test NAME)
   )
   target_compile_definitions(${NAME}.t
     PUBLIC WATCHMAN_TEST_SRC_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
-  gtest_discover_tests(${NAME}.t)
+  gtest_discover_tests(${NAME}.t DISCOVERY_TIMEOUT 60)
   list(APPEND tests ${NAME}.t)
 endfunction()
 


### PR DESCRIPTION
Parallel builds can fail intermittently with the default timeout for
`gtest_discover_tests`.[^1]

At Homebrew, we've been using this change for a while with no problems[^2],
so I hope it would be helpful to upstream it.

[^1]: See https://cmake.org/cmake/help/latest/module/GoogleTest.html#command:gtest_discover_tests
[^2]: Since https://github.com/Homebrew/homebrew-core/commit/3e9b81fe294535117437ec4c9f1b32b3634419bf
