### PR TITLE
Fix duplicated-word typos in comments and docs

### DIFF
--- a/watchman/XattrUtils.h
+++ b/watchman/XattrUtils.h
@@ -14,7 +14,7 @@ namespace watchman {
  * This function avoids needing to use chmod which wont work if the user is not
  * a member of the secondary group.
  *
- * @param path The path to to set attributes on
+ * @param path The path to set attributes on
  * @param secondary_group_name The name of the secondary group
  * @param read If the secondary group should be given read permissions
  * @param write If the secondary group should be given write permissions

--- a/watchman/integration/eden/test_eden_journal.py
+++ b/watchman/integration/eden/test_eden_journal.py
@@ -61,7 +61,7 @@ class TestEdenJournal(WatchmanEdenTestCase.WatchmanEdenTestCase):
             message="We expect to report the files changed in the commit",
         )
 
-        # Test the the journal has the correct contents across a "reset" like
+        # Test the journal has the correct contents across a "reset" like
         # operation where the parents are poked directly.   This is using
         # debugsetparents rather than reset because the latter isn't enabled
         # by default for hg in the watchman test machinery.

--- a/watchman/watcher/eden.cpp
+++ b/watchman/watcher/eden.cpp
@@ -939,7 +939,7 @@ class EdenView final : public QueryableView {
   void pathGenerator(const Query* query, QueryContext* ctx) const override {
     ctx->generationStarted();
     ctx->generatorType = "eden_path";
-    // If the query is anchored to a relative_root, use that that
+    // If the query is anchored to a relative_root, use that to
     // avoid sucking down a massive list of files from eden
     auto rel = computeRelativePathPiece(ctx);
 
@@ -989,7 +989,7 @@ class EdenView final : public QueryableView {
 
     ctx->generationStarted();
     ctx->generatorType = "eden_glob";
-    // If the query is anchored to a relative_root, use that that
+    // If the query is anchored to a relative_root, use that to
     // avoid sucking down a massive list of files from eden
     auto rel = computeRelativePathPiece(ctx);
 

--- a/website/docs/cmd/query.md
+++ b/website/docs/cmd/query.md
@@ -130,7 +130,7 @@ simple array of values; ~~~"fields": ["name"]~~~ produces:
 
 _Since 3.1._
 
-- `type` - string: the file type. Has the the values listed in
+- `type` - string: the file type. Has the values listed in
   [the type query expression](../expr/type.md)
 
 _Since 4.6._


### PR DESCRIPTION
## Summary

Fixes a handful of high-confidence duplicated-word typos in comments and documentation. Comment/doc-only — no behavior change.

These are distinct from #1246 (single-word misspellings); there is no overlap with the lines that PR touches.

## Changes

| File | Before | After |
|------|--------|-------|
| `watchman/XattrUtils.h` | `@param path The path to to set attributes on` | `@param path The path to set attributes on` |
| `watchman/integration/eden/test_eden_journal.py` | `# Test the the journal has the correct contents` | `# Test the journal has the correct contents` |
| `watchman/watcher/eden.cpp` (pathGenerator) | `use that that` / `avoid sucking down...` | `use that to` / `avoid sucking down...` |
| `watchman/watcher/eden.cpp` (globGenerator) | `use that that` / `avoid sucking down...` | `use that to` / `avoid sucking down...` |
| `website/docs/cmd/query.md` | `Has the the values listed in` | `Has the values listed in` |

## Notes

- Several other `that that` occurrences in the tree are legitimate grammar (e.g. "we know that that access pattern...", "make sure that that path matches...") and were intentionally left unchanged.
- No generated, vendored, or third-party files touched.