### PR TITLE
[docs] fix formatting on install guide

### DIFF
--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -7,9 +7,9 @@ category: Installation
 
 Watchman is known to compile and pass its test suite on:
 
-- <i class="fa fa-linux"></i> Linux systems with `inotify`
-- <i class="fa fa-apple"></i> macOS (uses `FSEvents` on 10.7+, `kqueue(2)` on
-  earlier versions)
+- <i class="fa fa-linux"></i> Linux systems with <code>inotify</code>
+- <i class="fa fa-apple"></i> macOS (uses <code>FSEvents</code> on 10.7+,
+  <code>kqueue(2)</code> on earlier versions)
 - <i class="fa fa-windows"></i> Windows 10 (64-bit) and up. Windows 7 support is
   provided by community patches
 


### PR DESCRIPTION
I don't really know why, but it seems like using HTML and code (`` ` ``) on the same line in a list item isn't working.

See: [before](https://i.imgur.com/6hvQKKO.png) (first two unordered list items under "System Requirements")

If we change `` ` `` to `<code>` (which is what it expands to currently anyways), it'll render as expected.

Of course this could mess things up if `` ` `` ever expanded to something other than `<code>`, but the current setup doesn't work either so might as well.