### PR TITLE
Restore macOS release binaries on Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,11 +317,21 @@ jobs:
   mac-build:
     continue-on-error: true
     needs: prepare
-    runs-on: macOS-10.15
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+      CC: /opt/homebrew/opt/llvm/bin/clang
+      CXX: /opt/homebrew/opt/llvm/bin/clang++
     steps:
       - uses: actions/checkout@v4
+      - name: Install Homebrew LLVM
+        run: brew install llvm
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install system deps
+        run: python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive watchman
       - name: Build watchman
-        run: "SDKROOT=$(xcrun --show-sdk-path --sdk macosx11.1) python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local"
+        run: "python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local"
       - name: Copy artifacts
         run: "python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/mac  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local"
       - name: Test watchman

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -188,13 +188,23 @@ jobs:
   mac-build:
     continue-on-error: true
     needs: prepare
-    # This release targets macOS 11.1 (Big Sur), which is available in
-    # Xcode 12.4 on the macOS-10.15 image.
-    runs-on: macOS-10.15
+    # Mirrors the environment of the `mac` CI workflow in getdeps_mac.yml, which
+    # builds green on main. macOS-latest is Apple Silicon.
+    runs-on: macOS-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+      CC: /opt/homebrew/opt/llvm/bin/clang
+      CXX: /opt/homebrew/opt/llvm/bin/clang++
     steps:
     - uses: actions/checkout@v4
+    - name: Install Homebrew LLVM
+      run: brew install llvm
+    - name: Install Rust Stable
+      uses: dtolnay/rust-toolchain@stable
+    - name: Install system deps
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive watchman
     - name: Build watchman
-      run: SDKROOT=$(xcrun --show-sdk-path --sdk macosx11.1) python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. watchman  --project-install-prefix watchman:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. watchman _artifacts/mac  --project-install-prefix watchman:/usr/local --final-install-prefix /usr/local
     - name: Test watchman

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -90,6 +90,9 @@ $ sudo port install watchman
    [latest release](https://github.com/facebook/watchman/releases/latest)
 2. It will be named something like `watchman-vYYYY.MM.DD.00-macos.zip`
 
+The macOS binaries are built for Apple Silicon. On an Intel Mac, use Homebrew or
+MacPorts above, or build from source.
+
 ```bash
 $ unzip watchman-*-macos.zip
 $ cd watchman-vYYYY.MM.DD.00-macos


### PR DESCRIPTION
## The problem

The `mac-build` job in `release.yml` runs on `macOS-10.15`. GitHub retired that image, so the job never runs. It is also marked `continue-on-error: true`, so releases still pass — just without the macOS file.

The last `watchman-*-macos.zip` is [v2023.05.01.00](https://github.com/facebook/watchman/releases/tag/v2023.05.01.00). Every release since has only the Linux zip and the Fedora RPM. But [the install docs](https://facebook.github.io/watchman/docs/install#prebuilt-binaries-2) still tell people to download a macOS build.

## The change

Make `mac-build` match the `mac` CI job in `getdeps_mac.yml`, which passes on `main`: run on `macOS-latest`, set `DEVELOPER_DIR`, build with Homebrew LLVM, and install Rust and the getdeps system deps. The old `SDKROOT` pin belonged to the 10.15 image, so it is dropped.

`release.yml` is regenerated from `release.yml.in`.

## Notes

- `macOS-latest` is Apple Silicon, so the zip becomes arm64 instead of x86_64. The file name is unchanged, and the install docs now say which architecture it is. Say the word if you would rather ship both.
- `windows-build` has the same problem (`windows-2019`). Not fixed here.
- I could not run the release workflow, because it only runs on `v*` tags.