### PR TITLE
CMake: add missing PathUtils.cpp to watchman target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,6 +624,7 @@ watchman/GroupLookup.cpp
 watchman/IgnoreSet.cpp
 watchman/InMemoryView.cpp
 watchman/Options.cpp
+watchman/PathUtils.cpp
 watchman/PDU.cpp
 watchman/PendingCollection.cpp
 watchman/PerfSample.cpp


### PR DESCRIPTION
Fixes the following linking error:

```
[ 98%] Linking CXX executable bin/watchman
/usr/bin/ld: CMakeFiles/watchman.dir/watchman/main.cpp.o: in function `(anonymous namespace)::get_pid_file()':
/home/builder/pkg_builds/build-watchman-32cab513/src/watchman-2025.09.29.00/watchman/main.cpp:73:(.text+0x275): undefined reference to `watchman::compute_file_name(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, char const*, bool)'
/usr/bin/ld: CMakeFiles/watchman.dir/watchman/main.cpp.o: in function `setup_sock_name()':
/home/builder/pkg_builds/build-watchman-32cab513/src/watchman-2025.09.29.00/watchman/main.cpp:697:(.text+0x1403): undefined reference to `watchman::compute_file_name(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, char const*, bool)'
/usr/bin/ld: /home/builder/pkg_builds/build-watchman-32cab513/src/watchman-2025.09.29.00/watchman/main.cpp:699:(.text+0x142a): undefined reference to `watchman::compute_file_name(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, char const*, bool)'
/usr/bin/ld: /home/builder/pkg_builds/build-watchman-32cab513/src/watchman-2025.09.29.00/watchman/main.cpp:701:(.text+0x146d): undefined reference to `watchman::compute_file_name(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, char const*, bool)'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/watchman.dir/build.make:1989: bin/watchman] Error 1
make[1]: *** [CMakeFiles/Makefile2:638: CMakeFiles/watchman.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```