### PR TITLE
Restore dropped `#include` directives in `fsevents.cpp`

### DIFF
--- a/watchman/watcher/fsevents.cpp
+++ b/watchman/watcher/fsevents.cpp
@@ -5,6 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <folly/String.h>
+#include <folly/Synchronized.h>
+#include <condition_variable>
+#include <iterator>
+#include <mutex>
+
+#include "watchman/Client.h"
+#include "watchman/FlagMap.h"
+#include "watchman/InMemoryView.h"
+#include "watchman/LogConfig.h"
+#include "watchman/fs/Pipe.h"
+#include "watchman/watcher/WatcherRegistry.h"
+#include "watchman/watchman_cmd.h"
+
 #if HAVE_FSEVENTS
 
 #include "watchman/watcher/fsevents.h"


### PR DESCRIPTION
These were incorrectly dropped in 376b9aeab18d75287f7f100313093f99d0b7a82a.

Fixes #1298.

Co-authored-by: Felipe Santos <felipemillhouse@gmail.com>
