### PR TITLE
Back out "fix hangs in watchman oss ubuntu tests by excluding liblzma-dev"

### DIFF
--- a/build/fbcode_builder/manifests/glog
+++ b/build/fbcode_builder/manifests/glog
@@ -24,8 +24,7 @@ HAVE_TR1_UNORDERED_SET=OFF
 [homebrew]
 glog
 
-# on ubuntu glog brings in liblzma-dev, which in turn breaks watchman tests
-[debs.not(distro=ubuntu)]
+[debs]
 libgoogle-glog-dev
 
 [rpms.distro=fedora]

--- a/build/fbcode_builder/manifests/libunwind
+++ b/build/fbcode_builder/manifests/libunwind
@@ -5,8 +5,7 @@ name = libunwind
 libunwind-devel
 libunwind
 
-# on ubuntu this brings in liblzma-dev, which in turn breaks watchman tests
-[debs.not(distro=ubuntu)]
+[debs]
 libunwind-dev
 
 # The current libunwind v1.8.1 release has compiler issues with aarch64 (https://github.com/libunwind/libunwind/issues/702).

--- a/build/fbcode_builder/manifests/xz
+++ b/build/fbcode_builder/manifests/xz
@@ -1,8 +1,7 @@
 [manifest]
 name = xz
 
-# ubuntu's package causes watchman's tests to hang
-[debs.not(distro=ubuntu)]
+[debs]
 liblzma-dev
 
 [homebrew]


### PR DESCRIPTION
Summary: Lets see if can back this out and use the system deps now.

Differential Revision: D86604386


