### PR TITLE
Add async generator API to pywatchman_aio

### DIFF
--- a/watchman/python/pywatchman_aio/__init__.py
+++ b/watchman/python/pywatchman_aio/__init__.py
@@ -258,6 +258,22 @@ class AIOClient:
         self._check_error(res)
         return res
 
+    async def watch_subscription(self, name, root):
+        """Async generator that yields watchman subscription events
+
+        If root is not None, then only yield the subscription
+        data that matches both root and name.  When used in this way,
+        remove processing impacts both the unscoped and scoped stores
+        for the subscription data.
+        """
+        self._check_receive_loop()
+        self._ensure_subscription_queue_exists(name, root)
+        q = self.sub_by_root[root][name]
+        while res := await q.get():
+            self._check_error(res)
+            yield res
+
+
     async def pop_log(self):
         """Get one log from the log queue."""
         self._check_receive_loop()


### PR DESCRIPTION

Summary:
Many of the other client libraries have event driven async APIs, but python does not really have that currently. The best it has is `get_subscription` which acts as a polling api as it directly returns `q.get()` instead of returning the queue itself.

This diff adds an API to yield elements in the queue so that it can be used as an async generator to make the code more event driven.

Test Plan:
tbd
