### PR TITLE
exclude lz4-static on rocky linux

### DIFF
--- a/build/fbcode_builder/manifests/lz4
+++ b/build/fbcode_builder/manifests/lz4
@@ -6,8 +6,8 @@ lz4
 
 [rpms]
 lz4-devel
-# centos 8 and centos_stream 9 are missing this rpm
-[rpms.not(any(all(distro=centos,distro_vers=8),all(distro=centos_stream,distro_vers=9)))]
+# centos 8, centos_stream 9 and rocky are missing this rpm
+[rpms.not(any(all(distro=centos,distro_vers=8),all(distro=centos_stream,distro_vers=9),distro=rocky))]
 lz4-static
 
 [debs]


### PR DESCRIPTION
got the following error running `sudo python3 ./build/fbcode_builder/getdeps.py install-system-deps --recursive watchman` on rocky linux:
```
No match for argument: lz4-static
```