### PR TITLE
update lz4 to 1.10 to fix windows xxhash duplicate symbol

### DIFF
--- a/build/fbcode_builder/manifests/lz4
+++ b/build/fbcode_builder/manifests/lz4
@@ -17,9 +17,9 @@ liblz4-dev
 lz4
 
 [download]
-url = https://github.com/lz4/lz4/archive/v1.8.3.tar.gz
-sha256 = 33af5936ac06536805f9745e0b6d61da606a1f8b4cc5c04dd3cbaca3b9b4fc43
+url = https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz
+sha256 = 537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
 
 [build]
 builder = cmake
-subdir = lz4-1.8.3/contrib/cmake_unofficial
+subdir = lz4-1.10.0/build/cmake


### PR DESCRIPTION
Summary: Update to 1.10 to get https://github.com/lz4/lz4/pull/1258 which fixes duplicate xxhash symbols

Differential Revision: D87088149


