### PR TITLE
Install pip in Ubuntu buildenv

### DIFF
--- a/watchman/build/package/ubuntu-env/Dockerfile
+++ b/watchman/build/package/ubuntu-env/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
 RUN apt-get -y update
-RUN apt-get -y install python3 gcc g++ libssl-dev curl sudo
+RUN apt-get -y install python3 python3-pip gcc g++ libssl-dev curl sudo
 
 # Ubuntu 18.04 has an older version of Git, which causes actions/checkout@v3
 # to check out the repository with REST, breaking version number generation.


### PR DESCRIPTION
getdeps requires pip for `install-system-packages` since D77674102, causing errors in the packaging workflow:
```
---
+ pip \
+      install \
+      pex
error running `pip \
+      install \
Traceback (most recent call last):
  File "/__w/watchman/watchman/build/fbcode_builder/getdeps/runcmd.py", line 108, in _run_cmd
    p = subprocess.Popen(
        ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'pip'
```