### PR TITLE
fix: bump sysinfo to 0.32.1

### DIFF
--- a/watchman/cli/Cargo.toml
+++ b/watchman/cli/Cargo.toml
@@ -16,7 +16,7 @@ jwalk = "0.6"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.132", features = ["float_roundtrip", "unbounded_depth"] }
 structopt = "0.3.26"
-sysinfo = "0.30.11"
+sysinfo = "0.32.1"
 tabular = "0.2.0"
 tokio = { version = "1.41.0", features = ["full", "test-util", "tracing"] }
 watchman_client = { version = "0.9.0", path = "../rust/watchman_client" }


### PR DESCRIPTION
seeing some build failure as in https://github.com/GuillaumeGomez/sysinfo/issues/1392 while building the latest release.

Bumping sysinfo crate to 0.32.1 fixed the issue, relates to https://github.com/Homebrew/homebrew-core/pull/198962

fixes https://github.com/facebook/watchman/issues/1254