### PR TITLE
Include <fmt/format.h> for fmt::format instead of <fmt/core.h>

### DIFF
--- a/watchman/ChildProcess.cpp
+++ b/watchman/ChildProcess.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/ChildProcess.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ScopeGuard.h>
 #include <folly/String.h>
 #include <memory>

--- a/watchman/Client.h
+++ b/watchman/Client.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <chrono>
 #include <deque>

--- a/watchman/ContentHash.cpp
+++ b/watchman/ContentHash.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/ContentHash.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ScopeGuard.h>
 #include <string>
 #include "watchman/Hash.h"

--- a/watchman/CookieSync.cpp
+++ b/watchman/CookieSync.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/CookieSync.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include <exception>
 #include <optional>

--- a/watchman/Errors.h
+++ b/watchman/Errors.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <cstdint>
 #include <string>
 #include <system_error>

--- a/watchman/InMemoryView.cpp
+++ b/watchman/InMemoryView.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/InMemoryView.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ScopeGuard.h>
 #include <algorithm>
 #include <chrono>

--- a/watchman/LRUCache.h
+++ b/watchman/LRUCache.h
@@ -6,7 +6,7 @@
  */
 
 #pragma once
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Synchronized.h>
 #include <folly/futures/Future.h>
 #include <chrono>

--- a/watchman/Logging.cpp
+++ b/watchman/Logging.cpp
@@ -15,7 +15,7 @@
 
 #include "watchman/portability/Backtrace.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <array>
 #include <limits>
 #include <optional>

--- a/watchman/Options.cpp
+++ b/watchman/Options.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/Options.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <string.h>
 #include "watchman/CommandRegistry.h"
 #include "watchman/LogConfig.h"

--- a/watchman/PathUtils.cpp
+++ b/watchman/PathUtils.cpp
@@ -7,7 +7,7 @@
 
 #include "watchman/PathUtils.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Exception.h>
 #include <folly/String.h>
 #include <folly/portability/Fcntl.h>

--- a/watchman/Poison.cpp
+++ b/watchman/Poison.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include "watchman/Logging.h"
 #include "watchman/WatchmanConfig.h"
 

--- a/watchman/ProcessLock.cpp
+++ b/watchman/ProcessLock.cpp
@@ -7,7 +7,7 @@
 
 #include "ProcessLock.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 
 #include "watchman/Logging.h"

--- a/watchman/SanityCheck.cpp
+++ b/watchman/SanityCheck.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 
 #include "watchman/Connect.h"

--- a/watchman/SanityCheck.cpp
+++ b/watchman/SanityCheck.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 
 #ifdef __linux__

--- a/watchman/SignalHandler.cpp
+++ b/watchman/SignalHandler.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include "watchman/Logging.h"
 #include "watchman/Shutdown.h"
 

--- a/watchman/UserDir.cpp
+++ b/watchman/UserDir.cpp
@@ -7,7 +7,7 @@
 
 #include "watchman/UserDir.h"
 #include <eden/common/utils/StringConv.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include <folly/portability/Unistd.h>
 #include "watchman/Logging.h"

--- a/watchman/benchmarks/bser.cpp
+++ b/watchman/benchmarks/bser.cpp
@@ -7,7 +7,7 @@
 
 #include "watchman/bser.h"
 #include <benchmark/benchmark.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <random>
 #include <vector>
 

--- a/watchman/bser.h
+++ b/watchman/bser.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include "watchman/thirdparty/jansson/jansson.h"
 
 typedef struct bser_ctx {

--- a/watchman/cmds/heapprof.cpp
+++ b/watchman/cmds/heapprof.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include <folly/memory/Malloc.h>
 #include "watchman/Client.h"

--- a/watchman/cppclient/WatchmanClient.cpp
+++ b/watchman/cppclient/WatchmanClient.cpp
@@ -7,7 +7,7 @@
 
 #include "WatchmanClient.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <utility>

--- a/watchman/cppclient/WatchmanConnection.cpp
+++ b/watchman/cppclient/WatchmanConnection.cpp
@@ -9,7 +9,7 @@
 
 #include <cstdlib>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/ExceptionWrapper.h>
 #include <folly/SocketAddress.h>

--- a/watchman/fs/FileSystem.cpp
+++ b/watchman/fs/FileSystem.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/fs/FileSystem.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include <system_error>
 #include "watchman/fs/FSDetect.h"

--- a/watchman/fs/ParallelWalk.cpp
+++ b/watchman/fs/ParallelWalk.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/fs/ParallelWalk.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/concurrency/UnboundedQueue.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/system/HardwareConcurrency.h>

--- a/watchman/fs/UnixDirHandle.cpp
+++ b/watchman/fs/UnixDirHandle.cpp
@@ -7,7 +7,7 @@
 
 #include "watchman/fs/DirHandle.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include <system_error>
 #include "watchman/Logging.h"

--- a/watchman/main.cpp
+++ b/watchman/main.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Exception.h>
 #include <folly/ScopeGuard.h>
 #include <folly/Singleton.h>

--- a/watchman/query/GlobTree.cpp
+++ b/watchman/query/GlobTree.cpp
@@ -7,7 +7,7 @@
 
 #include "watchman/query/GlobTree.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Range.h>
 
 namespace watchman {

--- a/watchman/query/TermRegistry.cpp
+++ b/watchman/query/TermRegistry.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/query/TermRegistry.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include "watchman/CommandRegistry.h"
 #include "watchman/Errors.h"
 #include "watchman/query/QueryExpr.h"

--- a/watchman/query/intcompare.cpp
+++ b/watchman/query/intcompare.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/query/intcompare.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include "watchman/Errors.h"
 #include "watchman/query/FileResult.h"
 #include "watchman/query/QueryExpr.h"

--- a/watchman/query/parse.cpp
+++ b/watchman/query/parse.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "watchman/CommandRegistry.h"
 #include "watchman/Errors.h"

--- a/watchman/query/pcre.cpp
+++ b/watchman/query/pcre.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <memory>
 #include "watchman/Errors.h"
 #include "watchman/fs/FileSystem.h"

--- a/watchman/query/type.cpp
+++ b/watchman/query/type.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include "watchman/Errors.h"
 #include "watchman/fs/FileInformation.h"
 #include "watchman/query/FileResult.h"

--- a/watchman/root/init.cpp
+++ b/watchman/root/init.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include "watchman/Logging.h"
 #include "watchman/QueryableView.h"

--- a/watchman/root/resolve.cpp
+++ b/watchman/root/resolve.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include <system_error>
 #include "watchman/Errors.h"

--- a/watchman/root/watchlist.cpp
+++ b/watchman/root/watchlist.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/root/watchlist.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Synchronized.h>
 #include <vector>
 #include "watchman/QueryableView.h"

--- a/watchman/scm/Git.cpp
+++ b/watchman/scm/Git.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/scm/Git.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include <folly/portability/SysTime.h>
 #include "watchman/ChildProcess.h"

--- a/watchman/scm/Mercurial.cpp
+++ b/watchman/scm/Mercurial.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "Mercurial.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include <folly/portability/SysTime.h>
 #include <chrono>

--- a/watchman/test/ArtTest.cpp
+++ b/watchman/test/ArtTest.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/logging/xlog.h>
 #include <folly/portability/GTest.h>
 #include <stdio.h>

--- a/watchman/test/BserTest.cpp
+++ b/watchman/test/BserTest.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "watchman/bser.h"
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ScopeGuard.h>
 #include <folly/logging/xlog.h>
 #include <folly/portability/GTest.h>

--- a/watchman/thirdparty/jansson/load.cpp
+++ b/watchman/thirdparty/jansson/load.cpp
@@ -20,7 +20,7 @@
 
 #include <system_error>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 
 

--- a/watchman/thirdparty/jansson/value.cpp
+++ b/watchman/thirdparty/jansson/value.cpp
@@ -13,7 +13,7 @@
 
 #include <algorithm>
 #include <cmath>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <string>
 #include <sstream>
 

--- a/watchman/watcher/WatcherRegistry.cpp
+++ b/watchman/watcher/WatcherRegistry.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "watchman/watcher/WatcherRegistry.h"
 

--- a/watchman/watcher/eden.cpp
+++ b/watchman/watcher/eden.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <cpptoml.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ScopeGuard.h>
 #include <folly/String.h>
 #include <folly/futures/Future.h>

--- a/watchman/watcher/eden.cpp
+++ b/watchman/watcher/eden.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <cpptoml.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/FBString.h>
 #include <folly/ScopeGuard.h>
 #include <folly/String.h>

--- a/watchman/watchman_string.h
+++ b/watchman/watchman_string.h
@@ -9,7 +9,7 @@
 
 #include "watchman/watchman_system.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/FBString.h>
 
 #include <stdint.h>

--- a/watchman/winbuild/susres.cpp
+++ b/watchman/winbuild/susres.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <errno.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <windows.h>


### PR DESCRIPTION
These files call fmt::format/format_to and included <fmt/core.h>, relying on it to pull in the formatting API. Since fmt 12.2, <fmt/core.h> no longer defines fmt::format (it must be included via <fmt/format.h>), so they fail to compile with "no member named 'format' in namespace 'fmt'". Include <fmt/format.h> directly where fmt::format is used.