### PR TITLE
Fix packaging workflows

### DIFF
--- a/.github/workflows/generate-release-yml.rs
+++ b/.github/workflows/generate-release-yml.rs
@@ -35,7 +35,7 @@ fn parse_pattern(pattern: &String) -> Option<(Pattern, Vec<&'static str>)> {
     } else if pattern.contains("%FEDORA_STABLE_VERSION%") {
         Some((
             Box::new(move |p: &str, s: &str| p.replace("%FEDORA_STABLE_VERSION%", s)),
-            vec!["40", "41", "42"],
+            vec!["41", "42", "43"],
         ))
     } else {
         None

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,20 +7,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           build-args: "UBUNTU_VERSION=24.04"
@@ -35,13 +35,17 @@ jobs:
       image: ${{ format('ghcr.io/{0}/watchman-build-env:latest', github.repository) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: rustup default stable
         run: rustup default stable
 
       - name: Install system dependencies
-        run: ./install-system-packages.sh
+        shell: bash
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          ./install-system-packages.sh
 
       - name: Test cargo
         run: cargo --help
@@ -53,4 +57,6 @@ jobs:
         run: ./autogen.sh
 
       - name: Make .deb
+        env:
+          UBUNTU_VERSION: '24.04'
         run: ./watchman/build/package/make-deb.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,17 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: "."
           build-args: UBUNTU_VERSION=22.04
@@ -53,59 +53,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: "."
           build-args: UBUNTU_VERSION=24.04
           file: watchman/build/package/ubuntu-env/Dockerfile
           push: true
           tags: "${{ format('ghcr.io/{0}/watchman-build-env:ubuntu-24-latest', github.repository) }}"
-  docker-fedora-40:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: "${{ github.repository_owner }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: "."
-          build-args: FEDORA_VERSION=40
-          file: watchman/build/package/fedora-env/Dockerfile
-          push: true
-          tags: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-40-latest', github.repository) }}"
   docker-fedora-41:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: "."
           build-args: FEDORA_VERSION=41
@@ -116,23 +95,44 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: "${{ github.repository_owner }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: "."
           build-args: FEDORA_VERSION=42
           file: watchman/build/package/fedora-env/Dockerfile
           push: true
           tags: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-42-latest', github.repository) }}"
+  docker-fedora-43:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: "${{ github.repository_owner }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: "."
+          build-args: FEDORA_VERSION=43
+          file: watchman/build/package/fedora-env/Dockerfile
+          push: true
+          tags: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-43-latest', github.repository) }}"
   clone-build-package-ubuntu-22:
     needs:
       - prepare
@@ -144,9 +144,10 @@ jobs:
       - name: Fix HOME
         run: echo HOME=/root >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install system dependencies
-        run: "./install-system-packages.sh"
+        shell: bash
+        run: "python3 -m venv venv\nsource venv/bin/activate\n./install-system-packages.sh\n"
       - name: Fix dubious ownership
         run: git config --global --add safe.directory /__w/watchman/watchman
       - name: Build Watchman binaries
@@ -175,9 +176,10 @@ jobs:
       - name: Fix HOME
         run: echo HOME=/root >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install system dependencies
-        run: "./install-system-packages.sh"
+        shell: bash
+        run: "python3 -m venv venv\nsource venv/bin/activate\n./install-system-packages.sh\n"
       - name: Fix dubious ownership
         run: git config --global --add safe.directory /__w/watchman/watchman
       - name: Build Watchman binaries
@@ -195,38 +197,6 @@ jobs:
           asset_path: /_debs/watchman.deb
           asset_name: "watchman_ubuntu24.04_${{ needs.prepare.outputs.release }}.deb"
           asset_content_type: application/x-deb
-  clone-build-package-fedora-40:
-    needs:
-      - prepare
-      - docker-fedora-40
-    runs-on: ubuntu-latest
-    container:
-      image: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-40-latest', github.repository) }}"
-    steps:
-      - name: Fix HOME
-        run: echo HOME=/root >> $GITHUB_ENV
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: "./install-system-packages.sh"
-      - name: Fix dubious ownership
-        run: git config --global --add safe.directory /__w/watchman/watchman
-      - name: Build Watchman binaries
-        run: "./autogen.sh"
-      - name: Make .rpm
-        id: make_rpm
-        env:
-          FEDORA_VERSION: "40"
-        run: "./watchman/build/package/make-rpm.sh"
-      - name: Upload .rpm
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: "${{ needs.prepare.outputs.upload_url }}"
-          asset_path: "${{ steps.make_rpm.outputs.rpm_path }}"
-          asset_name: "${{ steps.make_rpm.outputs.rpm_name }}"
-          asset_content_type: application/x-rpm
   clone-build-package-fedora-41:
     needs:
       - prepare
@@ -238,9 +208,10 @@ jobs:
       - name: Fix HOME
         run: echo HOME=/root >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install system dependencies
-        run: "./install-system-packages.sh"
+        shell: bash
+        run: "python3 -m venv venv\nsource venv/bin/activate\n./install-system-packages.sh\n"
       - name: Fix dubious ownership
         run: git config --global --add safe.directory /__w/watchman/watchman
       - name: Build Watchman binaries
@@ -270,9 +241,10 @@ jobs:
       - name: Fix HOME
         run: echo HOME=/root >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install system dependencies
-        run: "./install-system-packages.sh"
+        shell: bash
+        run: "python3 -m venv venv\nsource venv/bin/activate\n./install-system-packages.sh\n"
       - name: Fix dubious ownership
         run: git config --global --add safe.directory /__w/watchman/watchman
       - name: Build Watchman binaries
@@ -291,12 +263,45 @@ jobs:
           asset_path: "${{ steps.make_rpm.outputs.rpm_path }}"
           asset_name: "${{ steps.make_rpm.outputs.rpm_name }}"
           asset_content_type: application/x-rpm
+  clone-build-package-fedora-43:
+    needs:
+      - prepare
+      - docker-fedora-43
+    runs-on: ubuntu-latest
+    container:
+      image: "${{ format('ghcr.io/{0}/watchman-build-env:fedora-43-latest', github.repository) }}"
+    steps:
+      - name: Fix HOME
+        run: echo HOME=/root >> $GITHUB_ENV
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install system dependencies
+        shell: bash
+        run: "python3 -m venv venv\nsource venv/bin/activate\n./install-system-packages.sh\n"
+      - name: Fix dubious ownership
+        run: git config --global --add safe.directory /__w/watchman/watchman
+      - name: Build Watchman binaries
+        run: "./autogen.sh"
+      - name: Make .rpm
+        id: make_rpm
+        env:
+          FEDORA_VERSION: "43"
+        run: "./watchman/build/package/make-rpm.sh"
+      - name: Upload .rpm
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: "${{ needs.prepare.outputs.upload_url }}"
+          asset_path: "${{ steps.make_rpm.outputs.rpm_path }}"
+          asset_name: "${{ steps.make_rpm.outputs.rpm_name }}"
+          asset_content_type: application/x-rpm
   linux-build:
     continue-on-error: true
     needs: prepare
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build watchman
         run: "python3 build/fbcode_builder/getdeps.py build --src-dir=. watchman  --project-install-prefix watchman:/usr/local"
       - name: Copy artifacts

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -34,20 +34,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           build-args: "UBUNTU_VERSION=%UBUNTU_LTS_VERSION%.04"
@@ -59,20 +59,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           build-args: "FEDORA_VERSION=%FEDORA_STABLE_VERSION%"
@@ -94,10 +94,14 @@ jobs:
         run: echo HOME=/root >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
-        run: ./install-system-packages.sh
+        shell: bash
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          ./install-system-packages.sh
 
       - name: Fix dubious ownership
         run: git config --global --add safe.directory /__w/watchman/watchman
@@ -134,10 +138,14 @@ jobs:
         run: echo HOME=/root >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
-        run: ./install-system-packages.sh
+        shell: bash
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          ./install-system-packages.sh
 
       - name: Fix dubious ownership
         run: git config --global --add safe.directory /__w/watchman/watchman
@@ -166,7 +174,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build watchman
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts

--- a/build/fbcode_builder/manifests/fast_float
+++ b/build/fbcode_builder/manifests/fast_float
@@ -16,5 +16,5 @@ FASTFLOAT_SANITIZE = OFF
 [debs.not(all(distro=ubuntu,any(distro_vers="18.04",distro_vers="20.04",distro_vers="22.04",distro_vers="24.04")))]
 libfast-float-dev
 
-[rpms.distro=fedora]
+[rpms.all(distro=fedora,not(any(distro_vers="40",distro_vers="41")))]
 fast_float-devel

--- a/build/fbcode_builder/manifests/gflags
+++ b/build/fbcode_builder/manifests/gflags
@@ -10,10 +10,13 @@ builder = cmake
 subdir = gflags-2.3.0
 
 [cmake.defines]
-BUILD_SHARED_LIBS = ON
 BUILD_STATIC_LIBS = ON
 #BUILD_gflags_nothreads_LIB = OFF
 BUILD_gflags_LIB = ON
+BUILD_SHARED_LIBS = OFF
+
+[cmake.defines.os=windows]
+BUILD_SHARED_LIBS = ON
 
 [homebrew]
 gflags

--- a/build/fbcode_builder/manifests/glog
+++ b/build/fbcode_builder/manifests/glog
@@ -18,9 +18,12 @@ builder = cmake
 gflags
 
 [cmake.defines]
-BUILD_SHARED_LIBS=ON
 BUILD_TESTING=NO
 WITH_PKGCONFIG=ON
+BUILD_SHARED_LIBS=OFF
+
+[cmake.defines.os=windows]
+BUILD_SHARED_LIBS=ON
 
 [cmake.defines.os=freebsd]
 HAVE_TR1_UNORDERED_MAP=OFF

--- a/watchman/build/package/fedora-env/Dockerfile
+++ b/watchman/build/package/fedora-env/Dockerfile
@@ -1,7 +1,7 @@
 ARG FEDORA_VERSION
 FROM fedora:$FEDORA_VERSION
 
-RUN dnf install -y gcc g++ git openssl-devel rpmdevtools
+RUN dnf install -y python3 g++ git openssl-devel rpmdevtools
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/watchman/build/package/substcontrol.py
+++ b/watchman/build/package/substcontrol.py
@@ -27,6 +27,13 @@ DEPENDENCIES_BY_UBUNTU = {
         "libevent-2.1-7",
         "libsnappy1v5",
     ],
+    "24.04": [
+        "libgoogle-glog0v6t64",
+        "libboost-context1.83.0",
+        "libdouble-conversion3",
+        "libevent-2.1-7t64",
+        "libsnappy1v5",
+    ],
 }
 
 

--- a/watchman/build/package/ubuntu-env/Dockerfile
+++ b/watchman/build/package/ubuntu-env/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
 RUN apt-get -y update
-RUN apt-get -y install python3 python3-pip gcc g++ libssl-dev curl sudo
+RUN apt-get -y install python3 python3-pip python3-venv gcc g++ libssl-dev curl sudo
 
 # Ubuntu 18.04 has an older version of Git, which causes actions/checkout@v3
 # to check out the repository with REST, breaking version number generation.


### PR DESCRIPTION
My initial attempt at D90919043 only uncovered more failures, so try and fix the remaining ones:
* Add missing entry for Ubuntu Noble to substcontrol.py.
* Run `install-system-packages.sh` in a venv to workaround the unconditional `pip install pex` call from getdeps. `pex` isn't actually relevant to the watchman build so this just needs to not fail.
* Reapply D93644456 so that we don't produce random shared libraries that conflict with system ones. This appears to have been unintentionally unfixed by D94714599.
* Build fast_float from source on Fedora < 42.
* Drop Fedora 40, add Fedora 43.
* Update third-party workflow versions as we're here.

Tested via:
* https://github.com/mszabo-wikia/watchman/actions/runs/23025768943
* https://github.com/mszabo-wikia/watchman/actions/runs/23025768938

Fixes #1339, fixes #1337, fixes #1335, fixes #1301, fixes #1299, fixes #1282, fixes #1280, fixes #1256