### PR TITLE
Update default CMAKE_CXX_STANDARD to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,13 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH})
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   message(STATUS "setting C++ standard to C++${CMAKE_CXX_STANDARD}")
 endif()
 
 # Explicitly enable coroutine support, since GCC does not enable it
-# by default when targeting C++17.
+# by default when targeting C++17/20.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>)
 endif()


### PR DESCRIPTION
Most Meta C++ projects now use C++20 language features, causing the OSS build to fail.

Update the default CMAKE_CXX_STANDARD accordingly.