### PR TITLE
Unbreak generate-release-yml.rs, update Ubuntu/Fedora Docker bases

### DIFF
--- a/.github/workflows/generate-release-yml.rs
+++ b/.github/workflows/generate-release-yml.rs
@@ -1,11 +1,8 @@
 #!/usr/bin/env rust-script
-/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
+//! Copyright (c) Meta Platforms, Inc. and affiliates.
+//!
+//! This source code is licensed under the MIT license found in the
+//! LICENSE file in the root directory of this source tree.
 //!
 //! ```cargo
 //! [dependencies]
@@ -33,12 +30,12 @@ fn parse_pattern(pattern: &String) -> Option<(Pattern, Vec<&'static str>)> {
     if pattern.contains("%UBUNTU_LTS_VERSION%") {
         Some((
             Box::new(move |p: &str, s: &str| p.replace("%UBUNTU_LTS_VERSION%", s)),
-            vec!["20", "22"],
+            vec!["22", "24"],
         ))
     } else if pattern.contains("%FEDORA_STABLE_VERSION%") {
         Some((
             Box::new(move |p: &str, s: &str| p.replace("%FEDORA_STABLE_VERSION%", s)),
-            vec!["36", "37", "38"],
+            vec!["40", "41", "42"],
         ))
     } else {
         None

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,23 +7,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
-          build-args: "UBUNTU_VERSION=22.04"
+          build-args: "UBUNTU_VERSION=24.04"
           file: watchman/build/package/ubuntu-env/Dockerfile
           push: true
           tags: ${{ format('ghcr.io/{0}/watchman-build-env:latest', github.repository) }}
@@ -35,7 +35,7 @@ jobs:
       image: ${{ format('ghcr.io/{0}/watchman-build-env:latest', github.repository) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: rustup default stable
         run: rustup default stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,9 @@ name: release
   push:
     tags:
       - v*
-
 permissions:
-  contents: write  #  to create a release
-
+  contents: write
+  packages: write
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -29,154 +28,123 @@ jobs:
         with:
           tag_name: "${{ github.ref }}"
           release_name: "${{ github.ref }}"
-  docker-ubuntu-20:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: "${{ github.repository_owner }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: "."
-          build-args: UBUNTU_VERSION=20.04
-          file: watchman/build/package/ubuntu-env/Dockerfile
-          push: true
-          tags: "${{ format('ghcr.io/{0}/watchman-build-env-ubuntu-20:latest', github.repository) }}"
   docker-ubuntu-22:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: "."
           build-args: UBUNTU_VERSION=22.04
           file: watchman/build/package/ubuntu-env/Dockerfile
           push: true
-          tags: "${{ format('ghcr.io/{0}/watchman-build-env-ubuntu-22:latest', github.repository) }}"
-  docker-fedora-36:
+          tags: "${{ format('ghcr.io/{0}/watchman-build-env:ubuntu-22-latest', github.repository) }}"
+  docker-ubuntu-24:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: "."
-          build-args: FEDORA_VERSION=36
-          file: watchman/build/package/fedora-env/Dockerfile
+          build-args: UBUNTU_VERSION=24.04
+          file: watchman/build/package/ubuntu-env/Dockerfile
           push: true
-          tags: "${{ format('ghcr.io/{0}/watchman-build-env-fedora-36:latest', github.repository) }}"
-  docker-fedora-37:
+          tags: "${{ format('ghcr.io/{0}/watchman-build-env:ubuntu-24-latest', github.repository) }}"
+  docker-fedora-40:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: "."
-          build-args: FEDORA_VERSION=37
+          build-args: FEDORA_VERSION=40
           file: watchman/build/package/fedora-env/Dockerfile
           push: true
-          tags: "${{ format('ghcr.io/{0}/watchman-build-env-fedora-37:latest', github.repository) }}"
-  docker-fedora-38:
+          tags: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-40-latest', github.repository) }}"
+  docker-fedora-41:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: "."
-          build-args: FEDORA_VERSION=38
+          build-args: FEDORA_VERSION=41
           file: watchman/build/package/fedora-env/Dockerfile
           push: true
-          tags: "${{ format('ghcr.io/{0}/watchman-build-env-fedora-38:latest', github.repository) }}"
-  clone-build-package-ubuntu-20:
-    needs:
-      - prepare
-      - docker-ubuntu-20
+          tags: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-41-latest', github.repository) }}"
+  docker-fedora-42:
     runs-on: ubuntu-latest
-    container:
-      image: "${{ format('ghcr.io/{0}/watchman-build-env-ubuntu-20:latest', github.repository) }}"
     steps:
-      - name: Fix HOME
-        run: echo HOME=/root >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Install system dependencies
-        run: "./install-system-packages.sh"
-      - name: Fix dubious ownership
-        run: git config --global --add safe.directory /__w/watchman/watchman
-      - name: Build Watchman binaries
-        run: "./autogen.sh"
-      - name: Make .deb
-        env:
-          UBUNTU_VERSION: "20.04"
-        run: "./watchman/build/package/make-deb.sh"
-      - name: Upload .deb
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        uses: actions/upload-release-asset@v1
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          upload_url: "${{ needs.prepare.outputs.upload_url }}"
-          asset_path: /_debs/watchman.deb
-          asset_name: "watchman_ubuntu20.04_${{ needs.prepare.outputs.release }}.deb"
-          asset_content_type: application/x-deb
+          registry: ghcr.io
+          username: "${{ github.repository_owner }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: "."
+          build-args: FEDORA_VERSION=42
+          file: watchman/build/package/fedora-env/Dockerfile
+          push: true
+          tags: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-42-latest', github.repository) }}"
   clone-build-package-ubuntu-22:
     needs:
       - prepare
       - docker-ubuntu-22
     runs-on: ubuntu-latest
     container:
-      image: "${{ format('ghcr.io/{0}/watchman-build-env-ubuntu-22:latest', github.repository) }}"
+      image: "${{ format('ghcr.io/{0}/watchman-build-env:ubuntu-22-latest', github.repository) }}"
     steps:
       - name: Fix HOME
         run: echo HOME=/root >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install system dependencies
         run: "./install-system-packages.sh"
       - name: Fix dubious ownership
@@ -196,18 +164,49 @@ jobs:
           asset_path: /_debs/watchman.deb
           asset_name: "watchman_ubuntu22.04_${{ needs.prepare.outputs.release }}.deb"
           asset_content_type: application/x-deb
-  clone-build-package-fedora-36:
+  clone-build-package-ubuntu-24:
     needs:
       - prepare
-      - docker-fedora-36
+      - docker-ubuntu-24
     runs-on: ubuntu-latest
     container:
-      image: "${{ format('ghcr.io/{0}/watchman-build-env-fedora-36:latest', github.repository) }}"
+      image: "${{ format('ghcr.io/{0}/watchman-build-env:ubuntu-24-latest', github.repository) }}"
     steps:
       - name: Fix HOME
         run: echo HOME=/root >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: "./install-system-packages.sh"
+      - name: Fix dubious ownership
+        run: git config --global --add safe.directory /__w/watchman/watchman
+      - name: Build Watchman binaries
+        run: "./autogen.sh"
+      - name: Make .deb
+        env:
+          UBUNTU_VERSION: "24.04"
+        run: "./watchman/build/package/make-deb.sh"
+      - name: Upload .deb
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: "${{ needs.prepare.outputs.upload_url }}"
+          asset_path: /_debs/watchman.deb
+          asset_name: "watchman_ubuntu24.04_${{ needs.prepare.outputs.release }}.deb"
+          asset_content_type: application/x-deb
+  clone-build-package-fedora-40:
+    needs:
+      - prepare
+      - docker-fedora-40
+    runs-on: ubuntu-latest
+    container:
+      image: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-40-latest', github.repository) }}"
+    steps:
+      - name: Fix HOME
+        run: echo HOME=/root >> $GITHUB_ENV
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install system dependencies
         run: "./install-system-packages.sh"
       - name: Fix dubious ownership
@@ -217,7 +216,7 @@ jobs:
       - name: Make .rpm
         id: make_rpm
         env:
-          FEDORA_VERSION: "36"
+          FEDORA_VERSION: "40"
         run: "./watchman/build/package/make-rpm.sh"
       - name: Upload .rpm
         env:
@@ -228,18 +227,18 @@ jobs:
           asset_path: "${{ steps.make_rpm.outputs.rpm_path }}"
           asset_name: "${{ steps.make_rpm.outputs.rpm_name }}"
           asset_content_type: application/x-rpm
-  clone-build-package-fedora-37:
+  clone-build-package-fedora-41:
     needs:
       - prepare
-      - docker-fedora-37
+      - docker-fedora-41
     runs-on: ubuntu-latest
     container:
-      image: "${{ format('ghcr.io/{0}/watchman-build-env-fedora-37:latest', github.repository) }}"
+      image: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-41-latest', github.repository) }}"
     steps:
       - name: Fix HOME
         run: echo HOME=/root >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install system dependencies
         run: "./install-system-packages.sh"
       - name: Fix dubious ownership
@@ -249,7 +248,7 @@ jobs:
       - name: Make .rpm
         id: make_rpm
         env:
-          FEDORA_VERSION: "37"
+          FEDORA_VERSION: "41"
         run: "./watchman/build/package/make-rpm.sh"
       - name: Upload .rpm
         env:
@@ -260,18 +259,18 @@ jobs:
           asset_path: "${{ steps.make_rpm.outputs.rpm_path }}"
           asset_name: "${{ steps.make_rpm.outputs.rpm_name }}"
           asset_content_type: application/x-rpm
-  clone-build-package-fedora-38:
+  clone-build-package-fedora-42:
     needs:
       - prepare
-      - docker-fedora-38
+      - docker-fedora-42
     runs-on: ubuntu-latest
     container:
-      image: "${{ format('ghcr.io/{0}/watchman-build-env-fedora-38:latest', github.repository) }}"
+      image: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-42-latest', github.repository) }}"
     steps:
       - name: Fix HOME
         run: echo HOME=/root >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install system dependencies
         run: "./install-system-packages.sh"
       - name: Fix dubious ownership
@@ -281,7 +280,7 @@ jobs:
       - name: Make .rpm
         id: make_rpm
         env:
-          FEDORA_VERSION: "38"
+          FEDORA_VERSION: "42"
         run: "./watchman/build/package/make-rpm.sh"
       - name: Upload .rpm
         env:
@@ -295,9 +294,9 @@ jobs:
   linux-build:
     continue-on-error: true
     needs: prepare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build watchman
         run: "python3 build/fbcode_builder/getdeps.py build --src-dir=. watchman  --project-install-prefix watchman:/usr/local"
       - name: Copy artifacts
@@ -320,7 +319,7 @@ jobs:
     needs: prepare
     runs-on: macOS-10.15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build watchman
         run: "SDKROOT=$(xcrun --show-sdk-path --sdk macosx11.1) python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local"
       - name: Copy artifacts
@@ -343,7 +342,7 @@ jobs:
     needs: prepare
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Export boost environment
         run: echo BOOST_ROOT=%BOOST_ROOT_1_69_0% >> %GITHUB_ENV%
         shell: cmd

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -34,51 +34,51 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           build-args: "UBUNTU_VERSION=%UBUNTU_LTS_VERSION%.04"
           file: watchman/build/package/ubuntu-env/Dockerfile
           push: true
-          tags: ${{ format('ghcr.io/{0}/watchman-build-env-ubuntu-%UBUNTU_LTS_VERSION%:latest', github.repository) }}
+          tags: ${{ format('ghcr.io/{0}/watchman-build-env:ubuntu-%UBUNTU_LTS_VERSION%-latest', github.repository) }}
 
   docker-fedora-%FEDORA_STABLE_VERSION%:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           build-args: "FEDORA_VERSION=%FEDORA_STABLE_VERSION%"
           file: watchman/build/package/fedora-env/Dockerfile
           push: true
-          tags: ${{ format('ghcr.io/{0}/watchman-build-env-fedora-%FEDORA_STABLE_VERSION%:latest', github.repository) }}
+          tags: ${{ format('ghcr.io/{0}/watchman-build-env:fedora-%FEDORA_STABLE_VERSION%-latest', github.repository) }}
 
   clone-build-package-ubuntu-%UBUNTU_LTS_VERSION%:
     needs:
@@ -86,7 +86,7 @@ jobs:
       - docker-ubuntu-%UBUNTU_LTS_VERSION%
     runs-on: ubuntu-latest
     container:
-      image: ${{ format('ghcr.io/{0}/watchman-build-env-ubuntu-%UBUNTU_LTS_VERSION%:latest', github.repository) }}
+      image: ${{ format('ghcr.io/{0}/watchman-build-env:ubuntu-%UBUNTU_LTS_VERSION%-latest', github.repository) }}
     steps:
       # This allows rustup toolchains to survive between container construction and use.
       # https://github.com/actions/runner/issues/863
@@ -94,7 +94,7 @@ jobs:
         run: echo HOME=/root >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install system dependencies
         run: ./install-system-packages.sh
@@ -126,7 +126,7 @@ jobs:
       - docker-fedora-%FEDORA_STABLE_VERSION%
     runs-on: ubuntu-latest
     container:
-      image: ${{ format('ghcr.io/{0}/watchman-build-env-fedora-%FEDORA_STABLE_VERSION%:latest', github.repository) }}
+      image: ${{ format('ghcr.io/{0}/watchman-build-env:fedora-%FEDORA_STABLE_VERSION%-latest', github.repository) }}
     steps:
       # This allows rustup toolchains to survive between container construction and use.
       # https://github.com/actions/runner/issues/863
@@ -134,7 +134,7 @@ jobs:
         run: echo HOME=/root >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install system dependencies
         run: ./install-system-packages.sh
@@ -164,9 +164,9 @@ jobs:
   linux-build:
     continue-on-error: true
     needs: prepare
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build watchman
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts
@@ -192,7 +192,7 @@ jobs:
     # Xcode 12.4 on the macOS-10.15 image.
     runs-on: macOS-10.15
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build watchman
       run: SDKROOT=$(xcrun --show-sdk-path --sdk macosx11.1) python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts
@@ -216,7 +216,7 @@ jobs:
     needs: prepare
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Export boost environment
       run: "echo BOOST_ROOT=%BOOST_ROOT_1_69_0% >> %GITHUB_ENV%"
       shell: cmd


### PR DESCRIPTION
generate-release-yml.rs:

- Seems like rust-script is picky with the comment format for cargo
  dependencies. Switching from /* */ to //! allows is to correctly
  build the script.
- Remove Ubuntu 20.04 (gcc too old)
- Add Ubuntu 24.04 (latest LTS)
- Remove Fedora 36/37/38 (38 support ended 2024-05-21)
- Add Fedora 40/41/42 (42 to be released 2025-04-22)

release.yml.in:

- Bump action versions
- Switch from `watchman-build-env-DISTRO-VERSION:latest` to
  `watchman-build-env:DISTRO-VERSION-latest`. This will avoid package
  name changes when versions are bumped, which can trigger non-obvious
  permission issues.
- Bump `linux-build` job from ubuntu-20.04 to ubuntu-24.04
- Regenerate release.yml

package.yml:

- Bump action versions
- Switch from ubuntu-22.04 to ubuntu-24.04

Test Plan:
```
cd ~/github/watchman/.github/workflows/
./generate-release-yml.rs

cd ~/github/watchman
docker build --build-arg UBUNTU_VERSION=22.04 -f watchman/build/package/ubuntu-env/Dockerfile .
docker build --build-arg UBUNTU_VERSION=24.04 -f watchman/build/package/ubuntu-env/Dockerfile .
docker build --build-arg FEDORA_VERSION=40 -f watchman/build/package/fedora-env/Dockerfile .
docker build --build-arg FEDORA_VERSION=41 -f watchman/build/package/fedora-env/Dockerfile .
docker build --build-arg FEDORA_VERSION=42 -f watchman/build/package/fedora-env/Dockerfile .

git tag v2025.02.27.00
git push origin v2025.02.27.00
# Compare https://github.com/ckwalsh/watchman/actions/runs/13576588547 vs https://github.com/facebook/watchman/actions/runs/13502516295
# Note - cancelled full build to avoid GitHub Actions Billing
```