### PR TITLE
serde_bser: serialize struct enum variants in object form

### DIFF
--- a/watchman/rust/serde_bser/src/ser.rs
+++ b/watchman/rust/serde_bser/src/ser.rs
@@ -406,15 +406,21 @@ where
     #[inline]
     fn serialize_struct_variant(
         self,
-        name: &'static str,
-        variant_index: u32,
+        _name: &'static str,
+        _variant_index: u32,
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         // This is e.g. E { N { foo: A, bar: B } }, where N is the
         // variant. Serialize this as { variant: { foo: valA, bar: valB } }.
-        // That's really the same as serialize_tuple_variant.
-        self.serialize_tuple_variant(name, variant_index, variant, len)
+        // This must use the object form (not the tuple form), since the
+        // deserializer expects each field to be keyed by its name when
+        // decoding a struct variant.
+        self.maybe_flush()?;
+        self.scratch.push(BSER_OBJECT);
+        self.put_i8(1);
+        self.serialize_str(variant)?;
+        self.serialize_struct("", len)
     }
 }
 

--- a/watchman/rust/serde_bser/src/ser/test.rs
+++ b/watchman/rust/serde_bser/src/ser/test.rs
@@ -7,6 +7,7 @@
 
 use std::f64::consts;
 
+use serde::Deserialize;
 use serde::Serialize;
 
 use super::serialize;
@@ -34,7 +35,7 @@ const BASIC_SERIALIZED: &[u8] = b"\x00\x02\x00\x00\x00\x00\x04\xcb\x00\x01\x03\x
                                   test_enum_list\x00\x03\x03\x01\x03\x01\r\x03\x0bTestNewtype\
                                   \x02\x03\tBSER test\x01\x03\x01\r\x03\tTestTuple\x00\x03\x02\x03*\
                                   \x06\xff\xff\xff\xff\xff\xff\xff\x7f\x01\x03\x01\r\x03\n\
-                                  TestStruct\x00\x03\x02\r\x03\x03abc\n\r\x03\x03\
+                                  TestStruct\x01\x03\x02\r\x03\x03abc\n\r\x03\x03\
                                   def\r\x03\x04\xf0\x9f\x92\xa9";
 
 #[test]
@@ -56,4 +57,27 @@ fn test_basic_serialize() {
     let out = Vec::new();
     let out = serialize(out, to_serialize).unwrap();
     assert_eq!(out, BASIC_SERIALIZED);
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+enum RoundTripEnum {
+    TestUnit,
+    TestNewtype(String),
+    TestTuple(i8, u64),
+    TestStruct { abc: (), def: char },
+}
+
+#[test]
+fn test_struct_variant_round_trip() {
+    let to_serialize = RoundTripEnum::TestStruct {
+        abc: (),
+        def: '\u{1f4a9}',
+    };
+
+    let out = Vec::new();
+    let out = serialize(out, to_serialize.clone()).unwrap();
+
+    // The serialized form must be the object form: {"TestStruct": {"abc": ..., "def": ...}}
+    let decoded: RoundTripEnum = crate::from_slice(&out).unwrap();
+    assert_eq!(decoded, to_serialize);
 }


### PR DESCRIPTION
## Summary

`serde_bser::Serializer::serialize_struct_variant` was implemented by delegating to `serialize_tuple_variant`, which emits the variant payload as a BSER **array**:

```json
{"TestStruct": ["abc", null, "def", "💩"]}
```

But the deserializer (`VariantAccess::struct_variant` → `deserialize_any`) decodes the payload as a **map** — the object form `{"TestStruct": {"abc": null, "def": "💩"}}` that `de::test::test_struct_variant` already exercises. Struct-variant enums therefore could not round-trip: `serialize` → `from_slice` failed with `invalid type: string "abc", expected unit`.

## Fix

Serialize struct variants in object form, writing `<BSER_OBJECT> 1 <variant name> <BSER_OBJECT nfields> (key value)*`, instead of reusing the tuple-variant path. The `Compound` type is shared by both `SerializeStructVariant` and `SerializeStruct`, so the field-name-keyed output is produced by the same `SerializeStruct` machinery used for ordinary structs.

## Test

- Updated `BASIC_SERIALIZED` expectation in `ser/test.rs` to the object form (only the container tag byte changes; PDU length is unchanged).
- Added `test_struct_variant_round_trip`, which serializes `TestStruct { abc: (), def: '💩' }` and deserializes it back — this failed before the fix and passes after.

`cargo test` in `watchman/rust/serde_bser`: 16 passed.