### PR TITLE
Add jj to watchman's vcs ignore files.

### DIFF
--- a/watchman/root/init.cpp
+++ b/watchman/root/init.cpp
@@ -140,7 +140,8 @@ json_ref getIgnoreVcs(const Configuration& config) {
     return json_array(
         {typed_string_to_json(".git"),
          typed_string_to_json(".svn"),
-         typed_string_to_json(".hg")});
+         typed_string_to_json(".hg"),
+         typed_string_to_json(".jj")});
   }
 
   if (!ignores->isArray()) {

--- a/watchman/test/IgnoreTest.cpp
+++ b/watchman/test/IgnoreTest.cpp
@@ -45,7 +45,7 @@ const char* ignore_dirs[] = {
     "baz/bar/bar/foo/foo",
     "baz/bar/bar/foo/foo"};
 
-const char* ignore_vcs[] = {".hg", ".svn", ".git"};
+const char* ignore_vcs[] = {".hg", ".svn", ".git", ".jj"};
 
 struct test_case {
   const char* path;
@@ -100,6 +100,7 @@ TEST(Ignore, correctness) {
       {"buildfile", false},
       {"build/lower/baz", true},
       {"builda/hello", false},
+      {".jj/repo/store/foo", true},
   };
 
   init_state(&state);

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -163,8 +163,8 @@ use a default suggestion to relocate the directory to local disk.
 ### ignore_vcs
 
 Apply special VCS ignore logic to the set of named dirs. This option has a
-default value of `[".git", ".hg", ".svn"]`. Dirs that match this option are
-observed and watched using special shallow logic. The shallow watch allows
+default value of `[".git", ".hg", ".svn", ".jj"]`. Dirs that match this option
+are observed and watched using special shallow logic. The shallow watch allows
 watchman to mildly abuse the version control directories to store its query
 cookie files and to observe VCS locking activity without having to watch the
 entire set of VCS data for large trees.


### PR DESCRIPTION
Note: jj does not currently have a lock file - it uses git's lock file.