### PR TITLE
Fix 'occured' -> 'occurred' typo in portfs root-delete comment

### DIFF
--- a/watchman/watcher/portfs.cpp
+++ b/watchman/watcher/portfs.cpp
@@ -294,7 +294,7 @@ bool PortFSWatcher::waitNotify(int timeoutms) {
       return false;
     }
     if (pfd[1].revents) {
-      // An exceptional event (delete) occured on the root so delete it
+      // An exceptional event (delete) occurred on the root so delete it
       root_deleted = true;
       return true;
     }


### PR DESCRIPTION
Inline comment in `watchman/watcher/portfs.cpp:297` explaining the root-delete handling read `(delete) occured`. Doc-only change inside a comment in the Solaris portfs watcher.