### PR TITLE
Fix never-true IN_MOVED_TO mask check in inotify watcher

### DIFF
--- a/watchman/integration/test_dir_move.py
+++ b/watchman/integration/test_dir_move.py
@@ -61,3 +61,45 @@ class TestDirMove(WatchmanTestCase.WatchmanTestCase):
         self.build_under(root, "dir", latency=1)
 
         self.assertFileList(root, ["dir", "dir/a"])
+
+    def test_renameDirThenCreateChild(self) -> None:
+        # Regression test: after renaming a watched directory in-tree,
+        # file operations inside the renamed directory must be reported
+        # under the new parent name, not the pre-rename path.
+        #
+        # On Linux/inotify, the IN_MOVED_TO handler previously had an
+        # impossible mask check that left the watcher's wd -> name map
+        # stale after an in-tree directory rename, so subsequent
+        # IN_CREATE/IN_DELETE events on the renamed directory's children
+        # were synthesized under the old parent name and surfaced as
+        # phantom entries.
+        root = self.mkdtemp()
+        old_dir = os.path.join(root, "src")
+        new_dir = os.path.join(root, "dst")
+
+        os.mkdir(old_dir)
+        self.touchRelative(old_dir, "a")
+
+        self.watchmanCommand("watch", root)
+        self.assertFileList(root, ["src", "src/a"])
+
+        clock = self.watchmanCommand("clock", root)["clock"]
+
+        os.rename(old_dir, new_dir)
+        self.touchRelative(new_dir, "b")
+
+        # The settled file list must reflect the rename and the new child.
+        self.assertFileList(root, ["dst", "dst/a", "dst/b"])
+
+        # The since-cursor change set must include dst/b and must not
+        # contain a phantom src/b that would appear if the wd -> name
+        # map were stale.
+        res = self.watchmanCommand(
+            "query",
+            root,
+            {"since": clock, "expression": ["exists"], "fields": ["name"]},
+        )
+        names = set(res["files"])
+        self.assertIn("dst/b", names)
+        self.assertNotIn("src/b", names)
+        self.assertNotIn("src/a", names)

--- a/watchman/watcher/inotify.cpp
+++ b/watchman/watcher/inotify.cpp
@@ -298,7 +298,11 @@ bool InotifyWatcher::process_inotify_event(
     }
 
     if (ine->len > 0 &&
-        (ine->mask & (IN_MOVED_TO | IN_ISDIR)) == (IN_MOVED_FROM | IN_ISDIR)) {
+        (ine->mask & (IN_MOVED_TO | IN_ISDIR)) == (IN_MOVED_TO | IN_ISDIR)) {
+      // A watched directory was renamed inside the watched tree. Refresh
+      // our wd -> name mapping so that subsequent events on children of
+      // the renamed directory report paths under the new parent rather
+      // than the stale pre-rename path.
       auto wlock = maps.wlock();
       auto it = wlock->move_map.find(ine->cookie);
       if (it != wlock->move_map.end()) {
@@ -324,9 +328,25 @@ bool InotifyWatcher::process_inotify_event(
           }
         } else {
           logf(DBG, "moved {} -> {}\n", old.name.c_str(), name.c_str());
-          // TODO: assert that there is no entry in wd_to_name
+          // inotify_add_watch is idempotent and normally returns the same
+          // wd for an in-tree rename. Log if we ever see a different,
+          // already-mapped wd so we can spot wd-reuse anomalies via the
+          // inotify ring log without aborting in production.
+          auto existing = wlock->wd_to_name.find(wd);
+          if (existing != wlock->wd_to_name.end() && existing->second != name) {
+            logf(
+                DBG,
+                "moved: overwriting wd_to_name[{}] {} -> {}\n",
+                wd,
+                existing->second,
+                name);
+          }
           wlock->wd_to_name[wd] = name;
         }
+        // Remove the entry so move_map doesn't accumulate satisfied
+        // moves until the 5s aging pass. Without this, every in-tree
+        // directory rename keeps the cookie hot for up to 5 seconds.
+        wlock->move_map.erase(it);
       } else {
         logf(
             DBG,


### PR DESCRIPTION
## Summary

The `IN_MOVED_TO` branch in `InotifyWatcher::process_inotify_event` (`watchman/watcher/inotify.cpp`) is guarded by a mask check that is provably never true:

```cpp
if (ine->len > 0 &&
    (ine->mask & (IN_MOVED_TO | IN_ISDIR)) == (IN_MOVED_FROM | IN_ISDIR)) {
```

`ine->mask & (IN_MOVED_TO | IN_ISDIR)` strips out every bit except `IN_MOVED_TO` and `IN_ISDIR`, so equality with a value containing `IN_MOVED_FROM` can never hold. The entire branch — which refreshes the watcher's `wd → name` mapping when a watched directory is renamed inside the watched tree and drains the matching cookie from `move_map` — has therefore been dead code since the predicate was introduced in 2015.

The original intent (use `IN_ISDIR` to scope move-tracking to directories) is unambiguous from the surrounding code and original commit message; the RHS just had the wrong constant.

## Impact

With the bug present, after an in-tree directory rename on Linux:

- `wd_to_name[wd]` keeps pointing at the **pre-rename** path. Subsequent `IN_CREATE` / `IN_DELETE` / `IN_MODIFY` events on children of the renamed directory are added to the pending-change collection under the old parent path, surfacing as transient incorrect subscription output until the synthesized parent rescan from `IN_MOVED_TO` converges.
- Satisfied `IN_MOVED_FROM` cookies are never drained on match, so `move_map` carries up to 5 seconds of fulfilled renames at all times under rename-heavy workloads (large `hg` / `git` checkouts, build tools, `find … -execdir mv`).

Both effects are bounded — the IO thread's parent rescan eventually converges — so this didn't manifest as a hard failure, just intermittent incorrect events and a small steady-state memory cost. Existing `test_dir_move` / `test_find` tests only assert on the *settled* file list, which is why this has survived in the tree for about a decade.

## Fix

- Correct the predicate to require `IN_MOVED_TO` on both sides of the equality.
- Erase the matched cookie from `move_map` once consumed, instead of waiting for the 5-second aging pass to clean it up.
- Replace the inline `// TODO: assert that there is no entry in wd_to_name` with a `DBG`-level log when the assignment would overwrite a different existing mapping. `inotify_add_watch` is idempotent and normally returns the same `wd` for an in-tree rename, but logging the unexpected case surfaces wd-reuse anomalies via the inotify ring log without aborting in production.

The fix is strictly additive: the corrected branch is the exact recovery path the original author wrote; no production code currently relies on the branch being dead (when it is dead, the parent rescan compensates lazily).

## Test plan

Added `TestDirMove.test_renameDirThenCreateChild`, which:

1. Watches a root containing `src/a`.
2. Snapshots the clock via `clock`.
3. Renames `src` → `dst` and immediately touches `dst/b` (no sleep, so the `wd → name` map is still stale on the buggy code path).
4. Asserts the settled file list is `{dst, dst/a, dst/b}`.
5. Asserts the since-query change set contains `dst/b` and does **not** contain a phantom `src/b` — which is exactly what would be reported if the `wd → name` map remained stale after the rename.

The test is portable (only `os.name == 'nt'` is skipped, as elsewhere in `test_dir_move.py`); it serves as a positive correctness assertion on `fsevents` / `kqueue` and as a regression test on `inotify`.

## Risk

Very low. Linux-only code path; no API or wire-protocol change; unchanged behavior on macOS (`fsevents`), Windows, `kqueue`, or EdenFS watchers.