### PR TITLE
Use /proc/self instead of /proc/<pid> in getOpenedPath

### DIFF
--- a/watchman/fs/FileDescriptor.cpp
+++ b/watchman/fs/FileDescriptor.cpp
@@ -7,7 +7,6 @@
 
 #include "watchman/fs/FileDescriptor.h"
 #include <folly/String.h>
-#include <folly/system/Pid.h>
 #include <system_error>
 #include "watchman/fs/FSDetect.h"
 #include "watchman/fs/FileInformation.h"
@@ -228,19 +227,9 @@ w_string FileDescriptor::getOpenedPath() const {
 #elif defined(__linux__) || defined(__sun)
   char procpath[1024];
 #if defined(__linux__)
-  snprintf(
-      procpath,
-      sizeof(procpath),
-      "/proc/%d/fd/%d",
-      folly::get_cached_pid(),
-      fd_);
+  snprintf(procpath, sizeof(procpath), "/proc/self/fd/%d", fd_);
 #elif defined(__sun)
-  snprintf(
-      procpath,
-      sizeof(procpath),
-      "/proc/%d/path/%d",
-      folly::get_cached_pid(),
-      fd_);
+  snprintf(procpath, sizeof(procpath), "/proc/self/path/%d", fd_);
 #endif
 
   // Avoid an extra stat by speculatively attempting to read into


### PR DESCRIPTION
When running in a PID namespace (common in containers), watchman fails
with "need /proc to be mounted!" because it accesses /proc/<PID>/fd/X
using the namespace PID, but /proc may be mounted from the host with
different PID numbering.

The fix is to use /proc/self/fd/X instead of /proc/<getpid()>/fd/X
when resolving file descriptor paths. The /proc/self symlink is always
resolved by the kernel to the current process's /proc entry, regardless
of PID namespace boundaries.

This issue manifests when:
- Process is in a PID namespace (e.g., Docker container)
- /proc is mounted from host or a different namespace
- watchman tries to resolve paths via /proc/<PID>/fd

Error seen:
  getOpenedPath: need /proc to be mounted!: Function not implemented

Affected platforms: Linux containers with PID namespace isolation

