### PR TITLE
fix --free-up-disk action on windows

### DIFF
--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -18,7 +18,7 @@ import typing
 from shlex import quote as shellquote
 from typing import Optional
 
-from .copytree import simple_copytree
+from .copytree import rmtree_more, simple_copytree
 from .dyndeps import create_dyn_dep_munger
 from .envfuncs import add_path_entry, Env, path_search
 from .fetcher import copy_if_different, is_public_commit
@@ -203,7 +203,7 @@ class BuilderBase(object):
                 if os.path.islink(self.build_dir):
                     os.remove(self.build_dir)
                 else:
-                    shutil.rmtree(self.build_dir)
+                    rmtree_more(self.build_dir)
         elif self.build_opts.is_windows():
             # On Windows, emit a wrapper script that can be used to run build artifacts
             # directly from the build directory, without installing them.  On Windows $PATH


### PR DESCRIPTION
Summary:
on windows git checkout sets some files in readonly mode, which can block the free up disk action.

Add a variant of rmtree that checks for this and clears the readonly flag

e.g. failure in https://github.com/facebook/watchman/actions/runs/19267503560/job/55086850056
```
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\shutil.py", line 629, in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\shutil.py", line 627, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 5] Access is denied: 'Z:\build\fbthrift\source\.git\objects\pack\pack-1e9bd81db474c833f5ee1eec341f0ae8f4c05a51.idx'
```

Differential Revision: D86773115


