### PR TITLE
Fix build on big-endian architectures

### DIFF
--- a/watchman/rust/serde_bser/src/ser/mod.rs
+++ b/watchman/rust/serde_bser/src/ser/mod.rs
@@ -133,7 +133,7 @@ where
         #[cfg(target_endian = "little")]
         self.scratch.put_i16_le(v);
         #[cfg(target_endian = "big")]
-        self.scratch.put_i16_be(v);
+        self.scratch.put_i16(v);
     }
 
     #[inline]
@@ -143,7 +143,7 @@ where
         #[cfg(target_endian = "little")]
         self.scratch.put_i32_le(v);
         #[cfg(target_endian = "big")]
-        self.scratch.put_i32_be(v);
+        self.scratch.put_i32(v);
     }
 
     #[inline]
@@ -153,7 +153,7 @@ where
         #[cfg(target_endian = "little")]
         self.scratch.put_i64_le(v);
         #[cfg(target_endian = "big")]
-        self.scratch.put_i64_be(v);
+        self.scratch.put_i64(v);
     }
 }
 
@@ -255,7 +255,7 @@ where
         #[cfg(target_endian = "little")]
         self.scratch.put_f64_le(v);
         #[cfg(target_endian = "big")]
-        self.scratch.put_f64_be(v);
+        self.scratch.put_f64(v);
         Ok(())
     }
 


### PR DESCRIPTION
Per https://docs.rs/bytes/1.6.1/bytes/buf/trait.BufMut.html#method.put_i16, there are no *_be functions, the ones for big-endian do not have any suffix.