### PR TITLE
Add missing include to GlobTree.h

### DIFF
--- a/watchman/query/GlobTree.h
+++ b/watchman/query/GlobTree.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This fixes the below error when building with gcc / libstdc++ 15.1.1:
```
In file included from /watchman/watchman/query/GlobTree.cpp:8:
/watchman/watchman/query/GlobTree.h:31:33: error: ‘uint32_t’ has not been declared
   31 |   GlobTree(const char* pattern, uint32_t pattern_len);
      |                                 ^~~~~~~~
/watchman/watchman/query/GlobTree.h:13:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   12 | #include <vector>
  +++ |+#include <cstdint>
   13 |
/watchman/watchman/query/GlobTree.cpp:15:1: error: no declaration matches ‘watchman::GlobTree::GlobTree(const char*, uint32_t)’
   15 | GlobTree::GlobTree(const char* pattern, uint32_t pattern_len)
      | ^~~~~~~~
/watchman/watchman/query/GlobTree.h:19:8: note: candidates are: ‘watchman::GlobTree::GlobTree(watchman::GlobTree&&)’
   19 | struct GlobTree {
      |        ^~~~~~~~
/watchman/watchman/query/GlobTree.h:19:8: note:                 ‘watchman::GlobTree::GlobTree(const watchman::GlobTree&)’
/watchman/watchman/query/GlobTree.h:31:3: note:                 ‘watchman::GlobTree::GlobTree(const char*, int)’
   31 |   GlobTree(const char* pattern, uint32_t pattern_len);
      |   ^~~~~~~~
/watchman/watchman/query/GlobTree.h:19:8: note: ‘struct watchman::GlobTree’ defined here
   19 | struct GlobTree {
```