### PR TITLE
Add --allow-system-packages flag to install-system-packages.sh

### DIFF
--- a/install-system-packages.sh
+++ b/install-system-packages.sh
@@ -6,4 +6,4 @@
 # LICENSE file in the root directory of this source tree.
 
 set -x
-python3 "$(dirname "$0")/build/fbcode_builder/getdeps.py" install-system-deps --recursive watchman
+python3 "$(dirname "$0")/build/fbcode_builder/getdeps.py" --allow-system-packages install-system-deps --recursive watchman


### PR DESCRIPTION
Claude thinks this will fix the master failures

This flag is required for getdeps.py to properly install system dependencies, matching the behavior used in the main CI workflows.