### PR TITLE
fix windows build setuptools error

### DIFF
--- a/build/fbcode_builder/getdeps/cargo.py
+++ b/build/fbcode_builder/getdeps/cargo.py
@@ -13,7 +13,7 @@ import sys
 import typing
 
 from .builder import BuilderBase
-from .copytree import simple_copytree
+from .copytree import rmtree_more, simple_copytree
 
 if typing.TYPE_CHECKING:
     from .buildopts import BuildOptions
@@ -79,7 +79,7 @@ class CargoBuilder(BuilderBase):
             if os.path.islink(dst):
                 os.remove(dst)
             else:
-                shutil.rmtree(dst)
+                rmtree_more(dst)
         simple_copytree(src, dst)
 
     def recreate_linked_dir(self, src, dst) -> None:

--- a/build/fbcode_builder/manifests/python-setuptools-69
+++ b/build/fbcode_builder/manifests/python-setuptools-69
@@ -1,0 +1,18 @@
+[manifest]
+name = python-setuptools-69
+
+[download]
+url = https://files.pythonhosted.org/packages/c0/7a/3da654f49c95d0cc6e9549a855b5818e66a917e852ec608e77550c8dc08b/setuptools-69.1.1-py3-none-any.whl
+sha256 = 02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56
+
+[build]
+builder = python-wheel
+
+[rpms]
+python3-setuptools
+
+[homebrew]
+python-setuptools
+
+[debs]
+python3-setuptools

--- a/build/fbcode_builder/manifests/watchman
+++ b/build/fbcode_builder/manifests/watchman
@@ -19,7 +19,7 @@ fbthrift
 folly
 pcre2
 googletest
-python-setuptools
+python-setuptools-69
 
 [dependencies.fbsource=on]
 rust


### PR DESCRIPTION
Summary:
The upgrade of setuptools in D79195099 broke pywatchman  build,  Github windows CI erroring with  `AttributeError: module 'setuptools.dist' has no attribute 'check_test_suite'` https://github.com/facebook/watchman/actions/runs/19440507973/job/55622405533#step:131:1188 .  It was only affecting windows as only windows CI is building dependencies form source, the others use system dependencies.

Fix by pinning watchman to the previous setuptools version

Fix to help iterate locally:
*  fix the cargo.py remove behaviour to use rmtree_more.  This fixes repeat local builds while debugging. After the first build was getting `PermissionError: [WinError 5] Access is denied: 'Z:\build\fbthrift\source\.git\objects\pack\pack-250eb41d409d8c0f512fdb239d0225fa35d50c3d.idx'`

Differential Revision: D87655865
